### PR TITLE
chore(ci): remove static deploy instructions from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,12 +104,6 @@ jobs:
           # Build the extra section
           {
             echo "$CURRENT_BODY"
-            echo ""
-            echo "## Deploy"
-            echo ""
-            echo '```bash'
-            echo 'stellar contract deploy --wasm <contract>.wasm --network testnet --source <identity>'
-            echo '```'
             if [ -n "$CONTRIBUTORS" ]; then
               echo ""
               echo "## Contributors"


### PR DESCRIPTION
Removes the static deploy command block from release notes — it's the same text every time and adds no value. Contributors can find deploy instructions in the docs.