### PR TITLE
fix(ci): exempt dependabot from pr-checks and auto-label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     if: >-
       github.event.pull_request.user.login != 'github-actions[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.action != 'labeled' &&
       github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
@@ -78,7 +79,8 @@ jobs:
   pr-checks:
     if: >-
       github.event.pull_request.user.login != 'github-actions[bot]' &&
-      github.event.pull_request.user.login != 'release-please[bot]'
+      github.event.pull_request.user.login != 'release-please[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title


### PR DESCRIPTION
Dependabot PRs don't have linked issues or conventional commit titles. Skip auto-label and pr-checks for dependabot[bot] the same way we skip them for release-please[bot] and github-actions[bot].