### PR TITLE
fix(ci): show all commit types in release changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,22 +1,22 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",                                   
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
-        { "type": "feat", "section": "New Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "refactor", "section": "Refactoring" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "test", "section": "Tests" },
-        { "type": "ci", "section": "CI/CD" },
-        { "type": "build", "section": "Dependencies" },
-        { "type": "chore", "section": "Maintenance" },
-        { "type": "style", "section": "Maintenance" },
-        { "type": "revert", "section": "Reverts" }
+        { "type": "feat", "section": "New Features", "hidden": false },
+        { "type": "fix", "section": "Bug Fixes", "hidden": false },
+        { "type": "refactor", "section": "Refactoring", "hidden": false },
+        { "type": "perf", "section": "Performance", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "test", "section": "Tests", "hidden": false },
+        { "type": "ci", "section": "CI/CD", "hidden": false },
+        { "type": "build", "section": "Dependencies", "hidden": false },
+        { "type": "chore", "section": "Maintenance", "hidden": false },
+        { "type": "style", "section": "Maintenance", "hidden": false },
+        { "type": "revert", "section": "Reverts", "hidden": false }
       ],
       "include-component-in-tag": false,
       "include-v-in-tag": true


### PR DESCRIPTION
Explicitly set `hidden: false` on all changelog sections so docs, chore, ci, build, test, style, and revert commits all appear in release notes. No contributor's work gets hidden.