### PR TITLE
feat: implement dark/light mode toggle with theme persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, createContext, useContext } from "react"
 import { Analytics } from "@vercel/analytics/react"
 import { SpeedInsights } from "@vercel/speed-insights/react"
 import { Navbar } from "@/components/navbar"
@@ -10,6 +10,36 @@ import { NotFound } from "@/pages/not-found"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { CreateQuest } from "@/pages/create-quest"
 
+// ─── Theme Context ─────────────────────────────────────────────────────────────
+
+type Theme = "light" | "dark"
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  toggleTheme: () => {},
+})
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}
+
+function getInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem("lernza-theme")
+    if (stored === "dark" || stored === "light") return stored
+  } catch {
+    return "light"
+  }
+  return "light"
+}
+
+// ─── Routing ───────────────────────────────────────────────────────────────────
+
 const VALID_PAGES = ["landing", "dashboard", "profile", "create-quest"] as const
 type Page = (typeof VALID_PAGES)[number] | "workspace" | "404"
 
@@ -20,19 +50,36 @@ function pathToPage(pathname: string): { page: Page; workspaceId: number | null 
   if (clean === "/profile") return { page: "profile", workspaceId: null }
   if (clean === "/create-quest") return { page: "create-quest", workspaceId: null }
 
-  const wsMatch = clean.match(/^\/workspace\/(\d+)$/)
+  const wsMatch = clean.match(/^\/quest\/(\d+)$/)
   if (wsMatch) return { page: "workspace", workspaceId: Number(wsMatch[1]) }
   return { page: "404", workspaceId: null }
 }
 
 function pageToPath(page: Page, workspaceId: number | null): string {
   if (page === "landing") return "/"
-  if (page === "workspace" && workspaceId !== null) return `/workspace/${workspaceId}`
+  if (page === "workspace" && workspaceId !== null) return `/quest/${workspaceId}`
   return `/${page}`
 }
 
+// ─── App ───────────────────────────────────────────────────────────────────────
+
 function App() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
   const [state, setState] = useState(() => pathToPage(window.location.pathname))
+
+  // Apply .dark class to <html> and persist preference
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark")
+    try {
+      localStorage.setItem("lernza-theme", theme)
+    } catch {
+      // localStorage unavailable (sandboxed iframe, private mode quota) — ignore
+    }
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === "light" ? "dark" : "light"))
+  }, [])
 
   useEffect(() => {
     const onPopState = () => setState(pathToPage(window.location.pathname))
@@ -81,16 +128,18 @@ function App() {
   }
 
   return (
-    <ErrorBoundary githubRepo="https://github.com/lernza/lernza">
-      <div className="bg-background text-foreground min-h-screen">
-        <Navbar activePage={state.page} onNavigate={handleNavigate} />
-        <ErrorBoundary key={`${state.page}-${state.workspaceId ?? ""}`}>
-          <main>{renderPage()}</main>
-        </ErrorBoundary>
-        <Analytics />
-        <SpeedInsights />
-      </div>
-    </ErrorBoundary>
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <ErrorBoundary githubRepo="https://github.com/lernza/lernza">
+        <div className="bg-background text-foreground min-h-screen">
+          <Navbar activePage={state.page} onNavigate={handleNavigate} />
+          <ErrorBoundary key={`${state.page}-${state.workspaceId ?? ""}`}>
+            <main>{renderPage()}</main>
+          </ErrorBoundary>
+          <Analytics />
+          <SpeedInsights />
+        </div>
+      </ErrorBoundary>
+    </ThemeContext.Provider>
   )
 }
 

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
-import { Wallet, LogOut, Menu, X } from "lucide-react"
+import { Wallet, LogOut, Menu, X, Sun, Moon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useWallet } from "@/hooks/use-wallet"
+import { useTheme } from "@/App"
 import { cn } from "@/lib/utils"
 
 const NAV_ITEMS = [
@@ -34,6 +35,29 @@ function LogoMark({ className }: { className?: string }) {
   )
 }
 
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === "dark"
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
+      title={`Switch to ${isDark ? "light" : "dark"} mode`}
+      className={cn(
+        "w-9 h-9 border-[2px] border-border shadow-[2px_2px_0_var(--color-border)]",
+        "flex items-center justify-center neo-press cursor-pointer",
+        "transition-colors duration-300",
+        isDark
+          ? "bg-primary text-black hover:bg-yellow-300"
+          : "bg-background text-foreground hover:bg-secondary"
+      )}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  )
+}
+
 export function Navbar({ activePage, onNavigate }: NavbarProps) {
   const { connected, shortAddress, connect, disconnect, loading } = useWallet()
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -43,31 +67,29 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
     setMobileOpen(false)
   }
 
-  const visibleItems = NAV_ITEMS
-
   return (
-    <header className="sticky top-0 z-50 border-b-[3px] border-black bg-white">
+    <header className="sticky top-0 z-50 border-b-[3px] border-border bg-background transition-colors duration-300">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6">
         {/* Logo */}
         <button
           onClick={() => handleNavigate("landing")}
-          className="group flex cursor-pointer items-center gap-2"
+          className="flex items-center gap-2 cursor-pointer group"
         >
           <LogoMark className="h-8 w-8 transition-transform group-hover:scale-110" />
           <span className="text-xl font-black tracking-tight">Lernza</span>
         </button>
 
         {/* Desktop nav links */}
-        <nav className="hidden items-center gap-1 sm:flex">
-          {visibleItems.map(item => (
+        <nav className="hidden sm:flex items-center gap-1">
+          {NAV_ITEMS.map((item) => (
             <button
               key={item.key}
               onClick={() => handleNavigate(item.key)}
               className={cn(
-                "animated-underline cursor-pointer border-[2px] px-4 py-2 text-sm font-bold transition-all",
+                "px-4 py-2 text-sm font-bold transition-all cursor-pointer border-[2px] animated-underline",
                 activePage === item.key
-                  ? "bg-primary active border-black shadow-[2px_2px_0_#000]"
-                  : "hover:bg-secondary border-transparent hover:border-black"
+                  ? "bg-primary border-border shadow-[2px_2px_0_var(--color-border)] active"
+                  : "border-transparent hover:border-border hover:bg-secondary"
               )}
             >
               {item.label}
@@ -75,13 +97,15 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
           ))}
         </nav>
 
-        {/* Right side: wallet + mobile menu */}
-        <div className="flex items-center gap-3">
+        {/* Right side: theme toggle + wallet + mobile menu */}
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+
           {connected ? (
             <>
-              <div className="bg-secondary hidden items-center gap-2 border-[2px] border-black px-3 py-1.5 shadow-[2px_2px_0_#000] sm:flex">
-                <div className="bg-success h-2.5 w-2.5 border border-black" />
-                <span className="font-mono text-sm font-bold">{shortAddress}</span>
+              <div className="hidden sm:flex items-center gap-2 border-[2px] border-border bg-secondary px-3 py-1.5 shadow-[2px_2px_0_var(--color-border)]">
+                <div className="h-2.5 w-2.5 bg-success border border-border" />
+                <span className="text-sm font-mono font-bold">{shortAddress}</span>
               </div>
               <Button variant="ghost" size="icon" onClick={disconnect}>
                 <LogOut className="h-4 w-4" />
@@ -97,7 +121,7 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
           {/* Mobile hamburger */}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
-            className="neo-press flex h-9 w-9 cursor-pointer items-center justify-center border-[2px] border-black bg-white shadow-[2px_2px_0_#000] sm:hidden"
+            className="sm:hidden w-9 h-9 border-[2px] border-border bg-background shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center neo-press cursor-pointer"
           >
             {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
           </button>
@@ -106,17 +130,17 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
 
       {/* Mobile menu dropdown */}
       {mobileOpen && (
-        <div className="animate-fade-in-down border-t-[3px] border-black bg-white sm:hidden">
-          <div className="space-y-1 px-4 py-3">
-            {visibleItems.map(item => (
+        <div className="sm:hidden border-t-[3px] border-border bg-background animate-fade-in-down transition-colors duration-300">
+          <div className="px-4 py-3 space-y-1">
+            {NAV_ITEMS.map((item) => (
               <button
                 key={item.key}
                 onClick={() => handleNavigate(item.key)}
                 className={cn(
-                  "w-full cursor-pointer border-[2px] px-4 py-3 text-left text-sm font-bold transition-all",
+                  "w-full text-left px-4 py-3 text-sm font-bold transition-all cursor-pointer border-[2px]",
                   activePage === item.key
-                    ? "bg-primary border-black shadow-[2px_2px_0_#000]"
-                    : "hover:bg-secondary border-transparent hover:border-black"
+                    ? "bg-primary border-border shadow-[2px_2px_0_var(--color-border)]"
+                    : "border-transparent hover:border-border hover:bg-secondary"
                 )}
               >
                 {item.label}

--- a/frontend/src/components/share-button.tsx
+++ b/frontend/src/components/share-button.tsx
@@ -160,14 +160,14 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
         zIndex: 9999,
       }}
       className={cn(
-        "bg-card text-card-foreground border-[3px] border-black shadow-[6px_6px_0_#000]",
+        "bg-card text-card-foreground border-[3px] border-border shadow-[6px_6px_0_var(--color-border)]",
         "w-72 overflow-hidden animate-fade-in-down"
       )}
       role="dialog"
       aria-label="Share options"
     >
       {/* Panel header */}
-      <div className="bg-primary border-b-[3px] border-black px-4 py-2.5 flex items-center justify-between">
+      <div className="bg-primary border-b-[3px] border-border px-4 py-2.5 flex items-center justify-between">
         <span className="text-xs font-black uppercase tracking-wider">Share this quest</span>
         <button
           onClick={() => setOpen(false)}
@@ -179,7 +179,7 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
       </div>
 
       {/* Quest name preview */}
-      <div className="px-4 py-3 border-b-[2px] border-black bg-secondary">
+      <div className="px-4 py-3 border-b-[2px] border-border bg-secondary">
         <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-0.5">Quest</p>
         <p className="text-sm font-black truncate">{questName}</p>
       </div>
@@ -209,11 +209,11 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
       </div>
 
       {/* URL bar */}
-      <div className="mx-3 mb-3 border-[2px] border-black bg-secondary px-3 py-2 flex items-center gap-2">
+      <div className="mx-3 mb-3 border-[2px] border-border bg-secondary px-3 py-2 flex items-center gap-2">
         <p className="flex-1 text-xs font-mono text-muted-foreground truncate">{questUrl}</p>
         <button
           onClick={handleCopyLink}
-          className="shrink-0 w-6 h-6 border-[1.5px] border-black bg-card flex items-center justify-center neo-press hover:bg-primary transition-colors cursor-pointer"
+          className="shrink-0 w-6 h-6 border-[1.5px] border-border bg-card flex items-center justify-center neo-press hover:bg-primary transition-colors cursor-pointer"
           aria-label="Copy URL"
         >
           {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
@@ -236,10 +236,10 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
         aria-label="Share quest"
         aria-expanded={open}
         className={cn(
-          "flex items-center gap-2 border-[2px] border-black font-bold text-sm",
-          "bg-card text-card-foreground shadow-[3px_3px_0_#000]",
+          "flex items-center gap-2 border-[2px] border-border font-bold text-sm",
+          "bg-card text-card-foreground shadow-[3px_3px_0_var(--color-border)]",
           "neo-press hover:bg-primary transition-colors cursor-pointer",
-          open && "bg-primary shadow-[1px_1px_0_#000] translate-x-0.5 translate-y-0.5",
+          open && "bg-primary shadow-[1px_1px_0_var(--color-border)] translate-x-0.5 translate-y-0.5",
           compact ? "w-9 h-9 justify-center" : "px-4 py-2"
         )}
       >
@@ -268,9 +268,9 @@ function ShareOption({ icon, label, sublabel, onClick, active }: ShareOptionProp
     <button
       onClick={onClick}
       className={cn(
-        "w-full flex items-center gap-3 px-3 py-2.5 border-[2px] border-black",
+        "w-full flex items-center gap-3 px-3 py-2.5 border-[2px] border-border",
         "text-left transition-all cursor-pointer neo-press",
-        "shadow-[2px_2px_0_#000] hover:shadow-[3px_3px_0_#000]",
+        "shadow-[2px_2px_0_var(--color-border)] hover:shadow-[3px_3px_0_var(--color-border)]",
         active ? "bg-success" : "bg-card hover:bg-primary"
       )}
     >

--- a/frontend/src/components/toast.tsx
+++ b/frontend/src/components/toast.tsx
@@ -39,9 +39,9 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
   }
 
   const accents = {
-    success: "bg-success border-black",
-    error: "bg-destructive text-destructive-foreground border-black",
-    info: "bg-primary border-black",
+    success: "bg-success border-border",
+    error: "bg-destructive text-destructive-foreground border-border",
+    info: "bg-primary border-border",
   }
 
   const type = toast.type ?? "success"
@@ -49,7 +49,7 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-3 border-[3px] shadow-[4px_4px_0_#000] px-4 py-3 min-w-[260px] max-w-sm",
+        "flex items-center gap-3 border-[3px] shadow-[4px_4px_0_var(--color-border)] px-4 py-3 min-w-[260px] max-w-sm",
         "transition-all duration-300 ease-out",
         accents[type],
         visible && !leaving

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -3,16 +3,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center border-[2px] border-black px-3 py-1 text-xs font-bold transition-colors",
+  "inline-flex items-center border-[2px] border-border px-3 py-1 text-xs font-bold transition-colors",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow-[2px_2px_0_#000]",
-        secondary: "bg-secondary text-secondary-foreground shadow-[2px_2px_0_#000]",
-        destructive: "bg-destructive text-destructive-foreground shadow-[2px_2px_0_#000]",
+        default: "bg-primary text-primary-foreground shadow-[2px_2px_0_var(--color-border)]",
+        secondary: "bg-secondary text-secondary-foreground shadow-[2px_2px_0_var(--color-border)]",
+        destructive: "bg-destructive text-destructive-foreground shadow-[2px_2px_0_var(--color-border)]",
         outline: "bg-transparent text-foreground",
-        success: "bg-success text-success-foreground shadow-[2px_2px_0_#000]",
-        warning: "bg-warning text-warning-foreground shadow-[2px_2px_0_#000]",
+        success: "bg-success text-success-foreground shadow-[2px_2px_0_var(--color-border)]",
+        warning: "bg-warning text-warning-foreground shadow-[2px_2px_0_var(--color-border)]",
       },
     },
     defaultVariants: {
@@ -22,7 +22,8 @@ const badgeVariants = cva(
 )
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,15 +8,19 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
+          "bg-primary text-primary-foreground border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
         secondary:
-          "bg-white text-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
+          // bg-background (white in light, near-black in dark) keeps secondary buttons
+          // visually distinct from card surfaces (bg-card) in both modes.
+          "bg-background text-foreground border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
         destructive:
-          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
+          "bg-destructive text-destructive-foreground border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
         outline:
-          "bg-transparent text-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
-        ghost: "border-0 shadow-none hover:bg-secondary transition-colors",
-        link: "border-0 shadow-none underline-offset-4 hover:underline text-foreground",
+          "bg-transparent text-foreground border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+        ghost:
+          "border-0 shadow-none hover:bg-secondary transition-colors",
+        link:
+          "border-0 shadow-none underline-offset-4 hover:underline text-foreground",
       },
       size: {
         default: "h-11 px-5 py-2 text-sm",
@@ -33,12 +37,17 @@ const buttonVariants = cva(
 )
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, ...props }, ref) => {
     return (
-      <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
     )
   }
 )

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "bg-card text-card-foreground border-[3px] border-black shadow-[5px_5px_0_#000]",
+        "bg-card text-card-foreground border-[3px] border-border shadow-[5px_5px_0_var(--color-border)]",
         className
       )}
       {...props}
@@ -17,40 +17,35 @@ Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-1.5 p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col gap-1.5 p-6 text-card-foreground", className)} {...props} />
   )
 )
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3
-      ref={ref}
-      className={cn("text-lg leading-none font-black tracking-tight", className)}
-      {...props}
-    />
+    <h3 ref={ref} className={cn("text-lg font-black leading-none tracking-tight text-card-foreground", className)} {...props} />
   )
 )
 CardTitle.displayName = "CardTitle"
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn("text-muted-foreground text-sm", className)} {...props} />
-))
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+)
 CardDescription.displayName = "CardDescription"
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("p-6 pt-0 text-card-foreground", className)} {...props} />
   )
 )
 CardContent.displayName = "CardContent"
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("flex items-center p-6 pt-0 text-card-foreground", className)} {...props} />
   )
 )
 CardFooter.displayName = "CardFooter"

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -13,7 +13,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
       <div
         ref={ref}
         className={cn(
-          "bg-secondary h-5 w-full border-[3px] border-black shadow-[2px_2px_0_#000]",
+          "h-5 w-full border-[3px] border-border bg-secondary shadow-[2px_2px_0_var(--color-border)]",
           className
         )}
         {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,31 +2,30 @@
 
 @theme {
   /* ── Colors: Neo-brutalist palette ── */
-  --color-background: #ffffff;
+  --color-background: #FFFFFF;
   --color-foreground: #000000;
-  --color-primary: #facc15;
+  --color-primary: #FACC15;
   --color-primary-foreground: #000000;
-  --color-secondary: #f5f5f4;
-  --color-secondary-foreground: #1c1917;
-  --color-muted: #e7e5e4;
-  --color-muted-foreground: #78716c;
-  --color-card: #ffffff;
+  --color-secondary: #F5F5F4;
+  --color-secondary-foreground: #1C1917;
+  --color-muted: #E7E5E4;
+  --color-muted-foreground: #78716C;
+  --color-card: #FFFFFF;
   --color-card-foreground: #000000;
   --color-border: #000000;
   --color-input: #000000;
-  --color-ring: #facc15;
-  --color-accent: #facc15;
+  --color-ring: #FACC15;
+  --color-accent: #FACC15;
   --color-accent-foreground: #000000;
-  --color-destructive: #ef4444;
-  --color-destructive-foreground: #ffffff;
-  --color-success: #22c55e;
+  --color-destructive: #EF4444;
+  --color-destructive-foreground: #FFFFFF;
+  --color-success: #22C55E;
   --color-success-foreground: #000000;
-  --color-warning: #f59e0b;
+  --color-warning: #F59E0B;
   --color-warning-foreground: #000000;
 
   /* ── Typography ── */
-  --font-sans:
-    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 
   /* ── Animations ── */
@@ -38,81 +37,111 @@
   --animate-scale-in: scale-in 0.4s ease-out both;
 }
 
+/* ── Dark mode token overrides ────────────────────────────────────────────── */
+/*
+  Neo-brutalist dark: cream borders/shadows on near-black bg.
+  --color-border: #F5F0E8 mirrors what black does in light mode — it's the
+  structural color that gives cards and buttons their sharp offset shadow depth.
+  Yellow stays as --color-primary and --color-accent only (brand/highlight).
+  --color-ring stays yellow so focus rings remain visually distinct.
+  Card bg is one step lighter than page bg so cards read as distinct surfaces.
+*/
+.dark {
+  --color-background: #111110;
+  --color-foreground: #F5F0E8;
+  --color-primary: #FACC15;
+  --color-primary-foreground: #000000;
+  --color-secondary: #1C1917;
+  --color-secondary-foreground: #F5F0E8;
+  --color-muted: #292524;
+  --color-muted-foreground: #A8A29E;
+  --color-card: #1C1917;
+  --color-card-foreground: #F5F0E8;
+  --color-border: #F5F0E8;
+  --color-input: #F5F0E8;
+  --color-ring: #FACC15;
+  --color-accent: #FACC15;
+  --color-accent-foreground: #000000;
+  --color-destructive: #EF4444;
+  --color-destructive-foreground: #FFFFFF;
+  --color-success: #22C55E;
+  --color-success-foreground: #000000;
+  --color-warning: #F59E0B;
+  --color-warning-foreground: #000000;
+}
+
+/* ── Smooth theme transition — scoped, not global * ──────────────────────── */
+/*
+  Targeting only the structural/surface elements that actually change color
+  on theme switch. Avoids the page-load flash and performance cost of
+  transitioning every single DOM node.
+*/
+body,
+header,
+footer,
+main,
+[class*="bg-background"],
+[class*="bg-card"],
+[class*="bg-secondary"],
+[class*="bg-muted"],
+[class*="text-foreground"],
+[class*="text-card-foreground"],
+[class*="text-muted-foreground"],
+[class*="border-border"],
+[class*="border-black"] {
+  transition-property: background-color, border-color, color, box-shadow;
+  transition-duration: 250ms;
+  transition-timing-function: ease;
+}
+
+/* Keep interactive and animation classes snappy */
+.neo-press,
+.neo-lift,
+.card-tilt,
+.shimmer-on-hover,
+.shimmer-on-hover::after,
+[class*="animate-"],
+[class*="reveal-"] {
+  transition-property: translate, transform, opacity, box-shadow;
+}
+
 /* ── Keyframes ── */
 
 @keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 @keyframes fade-in-up {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes fade-in-down {
-  from {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(-20px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes slide-in-left {
-  from {
-    opacity: 0;
-    transform: translateX(-30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
+  from { opacity: 0; transform: translateX(-30px); }
+  to { opacity: 1; transform: translateX(0); }
 }
 
 @keyframes slide-in-right {
-  from {
-    opacity: 0;
-    transform: translateX(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
+  from { opacity: 0; transform: translateX(30px); }
+  to { opacity: 1; transform: translateX(0); }
 }
 
 @keyframes scale-in {
-  from {
-    opacity: 0;
-    transform: scale(0.9);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 /* ── Marquee ── */
 
 @keyframes marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
 }
 
 .animate-marquee {
@@ -126,83 +155,34 @@
 /* ── Glitch effect for 404 ── */
 
 @keyframes glitch-shift {
-  0%,
-  100% {
-    transform: translate(0);
-  }
-  10% {
-    transform: translate(-3px, 2px);
-  }
-  20% {
-    transform: translate(3px, -2px);
-  }
-  30% {
-    transform: translate(-2px, -3px);
-  }
-  40% {
-    transform: translate(2px, 3px);
-  }
-  50% {
-    transform: translate(-3px, -1px);
-  }
-  60% {
-    transform: translate(3px, 1px);
-  }
-  70% {
-    transform: translate(-1px, 3px);
-  }
-  80% {
-    transform: translate(1px, -3px);
-  }
-  90% {
-    transform: translate(-2px, 2px);
-  }
+  0%, 100% { transform: translate(0); }
+  10% { transform: translate(-3px, 2px); }
+  20% { transform: translate(3px, -2px); }
+  30% { transform: translate(-2px, -3px); }
+  40% { transform: translate(2px, 3px); }
+  50% { transform: translate(-3px, -1px); }
+  60% { transform: translate(3px, 1px); }
+  70% { transform: translate(-1px, 3px); }
+  80% { transform: translate(1px, -3px); }
+  90% { transform: translate(-2px, 2px); }
 }
 
 @keyframes glitch-clip-1 {
-  0%,
-  100% {
-    clip-path: inset(0 0 100% 0);
-  }
-  5% {
-    clip-path: inset(20% 0 60% 0);
-  }
-  10% {
-    clip-path: inset(80% 0 0% 0);
-  }
-  15% {
-    clip-path: inset(10% 0 75% 0);
-  }
-  20% {
-    clip-path: inset(45% 0 40% 0);
-  }
-  25%,
-  100% {
-    clip-path: inset(0 0 100% 0);
-  }
+  0%, 100% { clip-path: inset(0 0 100% 0); }
+  5% { clip-path: inset(20% 0 60% 0); }
+  10% { clip-path: inset(80% 0 0% 0); }
+  15% { clip-path: inset(10% 0 75% 0); }
+  20% { clip-path: inset(45% 0 40% 0); }
+  25%, 100% { clip-path: inset(0 0 100% 0); }
 }
 
 @keyframes glitch-clip-2 {
-  0%,
-  100% {
-    clip-path: inset(0 0 100% 0);
-  }
-  8% {
-    clip-path: inset(60% 0 15% 0);
-  }
-  13% {
-    clip-path: inset(5% 0 80% 0);
-  }
-  18% {
-    clip-path: inset(35% 0 50% 0);
-  }
-  23% {
-    clip-path: inset(70% 0 10% 0);
-  }
-  28%,
-  100% {
-    clip-path: inset(0 0 100% 0);
-  }
+  0%, 100% { clip-path: inset(0 0 100% 0); }
+  8% { clip-path: inset(60% 0 15% 0); }
+  13% { clip-path: inset(5% 0 80% 0); }
+  18% { clip-path: inset(35% 0 50% 0); }
+  23% { clip-path: inset(70% 0 10% 0); }
+  28%, 100% { clip-path: inset(0 0 100% 0); }
 }
 
 .glitch-text {
@@ -220,30 +200,22 @@
 }
 
 .glitch-text::before {
-  color: #ef4444;
-  animation:
-    glitch-clip-1 3s infinite linear,
-    glitch-shift 0.3s infinite reverse;
+  color: #EF4444;
+  animation: glitch-clip-1 3s infinite linear, glitch-shift 0.3s infinite reverse;
   animation-delay: 0.1s;
 }
 
 .glitch-text::after {
-  color: #22c55e;
-  animation:
-    glitch-clip-2 3s infinite linear,
-    glitch-shift 0.3s infinite;
+  color: #22C55E;
+  animation: glitch-clip-2 3s infinite linear, glitch-shift 0.3s infinite;
   animation-delay: 0.2s;
 }
 
 /* ── Shimmer / shine sweep ── */
 
 @keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
 }
 
 .shimmer-on-hover {
@@ -255,7 +227,7 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
   transform: translateX(-100%);
   transition: none;
 }
@@ -267,14 +239,8 @@
 /* ── Pulse ring (for live indicators) ── */
 
 @keyframes pulse-ring {
-  0% {
-    transform: scale(1);
-    opacity: 0.8;
-  }
-  100% {
-    transform: scale(2.5);
-    opacity: 0;
-  }
+  0% { transform: scale(1); opacity: 0.8; }
+  100% { transform: scale(2.5); opacity: 0; }
 }
 
 .pulse-ring {
@@ -294,9 +260,7 @@
 .reveal-up {
   opacity: 0;
   transform: translateY(40px);
-  transition:
-    opacity 0.6s ease-out,
-    transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
 .reveal-up.in-view {
@@ -307,9 +271,7 @@
 .reveal-left {
   opacity: 0;
   transform: translateX(-40px);
-  transition:
-    opacity 0.6s ease-out,
-    transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
 .reveal-left.in-view {
@@ -320,9 +282,7 @@
 .reveal-right {
   opacity: 0;
   transform: translateX(40px);
-  transition:
-    opacity 0.6s ease-out,
-    transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
 .reveal-right.in-view {
@@ -333,9 +293,7 @@
 .reveal-scale {
   opacity: 0;
   transform: scale(0.85);
-  transition:
-    opacity 0.6s ease-out,
-    transform 0.6s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
 .reveal-scale.in-view {
@@ -350,6 +308,10 @@
   background-size: 28px 28px;
 }
 
+.dark .bg-grid-dots {
+  background-image: radial-gradient(circle, rgba(245, 240, 232, 0.06) 1px, transparent 1px);
+}
+
 .bg-diagonal-lines {
   background-image: repeating-linear-gradient(
     -45deg,
@@ -357,6 +319,16 @@
     transparent 8px,
     rgba(0, 0, 0, 0.02) 8px,
     rgba(0, 0, 0, 0.02) 9px
+  );
+}
+
+.dark .bg-diagonal-lines {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 8px,
+    rgba(245, 240, 232, 0.03) 8px,
+    rgba(245, 240, 232, 0.03) 9px
   );
 }
 
@@ -382,9 +354,7 @@ body {
 /* ── Neo-brutalist interactive utilities ── */
 
 .neo-press {
-  transition:
-    translate 100ms ease,
-    box-shadow 100ms ease;
+  transition: translate 100ms ease, box-shadow 100ms ease;
 }
 .neo-press:hover {
   translate: -2px -2px;
@@ -394,9 +364,7 @@ body {
 }
 
 .neo-lift {
-  transition:
-    translate 150ms ease,
-    box-shadow 150ms ease;
+  transition: translate 150ms ease, box-shadow 150ms ease;
 }
 .neo-lift:hover {
   translate: -3px -3px;
@@ -408,73 +376,42 @@ body {
 /* ── Card 3D tilt on hover ── */
 
 .card-tilt {
-  transition:
-    transform 0.3s ease,
-    box-shadow 0.3s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
   transform-style: preserve-3d;
 }
 
 .card-tilt:hover {
   transform: perspective(800px) rotateX(2deg) rotateY(-3deg) translateY(-6px);
-  box-shadow: 10px 10px 0 #000;
+  box-shadow: 10px 10px 0 var(--color-border);
 }
 
 .card-tilt:active {
   transform: perspective(800px) rotateX(0) rotateY(0) translateY(0);
-  box-shadow: 3px 3px 0 #000;
+  box-shadow: 3px 3px 0 var(--color-border);
 }
 
 /* ── Stagger animation delays ── */
 
-.stagger-1 {
-  animation-delay: 100ms;
-}
-.stagger-2 {
-  animation-delay: 200ms;
-}
-.stagger-3 {
-  animation-delay: 300ms;
-}
-.stagger-4 {
-  animation-delay: 400ms;
-}
-.stagger-5 {
-  animation-delay: 500ms;
-}
-.stagger-6 {
-  animation-delay: 600ms;
-}
-.stagger-7 {
-  animation-delay: 700ms;
-}
-.stagger-8 {
-  animation-delay: 800ms;
-}
+.stagger-1 { animation-delay: 100ms; }
+.stagger-2 { animation-delay: 200ms; }
+.stagger-3 { animation-delay: 300ms; }
+.stagger-4 { animation-delay: 400ms; }
+.stagger-5 { animation-delay: 500ms; }
+.stagger-6 { animation-delay: 600ms; }
+.stagger-7 { animation-delay: 700ms; }
+.stagger-8 { animation-delay: 800ms; }
 
 /* Stagger for scroll-triggered reveals */
-.stagger-delay-1 {
-  transition-delay: 100ms;
-}
-.stagger-delay-2 {
-  transition-delay: 200ms;
-}
-.stagger-delay-3 {
-  transition-delay: 300ms;
-}
-.stagger-delay-4 {
-  transition-delay: 400ms;
-}
+.stagger-delay-1 { transition-delay: 100ms; }
+.stagger-delay-2 { transition-delay: 200ms; }
+.stagger-delay-3 { transition-delay: 300ms; }
+.stagger-delay-4 { transition-delay: 400ms; }
 
 /* ── Floating animation for background elements ── */
 
 @keyframes float {
-  0%,
-  100% {
-    transform: translateY(0px) rotate(var(--float-rotate, 0deg));
-  }
-  50% {
-    transform: translateY(-20px) rotate(var(--float-rotate, 0deg));
-  }
+  0%, 100% { transform: translateY(0px) rotate(var(--float-rotate, 0deg)); }
+  50% { transform: translateY(-20px) rotate(var(--float-rotate, 0deg)); }
 }
 
 .animate-float {
@@ -484,12 +421,8 @@ body {
 /* ── Spin slow (for decorative elements) ── */
 
 @keyframes spin-slow {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .animate-spin-slow {
@@ -499,20 +432,10 @@ body {
 /* ── Bounce in for emphasis ── */
 
 @keyframes bounce-in {
-  0% {
-    transform: scale(0);
-    opacity: 0;
-  }
-  50% {
-    transform: scale(1.15);
-  }
-  70% {
-    transform: scale(0.95);
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+  0% { transform: scale(0); opacity: 0; }
+  50% { transform: scale(1.15); }
+  70% { transform: scale(0.95); }
+  100% { transform: scale(1); opacity: 1; }
 }
 
 .animate-bounce-in {
@@ -522,13 +445,8 @@ body {
 /* ── Typewriter cursor blink ── */
 
 @keyframes blink-cursor {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 .typewriter-cursor::after {
@@ -553,7 +471,7 @@ body {
   width: 0;
   height: 4px;
   background: var(--color-primary);
-  border: 1px solid black;
+  border: 1px solid var(--color-border);
   transition: width 0.4s ease-out;
 }
 
@@ -565,19 +483,15 @@ body {
 /* ── Step connector line ── */
 
 @keyframes draw-line {
-  from {
-    width: 0;
-  }
-  to {
-    width: 100%;
-  }
+  from { width: 0; }
+  to { width: 100%; }
 }
 
 .step-line {
   height: 3px;
   background: var(--color-primary);
-  border-top: 1.5px solid black;
-  border-bottom: 1.5px solid black;
+  border-top: 1.5px solid var(--color-border);
+  border-bottom: 1.5px solid var(--color-border);
 }
 
 .step-line.in-view {

--- a/frontend/src/pages/create-quest.tsx
+++ b/frontend/src/pages/create-quest.tsx
@@ -104,16 +104,16 @@ function StepIndicator({ current }: { current: FormStep }) {
           <div key={s.n} className="flex items-center">
             <div
               className={cn(
-                "flex items-center gap-2 px-4 py-2 border-[2px] border-black text-xs font-black uppercase tracking-wider",
-                active && "bg-primary shadow-[2px_2px_0_#000]",
+                "flex items-center gap-2 px-4 py-2 border-[2px] border-border text-xs font-black uppercase tracking-wider",
+                active && "bg-primary shadow-[2px_2px_0_var(--color-border)]",
                 done && "bg-success",
-                !active && !done && "bg-white text-muted-foreground"
+                !active && !done && "bg-background text-muted-foreground"
               )}
             >
               <div
                 className={cn(
                   "w-5 h-5 border-[1.5px] border-current flex items-center justify-center text-[10px] font-black",
-                  done && "border-black"
+                  done && "border-border"
                 )}
               >
                 {done ? <Check className="h-3 w-3" /> : s.n}
@@ -155,7 +155,7 @@ function Step1Form({
   return (
     <form onSubmit={handleSubmit(onNext)} className="space-y-6">
       <div>
-        <div className="bg-primary border-b-[3px] border-black px-6 py-3">
+        <div className="bg-primary border-b-[3px] border-border px-6 py-3">
           <div className="flex items-center gap-2">
             <FileText className="h-4 w-4" />
             <span className="text-sm font-black uppercase tracking-wider">
@@ -163,7 +163,7 @@ function Step1Form({
             </span>
           </div>
         </div>
-        <div className="border-[3px] border-t-0 border-black p-6 bg-white shadow-[4px_4px_0_#000] space-y-5">
+        <div className="border-[3px] border-t-0 border-border p-6 bg-background shadow-[4px_4px_0_var(--color-border)] space-y-5">
           {/* Name */}
           <div>
             <FormLabel required>Quest Name</FormLabel>
@@ -171,7 +171,7 @@ function Step1Form({
               {...register("name")}
               placeholder="e.g. Learn to Code with Alex"
               className={cn(
-                "w-full border-[2px] border-black px-4 py-2.5 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_#000] transition-shadow bg-white",
+                "w-full border-[2px] border-border px-4 py-2.5 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_var(--color-border)] transition-shadow bg-background",
                 errors.name && "border-destructive"
               )}
               maxLength={64}
@@ -199,7 +199,7 @@ function Step1Form({
               rows={5}
               placeholder="Describe what learners will accomplish..."
               className={cn(
-                "w-full border-[2px] border-black px-4 py-2.5 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_#000] transition-shadow resize-none bg-white",
+                "w-full border-[2px] border-border px-4 py-2.5 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_var(--color-border)] transition-shadow resize-none bg-background",
                 errors.description && "border-destructive"
               )}
               maxLength={2000}
@@ -268,7 +268,7 @@ function Step2Form({
   return (
     <form onSubmit={handleSubmit(onNext)} className="space-y-6">
       <div>
-        <div className="bg-primary border-b-[3px] border-black px-6 py-3 flex items-center justify-between">
+        <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Target className="h-4 w-4" />
             <span className="text-sm font-black uppercase tracking-wider">
@@ -283,7 +283,7 @@ function Step2Form({
           </div>
         </div>
 
-        <div className="border-[3px] border-t-0 border-black bg-white shadow-[4px_4px_0_#000]">
+        <div className="border-[3px] border-t-0 border-border bg-background shadow-[4px_4px_0_var(--color-border)]">
           {/* Array-level error */}
           {errors.milestones?.root && (
             <div className="px-6 pt-4">
@@ -292,13 +292,13 @@ function Step2Form({
           )}
 
           {/* Milestone list */}
-          <div className="divide-y-[2px] divide-black">
+          <div className="divide-y-[2px] divide-border">
             {fields.map((field, index) => (
               <div key={field.id} className="p-5 space-y-4">
                 {/* Milestone header */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-6 h-6 bg-primary border-[2px] border-black flex items-center justify-center text-xs font-black">
+                    <div className="w-6 h-6 bg-primary border-[2px] border-border flex items-center justify-center text-xs font-black">
                       {index + 1}
                     </div>
                     <span className="text-xs font-black uppercase tracking-wider text-muted-foreground">
@@ -310,7 +310,7 @@ function Step2Form({
                       type="button"
                       onClick={() => swap(index, index - 1)}
                       disabled={index === 0}
-                      className="w-7 h-7 border-[2px] border-black bg-white flex items-center justify-center hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
+                      className="w-7 h-7 border-[2px] border-border bg-background flex items-center justify-center hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
                     >
                       <ChevronUp className="h-3.5 w-3.5" />
                     </button>
@@ -318,7 +318,7 @@ function Step2Form({
                       type="button"
                       onClick={() => swap(index, index + 1)}
                       disabled={index === fields.length - 1}
-                      className="w-7 h-7 border-[2px] border-black bg-white flex items-center justify-center hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
+                      className="w-7 h-7 border-[2px] border-border bg-background flex items-center justify-center hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
                     >
                       <ChevronDown className="h-3.5 w-3.5" />
                     </button>
@@ -326,7 +326,7 @@ function Step2Form({
                       type="button"
                       onClick={() => remove(index)}
                       disabled={fields.length === 1}
-                      className="w-7 h-7 border-[2px] border-black bg-white flex items-center justify-center hover:bg-destructive/10 hover:border-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
+                      className="w-7 h-7 border-[2px] border-border bg-background flex items-center justify-center hover:bg-destructive/10 hover:border-destructive disabled:opacity-30 disabled:cursor-not-allowed transition-colors neo-press cursor-pointer"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>
@@ -340,7 +340,7 @@ function Step2Form({
                     {...register(`milestones.${index}.title`)}
                     placeholder="e.g. Hello World"
                     className={cn(
-                      "w-full border-[2px] border-black px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_#000] transition-shadow bg-white",
+                      "w-full border-[2px] border-border px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_var(--color-border)] transition-shadow bg-background",
                       errors.milestones?.[index]?.title && "border-destructive"
                     )}
                     maxLength={100}
@@ -358,7 +358,7 @@ function Step2Form({
                     rows={2}
                     placeholder="What should the learner do to complete this milestone?"
                     className={cn(
-                      "w-full border-[2px] border-black px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_#000] transition-shadow resize-none bg-white",
+                      "w-full border-[2px] border-border px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_var(--color-border)] transition-shadow resize-none bg-background",
                       errors.milestones?.[index]?.description &&
                         "border-destructive"
                     )}
@@ -373,7 +373,7 @@ function Step2Form({
                 <div>
                   <FormLabel required>Reward Amount (USDC)</FormLabel>
                   <div className="flex items-center gap-0">
-                    <div className="border-[2px] border-r-0 border-black bg-secondary px-3 py-2 text-xs font-black">
+                    <div className="border-[2px] border-r-0 border-border bg-secondary px-3 py-2 text-xs font-black">
                       USDC
                     </div>
                     <input
@@ -385,7 +385,7 @@ function Step2Form({
                       step="0.01"
                       placeholder="100"
                       className={cn(
-                        "flex-1 border-[2px] border-black px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_#000] transition-shadow bg-white",
+                        "flex-1 border-[2px] border-border px-4 py-2 text-sm font-medium focus:outline-none focus:shadow-[3px_3px_0_var(--color-border)] transition-shadow bg-background",
                         errors.milestones?.[index]?.rewardAmount &&
                           "border-destructive"
                       )}
@@ -400,13 +400,13 @@ function Step2Form({
           </div>
 
           {/* Add milestone button */}
-          <div className="p-5 border-t-[2px] border-black">
+          <div className="p-5 border-t-[2px] border-border">
             <button
               type="button"
               onClick={() =>
                 append({ title: "", description: "", rewardAmount: 0 })
               }
-              className="w-full border-[2px] border-dashed border-black py-3 flex items-center justify-center gap-2 text-sm font-black hover:bg-secondary transition-colors cursor-pointer"
+              className="w-full border-[2px] border-dashed border-border py-3 flex items-center justify-center gap-2 text-sm font-black hover:bg-secondary transition-colors cursor-pointer"
             >
               <Plus className="h-4 w-4" />
               Add Milestone
@@ -416,7 +416,7 @@ function Step2Form({
       </div>
 
       {/* Running total */}
-      <div className="bg-secondary border-[2px] border-black px-5 py-3 flex items-center justify-between shadow-[3px_3px_0_#000]">
+      <div className="bg-secondary border-[2px] border-border px-5 py-3 flex items-center justify-between shadow-[3px_3px_0_var(--color-border)]">
         <div className="flex items-center gap-2">
           <Coins className="h-4 w-4" />
           <span className="text-sm font-black">Total reward pool needed</span>
@@ -478,7 +478,7 @@ function Step3Review({
   return (
     <div className="space-y-6">
       <div>
-        <div className="bg-primary border-b-[3px] border-black px-6 py-3">
+        <div className="bg-primary border-b-[3px] border-border px-6 py-3">
           <div className="flex items-center gap-2">
             <Sparkles className="h-4 w-4" />
             <span className="text-sm font-black uppercase tracking-wider">
@@ -486,7 +486,7 @@ function Step3Review({
             </span>
           </div>
         </div>
-        <div className="border-[3px] border-t-0 border-black bg-white shadow-[4px_4px_0_#000] divide-y-[2px] divide-black">
+        <div className="border-[3px] border-t-0 border-border bg-background shadow-[4px_4px_0_var(--color-border)] divide-y-[2px] divide-border">
           {/* Quest summary */}
           <div className="p-5 space-y-2">
             <p className="text-xs font-black uppercase tracking-wider text-muted-foreground mb-3">
@@ -507,10 +507,10 @@ function Step3Review({
               {step2Data.milestones.map((m: z.infer<typeof milestoneSchema>, i: number) => (
                 <div
                   key={i}
-                  className="flex items-start justify-between gap-3 p-3 bg-secondary border-[1.5px] border-black"
+                  className="flex items-start justify-between gap-3 p-3 bg-secondary border-[1.5px] border-border"
                 >
                   <div className="flex items-start gap-2">
-                    <div className="w-5 h-5 bg-primary border-[1.5px] border-black flex items-center justify-center text-[10px] font-black flex-shrink-0 mt-0.5">
+                    <div className="w-5 h-5 bg-primary border-[1.5px] border-border flex items-center justify-center text-[10px] font-black flex-shrink-0 mt-0.5">
                       {i + 1}
                     </div>
                     <div>
@@ -533,7 +533,7 @@ function Step3Review({
             <p className="text-xs font-black uppercase tracking-wider text-muted-foreground mb-3">
               Reward Pool
             </p>
-            <div className="flex items-center justify-between p-4 bg-primary border-[2px] border-black shadow-[3px_3px_0_#000] mb-4">
+            <div className="flex items-center justify-between p-4 bg-primary border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] mb-4">
               <div className="flex items-center gap-2">
                 <Coins className="h-5 w-5" />
                 <span className="font-black">Total USDC needed</span>
@@ -640,18 +640,18 @@ export function CreateQuest({ onBack }: CreateQuestProps) {
       <div className="min-h-[calc(100vh-67px)] flex items-center justify-center relative overflow-hidden">
         <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
         <div className="relative px-4 max-w-md mx-auto w-full">
-          <div className="bg-white border-[3px] border-black shadow-[8px_8px_0_#000] overflow-hidden animate-scale-in">
-            <div className="bg-primary border-b-[3px] border-black px-6 py-3 flex items-center justify-between">
+          <div className="bg-background border-[3px] border-border shadow-[8px_8px_0_var(--color-border)] overflow-hidden animate-scale-in">
+            <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
               <span className="text-xs font-black uppercase tracking-wider">
                 Create Quest
               </span>
               <div className="flex items-center gap-1.5">
-                <div className="w-2.5 h-2.5 bg-destructive border border-black" />
+                <div className="w-2.5 h-2.5 bg-destructive border border-border" />
                 <span className="text-xs font-bold">Not Connected</span>
               </div>
             </div>
             <div className="p-8 text-center">
-              <div className="w-16 h-16 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] flex items-center justify-center mb-5 mx-auto">
+              <div className="w-16 h-16 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-5 mx-auto">
                 <Wallet className="h-7 w-7" />
               </div>
               <h2 className="text-2xl font-black mb-2">Connect your wallet</h2>
@@ -691,7 +691,7 @@ export function CreateQuest({ onBack }: CreateQuestProps) {
         onClick={onBack}
         className="flex items-center gap-2 text-sm font-bold text-muted-foreground hover:text-foreground mb-6 transition-colors cursor-pointer group"
       >
-        <div className="w-7 h-7 border-[2px] border-black bg-white shadow-[2px_2px_0_#000] flex items-center justify-center neo-press hover:bg-primary transition-colors">
+        <div className="w-7 h-7 border-[2px] border-border bg-background shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center neo-press hover:bg-primary transition-colors">
           <ArrowLeft className="h-3.5 w-3.5" />
         </div>
         Back to Dashboard

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -53,25 +53,25 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
       <div className="min-h-[calc(100vh-67px)] flex items-center justify-center relative overflow-hidden">
         {/* Background elements */}
         <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
-        <div className="absolute top-[10%] left-[8%] w-20 h-20 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] rotate-12 opacity-[0.08] animate-float" style={{ animationDuration: "8s" }} />
-        <div className="absolute bottom-[15%] right-[6%] w-14 h-14 bg-primary border-[2px] border-black shadow-[3px_3px_0_#000] -rotate-6 opacity-[0.1] animate-float" style={{ animationDuration: "6s", animationDelay: "1s" }} />
-        <div className="absolute top-[60%] left-[5%] w-10 h-10 bg-success border-[2px] border-black shadow-[2px_2px_0_#000] rotate-45 opacity-[0.06] animate-float" style={{ animationDuration: "7s", animationDelay: "2s" }} />
-        <div className="absolute top-[20%] right-[12%] w-8 h-8 bg-primary border-[2px] border-black opacity-[0.07] -rotate-12 animate-float" style={{ animationDuration: "9s", animationDelay: "0.5s" }} />
+        <div className="absolute top-[10%] left-[8%] w-20 h-20 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] rotate-12 opacity-[0.08] animate-float" style={{ animationDuration: "8s" }} />
+        <div className="absolute bottom-[15%] right-[6%] w-14 h-14 bg-primary border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] -rotate-6 opacity-[0.1] animate-float" style={{ animationDuration: "6s", animationDelay: "1s" }} />
+        <div className="absolute top-[60%] left-[5%] w-10 h-10 bg-success border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] rotate-45 opacity-[0.06] animate-float" style={{ animationDuration: "7s", animationDelay: "2s" }} />
+        <div className="absolute top-[20%] right-[12%] w-8 h-8 bg-primary border-[2px] border-border opacity-[0.07] -rotate-12 animate-float" style={{ animationDuration: "9s", animationDelay: "0.5s" }} />
 
         <div className="relative px-4 max-w-lg mx-auto">
           {/* Card container */}
-          <div className="bg-white border-[3px] border-black shadow-[8px_8px_0_#000] overflow-hidden animate-scale-in">
+          <div className="bg-background border-[3px] border-border shadow-[8px_8px_0_var(--color-border)] overflow-hidden animate-scale-in">
             {/* Yellow header strip */}
-            <div className="bg-primary border-b-[3px] border-black px-6 py-3 flex items-center justify-between">
+            <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
               <span className="text-xs font-black uppercase tracking-wider">Dashboard</span>
               <div className="flex items-center gap-1.5">
-                <div className="w-2.5 h-2.5 bg-destructive border border-black" />
+                <div className="w-2.5 h-2.5 bg-destructive border border-border" />
                 <span className="text-xs font-bold">Not Connected</span>
               </div>
             </div>
 
             <div className="p-8 sm:p-10 text-center">
-              <div className="w-20 h-20 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] flex items-center justify-center mb-6 mx-auto animate-fade-in-up">
+              <div className="w-20 h-20 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-6 mx-auto animate-fade-in-up">
                 <Wallet className="h-8 w-8" />
               </div>
               <h2 className="text-2xl sm:text-3xl font-black mb-3 animate-fade-in-up stagger-1">
@@ -91,7 +91,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
               </Button>
 
               {/* Mini feature list */}
-              <div className="mt-8 pt-6 border-t-[2px] border-black animate-fade-in-up stagger-4">
+              <div className="mt-8 pt-6 border-t-[2px] border-border animate-fade-in-up stagger-4">
                 <div className="flex flex-wrap justify-center gap-4">
                   {[
                     { icon: Target, text: "Track quests" },
@@ -99,7 +99,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
                     { icon: Sparkles, text: "On-chain" },
                   ].map((item) => (
                     <div key={item.text} className="flex items-center gap-2">
-                      <div className="w-6 h-6 bg-secondary border-[1.5px] border-black flex items-center justify-center">
+                      <div className="w-6 h-6 bg-secondary border-[1.5px] border-border flex items-center justify-center">
                         <item.icon className="h-3 w-3" />
                       </div>
                       <span className="text-xs font-bold text-muted-foreground">{item.text}</span>
@@ -111,8 +111,8 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
           </div>
 
           {/* Decorative accent blocks */}
-          <div className="absolute -top-4 -right-4 w-10 h-10 bg-primary border-[2px] border-black shadow-[3px_3px_0_#000] rotate-12 animate-fade-in-up stagger-5 hidden sm:block" />
-          <div className="absolute -bottom-3 -left-3 w-8 h-8 bg-success border-[2px] border-black shadow-[2px_2px_0_#000] -rotate-6 animate-fade-in-up stagger-6 hidden sm:block" />
+          <div className="absolute -top-4 -right-4 w-10 h-10 bg-primary border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] rotate-12 animate-fade-in-up stagger-5 hidden sm:block" />
+          <div className="absolute -bottom-3 -left-3 w-8 h-8 bg-success border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] -rotate-6 animate-fade-in-up stagger-6 hidden sm:block" />
         </div>
       </div>
     )
@@ -128,7 +128,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
   return (
     <div className="relative mx-auto max-w-7xl px-4 sm:px-6 py-8">
       {/* Welcome banner */}
-      <div className="relative bg-primary border-[3px] border-black shadow-[6px_6px_0_#000] p-6 sm:p-8 mb-8 overflow-hidden animate-fade-in-up">
+      <div className="relative bg-primary border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] p-6 sm:p-8 mb-8 overflow-hidden animate-fade-in-up">
         <div className="absolute inset-0 bg-diagonal-lines pointer-events-none opacity-30" />
         <div className="relative flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div>
@@ -165,7 +165,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
           <PersonalProgress stats={MOCK_USER_STATS} />
 
           {/* Earnings Chart (Lazy Loaded) */}
-          <Suspense fallback={<div className="h-[250px] animate-pulse bg-muted border-[3px] border-black shadow-[6px_6px_0_#000]" />}>
+          <Suspense fallback={<div className="h-[250px] animate-pulse bg-muted border-[3px] border-border shadow-[6px_6px_0_var(--color-border)]" />}>
             <EarningsChart data={MOCK_EARNINGS_HISTORY} />
           </Suspense>
 
@@ -175,15 +175,15 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
               <h2 className="text-xl font-black flex items-center gap-2">
                 <LayoutDashboard className="w-5 h-5" /> Your Quests
               </h2>
-              <div className="flex gap-0 border-[2px] border-black shadow-[3px_3px_0_#000]">
+              <div className="flex gap-0 border-[2px] border-border shadow-[3px_3px_0_var(--color-border)]">
                 {(["all", "owned", "enrolled"] as const).map((f) => (
                   <button
                     key={f}
                     onClick={() => setFilter(f)}
-                    className={`px-4 py-2 text-xs font-black uppercase tracking-wider transition-colors capitalize cursor-pointer border-r-[2px] border-black last:border-r-0 ${
+                    className={`px-4 py-2 text-xs font-black uppercase tracking-wider transition-colors capitalize cursor-pointer border-r-[2px] border-border last:border-r-0 ${
                       filter === f
                         ? "bg-primary"
-                        : "bg-white hover:bg-secondary"
+                        : "bg-background hover:bg-secondary"
                     }`}
                   >
                     {f}
@@ -241,7 +241,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
                             {ws.description}
                           </p>
                         </div>
-                        <div className="w-8 h-8 bg-secondary border-[2px] border-black flex items-center justify-center flex-shrink-0 ml-3 group-hover:bg-primary group-hover:shadow-[2px_2px_0_#000] transition-all">
+                        <div className="w-8 h-8 bg-secondary border-[2px] border-border flex items-center justify-center flex-shrink-0 ml-3 group-hover:bg-primary group-hover:shadow-[2px_2px_0_var(--color-border)] transition-all">
                           <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
                         </div>
                       </div>
@@ -295,7 +295,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
             {filteredWorkspaces.length === 0 && (
               <Card className="animate-fade-in-up mt-5">
                 <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-                  <div className="w-16 h-16 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] flex items-center justify-center mb-6">
+                  <div className="w-16 h-16 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-6">
                     <Search className="h-6 w-6" />
                   </div>
                   <h3 className="font-black text-lg mb-2">

--- a/frontend/src/pages/dashboard/earnings-chart.tsx
+++ b/frontend/src/pages/dashboard/earnings-chart.tsx
@@ -9,13 +9,13 @@ interface EarningsChartProps {
 
 export default function EarningsChart({ data }: EarningsChartProps) {
   return (
-    <Card className="border-[3px] border-black shadow-[6px_6px_0_#000] overflow-hidden">
-      <CardHeader className="bg-white border-b-[2px] border-black py-4">
+    <Card className="border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] overflow-hidden">
+      <CardHeader className="bg-background border-b-[2px] border-border py-4">
         <CardTitle className="text-lg flex items-center gap-2">
           <TrendingUp className="w-5 h-5" /> Earnings History
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-6 bg-white">
+      <CardContent className="p-6 bg-background">
         <div className="h-[250px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>

--- a/frontend/src/pages/dashboard/personal-progress.tsx
+++ b/frontend/src/pages/dashboard/personal-progress.tsx
@@ -13,20 +13,20 @@ export function PersonalProgress({ stats }: PersonalProgressProps) {
         <Activity className="w-5 h-5" /> Your Progress
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+        <div className="bg-secondary border-[2px] border-border p-4 shadow-[3px_3px_0_var(--color-border)]">
           <p className="text-xs font-bold text-muted-foreground uppercase text-center">Enrolled</p>
           <p className="text-2xl font-black mt-1 text-center">{stats.workspacesEnrolled}</p>
         </div>
-        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+        <div className="bg-secondary border-[2px] border-border p-4 shadow-[3px_3px_0_var(--color-border)]">
           <p className="text-xs font-bold text-muted-foreground uppercase text-center">Completed</p>
           <p className="text-2xl font-black mt-1 text-center">{stats.milestonesCompleted}</p>
         </div>
-        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+        <div className="bg-secondary border-[2px] border-border p-4 shadow-[3px_3px_0_var(--color-border)]">
           <p className="text-xs font-bold text-muted-foreground uppercase text-center">Owned</p>
           <p className="text-2xl font-black mt-1 text-center">{stats.workspacesOwned}</p>
         </div>
-        <div className="bg-primary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
-          <p className="text-xs font-bold text-black uppercase text-center">Earnings</p>
+        <div className="bg-primary border-[2px] border-border p-4 shadow-[3px_3px_0_var(--color-border)]">
+          <p className="text-xs font-bold text-foreground uppercase text-center">Earnings</p>
           <p className="text-xl font-black mt-2 text-center text-green-800">{formatTokens(stats.totalEarned)} USDC</p>
         </div>
       </div>

--- a/frontend/src/pages/dashboard/platform-stats.tsx
+++ b/frontend/src/pages/dashboard/platform-stats.tsx
@@ -10,40 +10,40 @@ interface PlatformStatsProps {
 export function PlatformStats({ stats }: PlatformStatsProps) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 animate-fade-in-up stagger-1">
-      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+      <Card className="card-tilt bg-background border-[3px] border-border shadow-[4px_4px_0_var(--color-border)]">
         <CardContent className="p-6">
           <div className="flex justify-between items-start">
             <div>
               <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Total Quests</p>
               <h3 className="text-3xl font-black mt-1">{stats.totalQuests}</h3>
             </div>
-            <div className="w-10 h-10 bg-secondary border-[2px] border-black flex items-center justify-center">
+            <div className="w-10 h-10 bg-secondary border-[2px] border-border flex items-center justify-center">
               <Target className="w-5 h-5" />
             </div>
           </div>
         </CardContent>
       </Card>
-      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+      <Card className="card-tilt bg-background border-[3px] border-border shadow-[4px_4px_0_var(--color-border)]">
         <CardContent className="p-6">
           <div className="flex justify-between items-start">
             <div>
               <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Active Users</p>
               <h3 className="text-3xl font-black mt-1">{stats.activeUsers}</h3>
             </div>
-            <div className="w-10 h-10 bg-success border-[2px] border-black flex items-center justify-center">
+            <div className="w-10 h-10 bg-success border-[2px] border-border flex items-center justify-center">
               <Users className="w-5 h-5" />
             </div>
           </div>
         </CardContent>
       </Card>
-      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+      <Card className="card-tilt bg-background border-[3px] border-border shadow-[4px_4px_0_var(--color-border)]">
         <CardContent className="p-6">
           <div className="flex justify-between items-start">
             <div>
               <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Tokens Distributed</p>
               <h3 className="text-3xl font-black mt-1 text-green-700">{formatTokens(stats.tokensDistributed)} USDC</h3>
             </div>
-            <div className="w-10 h-10 bg-primary border-[2px] border-black flex items-center justify-center">
+            <div className="w-10 h-10 bg-primary border-[2px] border-border flex items-center justify-center">
               <Coins className="w-5 h-5" />
             </div>
           </div>

--- a/frontend/src/pages/dashboard/recent-activity.tsx
+++ b/frontend/src/pages/dashboard/recent-activity.tsx
@@ -12,18 +12,18 @@ export function RecentActivity({ activities }: RecentActivityProps) {
       <h2 className="text-xl font-black mb-4 flex items-center gap-2">
         <Clock className="w-5 h-5" /> Recent Activity
       </h2>
-      <Card className="border-[3px] border-black shadow-[4px_4px_0_#000]">
+      <Card className="border-[3px] border-border shadow-[4px_4px_0_var(--color-border)]">
         <CardContent className="p-0">
-          <div className="divide-y-[2px] divide-black">
+          <div className="divide-y-[2px] divide-border">
             {activities.map((activity) => {
               const isEnrolled = activity.action === "enrolled"
               const isCompleted = activity.action === "completed"
               const Icon = isEnrolled ? Plus : isCompleted ? Target : Sparkles
-              const iconColor = isEnrolled ? "bg-primary" : isCompleted ? "bg-success" : "bg-white"
+              const iconColor = isEnrolled ? "bg-primary" : isCompleted ? "bg-success" : "bg-background"
 
               return (
                 <div key={activity.id} className="p-4 flex gap-3 hover:bg-secondary transition-colors">
-                  <div className={`w-8 h-8 ${iconColor} border-[2px] border-black flex-shrink-0 flex items-center justify-center shadow-[2px_2px_0_#000] mt-1`}>
+                  <div className={`w-8 h-8 ${iconColor} border-[2px] border-border flex-shrink-0 flex items-center justify-center shadow-[2px_2px_0_var(--color-border)] mt-1`}>
                      <Icon className="w-4 h-4" />
                   </div>
                   <div>

--- a/frontend/src/pages/dashboard/trending-quests.tsx
+++ b/frontend/src/pages/dashboard/trending-quests.tsx
@@ -19,13 +19,13 @@ export function TrendingQuests({ quests, onSelectQuest }: TrendingQuestsProps) {
         {quests.map((quest) => (
           <Card 
             key={quest.id} 
-            className="card-tilt cursor-pointer border-[2px] border-black shadow-[4px_4px_0_#000]"
+            className="card-tilt cursor-pointer border-[2px] border-border shadow-[4px_4px_0_var(--color-border)]"
             onClick={() => onSelectQuest(quest.id)}
           >
             <CardHeader className="p-4 pb-2">
               <div className="flex justify-between items-start">
                  <CardTitle className="text-sm font-bold line-clamp-1">{quest.name}</CardTitle>
-                 <Badge variant="default" className="text-[10px] bg-primary text-black border-[1px] border-black ml-2 px-1">
+                 <Badge variant="default" className="text-[10px] bg-primary text-foreground border-[1px] border-border ml-2 px-1">
                    Trending
                  </Badge>
               </div>

--- a/frontend/src/pages/landing.tsx
+++ b/frontend/src/pages/landing.tsx
@@ -46,7 +46,7 @@ function AnimatedQuestCard() {
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setStep(s => (s + 1) % 6)
+      setStep((s) => (s + 1) % 6)
     }, 2200)
     return () => clearInterval(timer)
   }, [])
@@ -65,46 +65,48 @@ function AnimatedQuestCard() {
   return (
     <div className="relative">
       {/* Stacked back cards */}
-      <div className="bg-primary/20 absolute -top-3 -left-3 h-full w-full border-[3px] border-black" />
-      <div className="bg-primary/40 absolute -top-1.5 -left-1.5 h-full w-full border-[3px] border-black" />
+      <div className="absolute -top-3 -left-3 w-full h-full bg-primary/20 border-[3px] border-border" />
+      <div className="absolute -top-1.5 -left-1.5 w-full h-full bg-primary/40 border-[3px] border-border" />
 
       {/* Main quest card */}
-      <div className="relative overflow-hidden border-[3px] border-black bg-white shadow-[8px_8px_0_#000]">
+      <div className="relative bg-card text-card-foreground border-[3px] border-border shadow-[8px_8px_0_var(--color-border)] overflow-hidden">
         {/* Card header */}
-        <div className="bg-primary flex items-center justify-between border-b-[3px] border-black px-6 py-3">
-          <span className="text-xs font-black tracking-wider uppercase">Active Quest</span>
+        <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
+          <span className="text-xs font-black uppercase tracking-wider">Active Quest</span>
           <div className="flex items-center gap-1.5">
-            <div className="bg-success h-2.5 w-2.5 border border-black" />
+            <div className="w-2.5 h-2.5 bg-success border border-border" />
             <span className="text-xs font-bold">Live</span>
           </div>
         </div>
 
         <div className="p-6">
-          <h3 className="mb-1 text-xl font-black">Stellar Dev Bootcamp</h3>
-          <p className="text-muted-foreground mb-6 text-sm">8 enrolled &middot; 1,000 USDC pool</p>
+          <h3 className="text-xl font-black mb-1">Stellar Dev Bootcamp</h3>
+          <p className="text-sm text-muted-foreground mb-6">
+            8 enrolled &middot; 1,000 USDC pool
+          </p>
 
           {/* Milestones with animated check states */}
-          <div className="mb-6 space-y-4">
+          <div className="space-y-4 mb-6">
             {milestones.map((m, i) => {
               const done = i < completedCount
               return (
                 <div key={m.label} className="flex items-center gap-3">
                   <div
-                    className={`flex h-6 w-6 flex-shrink-0 items-center justify-center border-[2px] border-black transition-all duration-500 ${
-                      done ? "bg-success scale-110" : "bg-white"
+                    className={`w-6 h-6 border-2 border-border flex items-center justify-center shrink-0 transition-all duration-500 ${
+                      done ? "bg-success scale-110" : "bg-card"
                     }`}
                   >
-                    {done && <CheckCircle2 className="animate-scale-in h-3.5 w-3.5" />}
+                    {done && <CheckCircle2 className="h-3.5 w-3.5 animate-scale-in" />}
                   </div>
                   <span
                     className={`flex-1 text-sm font-bold transition-all duration-500 ${
-                      done ? "text-muted-foreground line-through" : ""
+                      done ? "line-through text-muted-foreground" : ""
                     }`}
                   >
                     {m.label}
                   </span>
                   <span
-                    className={`border-[1.5px] border-black px-2 py-0.5 text-xs font-bold shadow-[2px_2px_0_#000] transition-colors duration-500 ${
+                    className={`text-xs font-bold border-[1.5px] border-border px-2 py-0.5 shadow-[2px_2px_0_var(--color-border)] transition-colors duration-500 ${
                       done ? "bg-success" : "bg-secondary"
                     }`}
                   >
@@ -116,7 +118,7 @@ function AnimatedQuestCard() {
           </div>
 
           {/* Animated progress bar */}
-          <div className="bg-secondary h-5 w-full border-[3px] border-black shadow-[2px_2px_0_#000]">
+          <div className="h-5 w-full border-[3px] border-border bg-secondary shadow-[2px_2px_0_var(--color-border)]">
             <div
               className={`h-full transition-all duration-700 ease-out ${
                 isComplete ? "bg-success" : "bg-primary"
@@ -124,29 +126,27 @@ function AnimatedQuestCard() {
               style={{ width: `${progress}%` }}
             />
           </div>
-          <div className="mt-2 flex items-center justify-between">
-            <p className="text-muted-foreground text-xs font-bold">
-              {completedCount} of 3 milestones
-            </p>
-            <p className="text-muted-foreground text-xs font-bold">{Math.round(progress)}%</p>
+          <div className="flex items-center justify-between mt-2">
+            <p className="text-xs font-bold text-muted-foreground">{completedCount} of 3 milestones</p>
+            <p className="text-xs font-bold text-muted-foreground">{Math.round(progress)}%</p>
           </div>
 
           {/* Earned bar */}
           <div
-            className={`mt-4 flex items-center justify-between border-[2px] border-black px-4 py-2 transition-all duration-500 ${
-              isComplete ? "bg-green-100" : "bg-green-50"
+            className={`mt-4 border-2 border-border px-4 py-2 flex items-center justify-between transition-all duration-500 ${
+              isComplete ? "bg-success/20" : "bg-success/10"
             }`}
           >
-            <span className="text-muted-foreground text-xs font-bold">Total earned</span>
-            <span className="text-sm font-black text-green-700 transition-all duration-300">
+            <span className="text-xs font-bold text-muted-foreground">Total earned</span>
+            <span className="text-sm font-black text-success transition-all duration-300">
               +{totalEarned} USDC
             </span>
           </div>
 
           {/* Quest complete banner */}
           {isComplete && (
-            <div className="bg-success animate-bounce-in mt-4 border-[2px] border-black px-4 py-2.5 text-center">
-              <span className="flex items-center justify-center gap-2 text-sm font-black">
+            <div className="mt-4 bg-success border-2 border-border px-4 py-2.5 text-center animate-bounce-in">
+              <span className="font-black text-sm flex items-center justify-center gap-2">
                 <Sparkles className="h-4 w-4" />
                 Quest Complete!
                 <Sparkles className="h-4 w-4" />
@@ -160,18 +160,15 @@ function AnimatedQuestCard() {
       {completedCount > 0 && !isComplete && (
         <div
           key={completedCount}
-          className="bg-success animate-bounce-in absolute -right-4 -bottom-5 border-[2px] border-black px-4 py-2.5 shadow-[3px_3px_0_#000]"
+          className="absolute -bottom-5 -right-4 bg-success border-2 border-border shadow-[3px_3px_0_var(--color-border)] px-4 py-2.5 animate-bounce-in"
         >
-          <span className="text-sm font-black">+{milestones[completedCount - 1]?.reward} USDC</span>
+          <span className="font-black text-sm">+{milestones[completedCount - 1]?.reward} USDC</span>
         </div>
       )}
 
       {/* Floating accent blocks */}
-      <div className="bg-primary animate-float absolute -top-8 -right-6 h-10 w-10 rotate-12 border-[2px] border-black shadow-[3px_3px_0_#000]" />
-      <div
-        className="bg-primary animate-float absolute -bottom-7 -left-5 h-8 w-8 -rotate-6 border-[2px] border-black shadow-[2px_2px_0_#000]"
-        style={{ animationDelay: "2s" }}
-      />
+      <div className="absolute -top-8 -right-6 w-10 h-10 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] rotate-12 animate-float" />
+      <div className="absolute -bottom-7 -left-5 w-8 h-8 bg-primary border-2 border-border shadow-[2px_2px_0_var(--color-border)] -rotate-6 animate-float" style={{ animationDelay: "2s" }} />
     </div>
   )
 }
@@ -179,28 +176,28 @@ function AnimatedQuestCard() {
 /* ─── Marquee Banner ─── */
 
 function MarqueeBanner() {
-  const items = ["LEARN TO EARN ON STELLAR", "ON THE DRIPS WAVE", "ON-CHAIN REWARDS, NO MIDDLEMEN"]
-
-  // Repeat items enough times so one half is always wider than the viewport
+  const items = [
+    "LEARN TO EARN ON STELLAR",
+    "ON THE DRIPS WAVE",
+    "ON-CHAIN REWARDS, NO MIDDLEMEN",
+  ]
   const repeated = Array.from({ length: 8 }, () => items).flat()
 
   return (
-    <div className="bg-primary overflow-hidden border-y-[3px] border-black select-none">
-      <div className="animate-marquee flex py-3.5 whitespace-nowrap">
-        {/* First half */}
+    <div className="border-y-[3px] border-border bg-primary overflow-hidden select-none">
+      <div className="flex whitespace-nowrap py-3.5 animate-marquee">
         <div className="flex shrink-0">
           {repeated.map((item, i) => (
-            <span key={`a-${i}`} className="mx-5 flex items-center gap-4">
-              <span className="text-sm font-black tracking-wider uppercase">{item}</span>
+            <span key={`a-${i}`} className="flex items-center gap-4 mx-5">
+              <span className="text-sm font-black uppercase tracking-wider">{item}</span>
               <Star className="h-3.5 w-3.5 fill-current" />
             </span>
           ))}
         </div>
-        {/* Duplicate half — seamless loop */}
         <div className="flex shrink-0">
           {repeated.map((item, i) => (
-            <span key={`b-${i}`} className="mx-5 flex items-center gap-4">
-              <span className="text-sm font-black tracking-wider uppercase">{item}</span>
+            <span key={`b-${i}`} className="flex items-center gap-4 mx-5">
+              <span className="text-sm font-black uppercase tracking-wider">{item}</span>
               <Star className="h-3.5 w-3.5 fill-current" />
             </span>
           ))}
@@ -228,79 +225,47 @@ export function Landing({ onNavigate }: LandingProps) {
 
   return (
     <div className="flex flex-col">
-      {/* ══════════════════════════════════════════════ */}
-      {/* HERO                                          */}
-      {/* ══════════════════════════════════════════════ */}
-      <section className="relative flex min-h-[calc(100vh-67px)] items-center overflow-hidden">
-        {/* Dot grid background */}
-        <div className="bg-grid-dots pointer-events-none absolute inset-0" />
+      {/* HERO */}
+      <section className="relative min-h-[calc(100vh-67px)] flex items-center overflow-hidden">
+        <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
 
-        {/* Floating geometric shapes */}
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div
-            className="bg-primary animate-float absolute top-[6%] left-[3%] h-20 w-20 rotate-12 border-[3px] border-black opacity-[0.08] shadow-[4px_4px_0_#000]"
-            style={{ animationDuration: "8s" }}
-          />
-          <div
-            className="bg-primary animate-float absolute top-[14%] right-[6%] h-14 w-14 -rotate-6 border-[2px] border-black opacity-[0.1] shadow-[3px_3px_0_#000]"
-            style={{ animationDuration: "6s", animationDelay: "1s" }}
-          />
-          <div
-            className="bg-success animate-float absolute bottom-[22%] left-[7%] h-10 w-10 rotate-45 border-[2px] border-black opacity-[0.06] shadow-[3px_3px_0_#000]"
-            style={{ animationDuration: "7s", animationDelay: "2s" }}
-          />
-          <div
-            className="animate-float absolute top-[42%] right-[3%] h-8 w-8 rotate-12 bg-black opacity-[0.04]"
-            style={{ animationDuration: "9s", animationDelay: "0.5s" }}
-          />
-          <div
-            className="bg-primary animate-float absolute right-[10%] bottom-[16%] h-16 w-16 -rotate-12 border-[2px] border-black opacity-[0.08] shadow-[3px_3px_0_#000]"
-            style={{ animationDuration: "7s", animationDelay: "3s" }}
-          />
-          <div
-            className="bg-primary animate-float absolute top-[55%] left-[14%] h-6 w-6 rotate-6 border-[2px] border-black opacity-[0.1]"
-            style={{ animationDuration: "5s", animationDelay: "1.5s" }}
-          />
-          <div
-            className="bg-primary animate-float absolute top-[4%] left-[42%] h-12 w-12 rotate-45 border-[2px] border-black opacity-[0.05] shadow-[2px_2px_0_#000]"
-            style={{ animationDuration: "10s", animationDelay: "2s" }}
-          />
-          <div
-            className="bg-success animate-float absolute top-[75%] right-[25%] h-5 w-5 rotate-12 border border-black opacity-[0.08]"
-            style={{ animationDuration: "6s", animationDelay: "3.5s" }}
-          />
+        {/* Decorative floating shapes — intentionally low opacity, borders stay border-border */}
+        <div className="absolute inset-0 pointer-events-none overflow-hidden">
+          <div className="absolute top-[6%] left-[3%] w-20 h-20 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] rotate-12 opacity-[0.08] animate-float" style={{ animationDuration: "8s" }} />
+          <div className="absolute top-[14%] right-[6%] w-14 h-14 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] -rotate-6 opacity-[0.1] animate-float" style={{ animationDuration: "6s", animationDelay: "1s" }} />
+          <div className="absolute bottom-[22%] left-[7%] w-10 h-10 bg-success border-2 border-border shadow-[3px_3px_0_var(--color-border)] rotate-45 opacity-[0.06] animate-float" style={{ animationDuration: "7s", animationDelay: "2s" }} />
+          <div className="absolute top-[42%] right-[3%] w-8 h-8 bg-foreground opacity-[0.04] rotate-12 animate-float" style={{ animationDuration: "9s", animationDelay: "0.5s" }} />
+          <div className="absolute bottom-[16%] right-[10%] w-16 h-16 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] -rotate-12 opacity-[0.08] animate-float" style={{ animationDuration: "7s", animationDelay: "3s" }} />
+          <div className="absolute top-[55%] left-[14%] w-6 h-6 bg-primary border-2 border-border opacity-[0.1] rotate-6 animate-float" style={{ animationDuration: "5s", animationDelay: "1.5s" }} />
+          <div className="absolute top-[4%] left-[42%] w-12 h-12 bg-primary border-2 border-border shadow-[2px_2px_0_var(--color-border)] rotate-45 opacity-[0.05] animate-float" style={{ animationDuration: "10s", animationDelay: "2s" }} />
+          <div className="absolute top-[75%] right-[25%] w-5 h-5 bg-success border border-border opacity-[0.08] rotate-12 animate-float" style={{ animationDuration: "6s", animationDelay: "3.5s" }} />
         </div>
 
-        <div className="mx-auto w-full max-w-7xl px-4 sm:px-6">
-          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-20">
-            {/* ── Left: Copy ── */}
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 w-full">
+          <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             <div className="py-20 lg:py-0">
-              <div className="bg-primary animate-fade-in-up shimmer-on-hover mb-10 inline-flex cursor-default items-center gap-2 border-[2px] border-black px-4 py-2 text-sm font-bold shadow-[3px_3px_0_#000]">
+              <div className="inline-flex items-center gap-2 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] px-4 py-2 mb-10 animate-fade-in-up text-sm font-bold shimmer-on-hover cursor-default">
                 <Sparkles className="h-3.5 w-3.5" />
                 Built on Stellar
               </div>
 
-              <h1 className="mb-10 text-6xl leading-[0.88] font-black tracking-tight sm:text-7xl lg:text-[5.5rem] xl:text-[6.5rem]">
-                <span className="animate-slide-in-left block">Learn.</span>
-                <span className="animate-slide-in-left stagger-2 block">
-                  <span className="bg-primary my-2 inline-block -rotate-2 cursor-default border-[3px] border-black px-4 py-2 shadow-[6px_6px_0_#000] transition-all duration-300 hover:rotate-0 hover:shadow-[8px_8px_0_#000]">
+              <h1 className="text-6xl sm:text-7xl lg:text-[5.5rem] xl:text-[6.5rem] font-black leading-[0.88] tracking-tight mb-10">
+                <span className="block animate-slide-in-left">Learn.</span>
+                <span className="block animate-slide-in-left stagger-2">
+                  <span className="inline-block bg-primary px-4 py-2 border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] -rotate-2 my-2 hover:rotate-0 hover:shadow-[8px_8px_0_var(--color-border)] transition-all duration-300 cursor-default">
                     Earn.
                   </span>
                 </span>
-                <span className="animate-slide-in-left stagger-3 block">On-chain.</span>
+                <span className="block animate-slide-in-left stagger-3">On-chain.</span>
               </h1>
 
-              <p className="text-muted-foreground animate-fade-in stagger-4 mb-12 h-[3.5em] max-w-lg text-xl leading-relaxed">
+              <p className="text-xl text-muted-foreground mb-12 max-w-lg leading-relaxed h-[3.5em] animate-fade-in stagger-4">
                 <span>{subtitle}</span>
                 <span className="typewriter-cursor" />
               </p>
 
-              <div className="animate-fade-in-up stagger-5 flex flex-col gap-4 sm:flex-row">
-                <Button
-                  size="lg"
-                  className="shimmer-on-hover group text-base"
-                  onClick={() => onNavigate("dashboard")}
-                >
+              <div className="flex flex-col sm:flex-row gap-4 animate-fade-in-up stagger-5">
+                <Button size="lg" className="text-base shimmer-on-hover group" onClick={() => onNavigate("dashboard")}>
                   Launch App
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Button>
@@ -317,18 +282,15 @@ export function Landing({ onNavigate }: LandingProps) {
                 </Button>
               </div>
 
-              {/* Social proof */}
-              <div className="animate-fade-in-up stagger-6 mt-14 flex flex-wrap gap-6">
+              <div className="flex flex-wrap gap-6 mt-14 animate-fade-in-up stagger-6">
                 {[
                   { color: "bg-primary", text: "3 smart contracts" },
                   { color: "bg-success", text: "On-chain rewards" },
                   { color: "bg-foreground", text: "Open source" },
-                ].map(item => (
-                  <div key={item.text} className="group flex cursor-default items-center gap-2">
-                    <div
-                      className={`h-3 w-3 ${item.color} border border-black transition-transform group-hover:scale-125`}
-                    />
-                    <span className="text-muted-foreground group-hover:text-foreground text-sm font-bold transition-colors">
+                ].map((item) => (
+                  <div key={item.text} className="flex items-center gap-2 group cursor-default">
+                    <div className={`w-3 h-3 ${item.color} border border-border transition-transform group-hover:scale-125`} />
+                    <span className="text-sm font-bold text-muted-foreground group-hover:text-foreground transition-colors">
                       {item.text}
                     </span>
                   </div>
@@ -336,38 +298,30 @@ export function Landing({ onNavigate }: LandingProps) {
               </div>
             </div>
 
-            {/* ── Right: Animated Hero illustration ── */}
-            <div className="animate-scale-in stagger-3 hidden lg:block">
+            <div className="hidden lg:block animate-scale-in stagger-3">
               <AnimatedQuestCard />
             </div>
           </div>
         </div>
 
-        {/* Marquee at bottom of hero */}
-        <div className="absolute right-0 bottom-0 left-0">
+        <div className="absolute bottom-0 left-0 right-0">
           <MarqueeBanner />
         </div>
       </section>
 
-      {/* ══════════════════════════════════════════════ */}
-      {/* HOW IT WORKS                                  */}
-      {/* ══════════════════════════════════════════════ */}
-      <section
-        id="how-it-works"
-        ref={howRef}
-        className="bg-secondary relative overflow-hidden py-24 sm:py-32"
-      >
-        <div className="bg-diagonal-lines pointer-events-none absolute inset-0" />
+      {/* HOW IT WORKS */}
+      <section id="how-it-works" ref={howRef} className="bg-secondary py-24 sm:py-32 relative overflow-hidden">
+        <div className="absolute inset-0 bg-diagonal-lines pointer-events-none" />
 
-        <div className="relative mx-auto max-w-7xl px-4 sm:px-6">
-          <div className={`reveal-up mb-16 text-center ${howInView ? "in-view" : ""}`}>
-            <div className="bg-primary mb-6 inline-block border-[2px] border-black px-4 py-2 shadow-[3px_3px_0_#000]">
-              <span className="text-sm font-black tracking-wider uppercase">How it works</span>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 relative">
+          <div className={`text-center mb-16 reveal-up ${howInView ? "in-view" : ""}`}>
+            <div className="inline-block bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] px-4 py-2 mb-6">
+              <span className="font-black text-sm uppercase tracking-wider">How it works</span>
             </div>
-            <h2 className="text-4xl font-black sm:text-5xl">Three steps. Zero complexity.</h2>
+            <h2 className="text-4xl sm:text-5xl font-black">Three steps. Zero complexity.</h2>
           </div>
 
-          <div className="grid grid-cols-1 items-stretch gap-0 sm:grid-cols-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-0 items-stretch">
             {[
               {
                 step: "01",
@@ -390,27 +344,25 @@ export function Landing({ onNavigate }: LandingProps) {
             ].map((item, i) => (
               <div key={item.step} className="flex items-stretch">
                 <div
-                  className={`card-tilt reveal-up relative flex-1 border-[3px] border-black bg-white p-8 shadow-[6px_6px_0_#000] ${howInView ? "in-view" : ""} shimmer-on-hover group`}
+                  className={`relative flex-1 bg-card text-card-foreground border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] p-8 card-tilt reveal-up ${howInView ? "in-view" : ""} shimmer-on-hover group`}
                   style={{ transitionDelay: `${i * 200}ms` }}
                 >
-                  {/* Large watermark number */}
-                  <div className="text-primary/15 group-hover:text-primary/25 pointer-events-none absolute top-3 right-4 text-[80px] leading-none font-black transition-colors duration-300 select-none">
+                  <div className="absolute top-3 right-4 text-[80px] font-black text-primary/15 leading-none select-none pointer-events-none group-hover:text-primary/25 transition-colors duration-300">
                     {item.step}
                   </div>
                   <div className="relative">
-                    <div className="bg-primary mb-6 flex h-14 w-14 items-center justify-center border-[2px] border-black shadow-[3px_3px_0_#000] transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-[5px_5px_0_#000]">
+                    <div className="w-14 h-14 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] flex items-center justify-center mb-6 group-hover:shadow-[5px_5px_0_var(--color-border)] group-hover:-translate-y-1 transition-all duration-300">
                       <item.icon className="h-6 w-6" />
                     </div>
-                    <h3 className="mb-3 text-xl font-black">{item.title}</h3>
+                    <h3 className="text-xl font-black mb-3">{item.title}</h3>
                     <p className="text-muted-foreground leading-relaxed">{item.desc}</p>
                   </div>
                 </div>
 
-                {/* Connector arrow between cards */}
                 {i < 2 && (
-                  <div className="z-10 -mx-1 hidden w-8 items-center justify-center sm:flex">
+                  <div className="hidden sm:flex items-center justify-center w-8 -mx-1 z-10">
                     <div
-                      className={`step-line w-full ${howInView ? "in-view" : ""}`}
+                      className={`w-full step-line ${howInView ? "in-view" : ""}`}
                       style={{ transitionDelay: `${(i + 1) * 300}ms` }}
                     />
                   </div>
@@ -421,131 +373,64 @@ export function Landing({ onNavigate }: LandingProps) {
         </div>
       </section>
 
-      {/* ══════════════════════════════════════════════ */}
-      {/* FEATURES                                      */}
-      {/* ══════════════════════════════════════════════ */}
-      <section
-        ref={featRef}
-        className="relative overflow-hidden border-t-[3px] border-black py-24 sm:py-32"
-      >
-        <div className="bg-grid-dots pointer-events-none absolute inset-0" />
+      {/* FEATURES */}
+      <section ref={featRef} className="border-t-[3px] border-border py-24 sm:py-32 relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
 
-        <div className="relative mx-auto max-w-7xl px-4 sm:px-6">
-          <div className={`reveal-up mb-16 text-center ${featInView ? "in-view" : ""}`}>
-            <h2 className="mb-5 text-4xl font-black sm:text-5xl">Why Lernza?</h2>
-            <p className="text-muted-foreground mx-auto max-w-lg text-lg">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 relative">
+          <div className={`text-center mb-16 reveal-up ${featInView ? "in-view" : ""}`}>
+            <h2 className="text-4xl sm:text-5xl font-black mb-5">Why Lernza?</h2>
+            <p className="text-lg text-muted-foreground max-w-lg mx-auto">
               Real incentives drive real learning. Everything on-chain, everything verifiable.
             </p>
           </div>
 
-          {/* Bento grid */}
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
             {[
-              {
-                icon: Users,
-                title: "For anyone",
-                desc: "Teach a friend, mentor a team, run a bootcamp. Anyone can create a quest. No gatekeeping, no approval needed.",
-                accent: "bg-primary",
-                large: true,
-              },
-              {
-                icon: Zap,
-                title: "Instant rewards",
-                desc: "Tokens transfer on-chain the moment you verify. No delays, no middleman, no withdrawal queues.",
-                accent: "bg-primary",
-                large: true,
-              },
-              {
-                icon: Shield,
-                title: "Fully transparent",
-                desc: "Everything on Stellar's ledger. Every milestone, every reward — verifiable and auditable by anyone.",
-                accent: "bg-success",
-                large: false,
-              },
-              {
-                icon: Trophy,
-                title: "Real incentive",
-                desc: "Financial commitment drives real completion. Skin in the game works — learners finish what they start.",
-                accent: "bg-primary",
-                large: false,
-              },
+              { icon: Users,  title: "For anyone",         desc: "Teach a friend, mentor a team, run a bootcamp. Anyone can create a quest. No gatekeeping, no approval needed.", accent: "bg-primary", large: true },
+              { icon: Zap,    title: "Instant rewards",    desc: "Tokens transfer on-chain the moment you verify. No delays, no middleman, no withdrawal queues.",                 accent: "bg-primary", large: true },
+              { icon: Shield, title: "Fully transparent",  desc: "Everything on Stellar's ledger. Every milestone, every reward — verifiable and auditable by anyone.",            accent: "bg-success", large: false },
+              { icon: Trophy, title: "Real incentive",     desc: "Financial commitment drives real completion. Skin in the game works — learners finish what they start.",         accent: "bg-primary", large: false },
             ].map((feature, i) => (
               <div
                 key={feature.title}
-                className={`card-tilt shimmer-on-hover group reveal-up border-[3px] border-black bg-white shadow-[6px_6px_0_#000] ${featInView ? "in-view" : ""} ${feature.large ? "p-10" : "p-8"}`}
+                className={`border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] bg-card text-card-foreground card-tilt shimmer-on-hover group reveal-up ${featInView ? "in-view" : ""} ${feature.large ? "p-10" : "p-8"}`}
                 style={{ transitionDelay: `${i * 150}ms` }}
               >
                 <div
-                  className={`h-14 w-14 ${feature.accent} mb-6 flex items-center justify-center border-[2px] border-black shadow-[3px_3px_0_#000] transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-[5px_5px_0_#000]`}
+                  className={`w-14 h-14 ${feature.accent} border-2 border-border shadow-[3px_3px_0_var(--color-border)] flex items-center justify-center mb-6 group-hover:shadow-[5px_5px_0_var(--color-border)] group-hover:-translate-y-1 transition-all duration-300`}
                 >
                   <feature.icon className="h-6 w-6" />
                 </div>
-                <h3 className={`mb-3 font-black ${feature.large ? "text-2xl" : "text-lg"}`}>
-                  {feature.title}
-                </h3>
-                <p
-                  className={`text-muted-foreground leading-relaxed ${feature.large ? "text-base" : ""}`}
-                >
-                  {feature.desc}
-                </p>
+                <h3 className={`font-black mb-3 ${feature.large ? "text-2xl" : "text-lg"}`}>{feature.title}</h3>
+                <p className={`text-muted-foreground leading-relaxed ${feature.large ? "text-base" : ""}`}>{feature.desc}</p>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ══════════════════════════════════════════════ */}
-      {/* CTA                                           */}
-      {/* ══════════════════════════════════════════════ */}
-      <section
-        ref={ctaRef}
-        className="bg-primary relative overflow-hidden border-t-[3px] border-black py-24 sm:py-32"
-      >
-        <div className="bg-diagonal-lines pointer-events-none absolute inset-0 opacity-50" />
+      {/* CTA — lives on bg-primary so its internal decoration can stay semi-literal */}
+      <section ref={ctaRef} className="border-t-[3px] border-border bg-primary py-24 sm:py-32 relative overflow-hidden">
+        <div className="absolute inset-0 bg-diagonal-lines pointer-events-none opacity-50" />
+        {/* Decorative blocks inside a yellow section — rgba shadows are fine here */}
+        <div className="absolute top-8 left-[4%] w-24 h-24 bg-background border-[3px] border-border shadow-[5px_5px_0_rgba(0,0,0,0.2)] rotate-12 opacity-20 animate-float" style={{ animationDuration: "7s" }} />
+        <div className="absolute bottom-8 right-[6%] w-20 h-20 bg-foreground border-[3px] border-border/20 -rotate-6 opacity-20 animate-float" style={{ animationDuration: "9s", animationDelay: "2s" }} />
+        <div className="absolute top-[40%] left-[78%] w-14 h-14 bg-success border-[3px] border-border shadow-[4px_4px_0_rgba(0,0,0,0.2)] rotate-45 opacity-[0.18] animate-float" style={{ animationDuration: "6s", animationDelay: "1s" }} />
+        <div className="absolute bottom-[25%] left-[12%] w-12 h-12 bg-background border-[3px] border-border shadow-[3px_3px_0_rgba(0,0,0,0.2)] -rotate-12 opacity-[0.15] animate-float" style={{ animationDuration: "8s", animationDelay: "3s" }} />
+        <div className="absolute top-[20%] right-[20%] w-10 h-10 bg-foreground border-2 border-border/20 rotate-45 opacity-[0.12] animate-float" style={{ animationDuration: "10s", animationDelay: "0.5s" }} />
+        <div className="absolute bottom-[40%] right-[35%] w-8 h-8 bg-background border-2 border-border -rotate-6 opacity-[0.12] animate-float" style={{ animationDuration: "7s", animationDelay: "4s" }} />
+        <div className="absolute top-[65%] left-[40%] w-16 h-16 bg-success/30 border-2 border-border/30 rotate-12 opacity-[0.15] animate-float" style={{ animationDuration: "8s", animationDelay: "1.5s" }} />
 
-        {/* Floating shapes - brutalist variety, bold and visible */}
-        <div
-          className="animate-float absolute top-8 left-[4%] h-24 w-24 rotate-12 border-[3px] border-black bg-white opacity-20 shadow-[5px_5px_0_rgba(0,0,0,0.4)]"
-          style={{ animationDuration: "7s" }}
-        />
-        <div
-          className="animate-float absolute right-[6%] bottom-8 h-20 w-20 -rotate-6 border-[3px] border-white/20 bg-black opacity-20"
-          style={{ animationDuration: "9s", animationDelay: "2s" }}
-        />
-        <div
-          className="bg-success animate-float absolute top-[40%] left-[78%] h-14 w-14 rotate-45 border-[3px] border-black opacity-[0.18] shadow-[4px_4px_0_rgba(0,0,0,0.3)]"
-          style={{ animationDuration: "6s", animationDelay: "1s" }}
-        />
-        <div
-          className="animate-float absolute bottom-[25%] left-[12%] h-12 w-12 -rotate-12 border-[3px] border-black bg-white opacity-[0.15] shadow-[3px_3px_0_rgba(0,0,0,0.3)]"
-          style={{ animationDuration: "8s", animationDelay: "3s" }}
-        />
-        <div
-          className="animate-float absolute top-[20%] right-[20%] h-10 w-10 rotate-45 border-[2px] border-white/20 bg-black opacity-[0.12]"
-          style={{ animationDuration: "10s", animationDelay: "0.5s" }}
-        />
-        <div
-          className="animate-float absolute right-[35%] bottom-[40%] h-8 w-8 -rotate-6 border-[2px] border-black bg-white opacity-[0.12]"
-          style={{ animationDuration: "7s", animationDelay: "4s" }}
-        />
-        <div
-          className="bg-success/30 animate-float absolute top-[65%] left-[40%] h-16 w-16 rotate-12 border-[2px] border-black/30 opacity-[0.15]"
-          style={{ animationDuration: "8s", animationDelay: "1.5s" }}
-        />
-
-        <div
-          className={`reveal-scale relative mx-auto max-w-7xl px-4 text-center sm:px-6 ${ctaInView ? "in-view" : ""}`}
-        >
-          <h2 className="mb-5 text-4xl font-black sm:text-5xl lg:text-6xl">
-            Ready to start earning?
-          </h2>
-          <p className="mx-auto mb-12 max-w-md text-lg opacity-80">
+        <div className={`mx-auto max-w-7xl px-4 sm:px-6 text-center relative reveal-scale ${ctaInView ? "in-view" : ""}`}>
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black mb-5">Ready to start earning?</h2>
+          <p className="text-lg mb-12 max-w-md mx-auto opacity-80">
             Connect your Freighter wallet and create your first quest. It takes two minutes.
           </p>
           <Button
             variant="secondary"
             size="lg"
-            className="shimmer-on-hover group text-base"
+            className="text-base shimmer-on-hover group"
             onClick={() => onNavigate("dashboard")}
           >
             Launch App
@@ -554,52 +439,40 @@ export function Landing({ onNavigate }: LandingProps) {
         </div>
       </section>
 
-      {/* ══════════════════════════════════════════════ */}
-      {/* FOOTER                                        */}
-      {/* ══════════════════════════════════════════════ */}
-      <footer className="border-t-[3px] border-black bg-white">
+      {/* FOOTER */}
+      <footer className="border-t-[3px] border-border bg-background">
         <div className="mx-auto max-w-7xl px-4 sm:px-6">
-          <div className="grid grid-cols-1 gap-10 py-12 sm:grid-cols-3">
+          <div className="py-12 grid grid-cols-1 sm:grid-cols-3 gap-10">
             {/* Brand */}
             <div>
-              <div className="mb-4 flex items-center gap-3">
-                <div className="bg-primary flex h-8 w-8 items-center justify-center overflow-hidden border-[2px] border-black shadow-[2px_2px_0_#000]">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="w-8 h-8 bg-primary border-2 border-border shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center overflow-hidden">
                   <svg viewBox="0 0 512 512" className="h-6 w-6" aria-hidden="true">
-                    <path
-                      d="M 149 117 L 149 382 L 349 382 L 349 317 L 214 317 L 214 117 Z"
-                      fill="#000000"
-                    />
+                    <path d="M 149 117 L 149 382 L 349 382 L 349 317 L 214 317 L 214 117 Z" fill="#000000" />
                   </svg>
                 </div>
-                <span className="text-xl font-black">Lernza</span>
+                <span className="font-black text-xl">Lernza</span>
               </div>
-              <p className="text-muted-foreground max-w-xs text-sm leading-relaxed">
-                The first learn-to-earn platform on Stellar. Create quests, set milestones, reward
-                learners with tokens.
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-xs">
+                The first learn-to-earn platform on Stellar. Create quests, set milestones, reward learners with tokens.
               </p>
             </div>
 
             {/* Links */}
             <div>
-              <h4 className="mb-4 text-sm font-black tracking-wider uppercase">Resources</h4>
+              <h4 className="font-black text-sm uppercase tracking-wider mb-4">Resources</h4>
               <div className="flex flex-col gap-3">
                 {[
                   { label: "Documentation", href: "https://github.com/lernza/lernza" },
-                  {
-                    label: "Contributing",
-                    href: "https://github.com/lernza/lernza/blob/main/CONTRIBUTING.md",
-                  },
-                  {
-                    label: "MIT License",
-                    href: "https://github.com/lernza/lernza/blob/main/LICENSE",
-                  },
-                ].map(link => (
+                  { label: "Contributing", href: "https://github.com/lernza/lernza/blob/main/CONTRIBUTING.md" },
+                  { label: "MIT License", href: "https://github.com/lernza/lernza/blob/main/LICENSE" },
+                ].map((link) => (
                   <a
                     key={link.label}
                     href={link.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-muted-foreground hover:text-foreground animated-underline text-sm font-bold transition-colors"
+                    className="text-sm font-bold text-muted-foreground hover:text-foreground transition-colors animated-underline"
                   >
                     {link.label}
                   </a>
@@ -609,36 +482,36 @@ export function Landing({ onNavigate }: LandingProps) {
 
             {/* Socials */}
             <div>
-              <h4 className="mb-4 text-sm font-black tracking-wider uppercase">Community</h4>
+              <h4 className="font-black text-sm uppercase tracking-wider mb-4">Community</h4>
               <div className="flex gap-3">
                 {[
                   { href: "https://github.com/lernza", label: "GitHub", Icon: GithubIcon },
                   { href: "https://x.com/lernza", label: "X", Icon: XIcon },
                   { href: "https://discord.gg/lernza", label: "Discord", Icon: DiscordIcon },
-                ].map(social => (
+                ].map((social) => (
                   <a
                     key={social.label}
                     href={social.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="neo-press hover:bg-primary flex h-10 w-10 items-center justify-center border-[2px] border-black bg-white shadow-[3px_3px_0_#000] transition-colors hover:shadow-[4px_4px_0_#000] active:shadow-[1px_1px_0_#000]"
+                    className="w-10 h-10 bg-card border-2 border-border shadow-[3px_3px_0_var(--color-border)] flex items-center justify-center neo-press hover:shadow-[4px_4px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] hover:bg-primary transition-colors"
                     aria-label={social.label}
                   >
                     <social.Icon className="h-4 w-4" />
                   </a>
                 ))}
               </div>
-              <p className="text-muted-foreground mt-4 text-xs">
+              <p className="text-xs text-muted-foreground mt-4">
                 Join the community and help build the future of learn-to-earn.
               </p>
             </div>
           </div>
 
-          <div className="flex flex-col items-center justify-between gap-3 border-t-[2px] border-black py-5 sm:flex-row">
-            <p className="text-muted-foreground text-xs font-bold">
+          <div className="border-t-2 border-border py-5 flex flex-col sm:flex-row items-center justify-between gap-3">
+            <p className="text-xs font-bold text-muted-foreground">
               Built on Stellar &middot; Open source &middot; MIT License
             </p>
-            <p className="text-muted-foreground text-xs">
+            <p className="text-xs text-muted-foreground">
               &copy; {new Date().getFullYear()} Lernza
             </p>
           </div>

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -37,60 +37,62 @@ export function NotFound({ onNavigate }: NotFoundProps) {
   const [hovered, setHovered] = useState(false)
 
   return (
-    <div className="relative flex min-h-[calc(100vh-67px)] items-center justify-center overflow-hidden">
+    <div className="min-h-[calc(100vh-67px)] flex items-center justify-center relative overflow-hidden">
       {/* Animated background grid */}
-      <div className="bg-grid-dots pointer-events-none absolute inset-0" />
+      <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
 
       {/* Floating background shapes */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="absolute inset-0 pointer-events-none overflow-hidden">
         <div
-          className="bg-primary animate-float absolute top-[8%] left-[5%] h-28 w-28 rotate-12 border-[3px] border-black opacity-[0.08] shadow-[5px_5px_0_#000]"
+          className="absolute top-[8%] left-[5%] w-28 h-28 bg-primary border-[3px] border-border shadow-[5px_5px_0_var(--color-border)] rotate-12 opacity-[0.08] animate-float"
           style={{ animationDuration: "7s" }}
         />
         <div
-          className="bg-destructive animate-float absolute top-[15%] right-[8%] h-20 w-20 -rotate-6 border-[3px] border-black opacity-[0.07] shadow-[4px_4px_0_#000]"
+          className="absolute top-[15%] right-[8%] w-20 h-20 bg-destructive border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] -rotate-6 opacity-[0.07] animate-float"
           style={{ animationDuration: "9s", animationDelay: "1s" }}
         />
         <div
-          className="bg-primary animate-float absolute bottom-[12%] left-[10%] h-16 w-16 rotate-45 border-[2px] border-black opacity-[0.06] shadow-[3px_3px_0_#000]"
+          className="absolute bottom-[12%] left-[10%] w-16 h-16 bg-primary border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] rotate-45 opacity-[0.06] animate-float"
           style={{ animationDuration: "8s", animationDelay: "2s" }}
         />
         <div
-          className="bg-primary animate-float absolute right-[6%] bottom-[20%] h-24 w-24 -rotate-12 border-[3px] border-black opacity-[0.07] shadow-[4px_4px_0_#000]"
+          className="absolute bottom-[20%] right-[6%] w-24 h-24 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] -rotate-12 opacity-[0.07] animate-float"
           style={{ animationDuration: "6s", animationDelay: "0.5s" }}
         />
         <div
-          className="bg-success animate-float absolute top-[50%] left-[50%] h-10 w-10 rotate-6 border-[2px] border-black opacity-[0.08] shadow-[3px_3px_0_#000]"
+          className="absolute top-[50%] left-[50%] w-10 h-10 bg-success border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] rotate-6 opacity-[0.08] animate-float"
           style={{ animationDuration: "10s", animationDelay: "3s" }}
         />
         <div
-          className="bg-success animate-float absolute top-[30%] left-[25%] h-8 w-8 -rotate-45 border-[2px] border-black opacity-[0.06] shadow-[2px_2px_0_#000]"
+          className="absolute top-[30%] left-[25%] w-8 h-8 bg-success border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] -rotate-45 opacity-[0.06] animate-float"
           style={{ animationDuration: "11s", animationDelay: "1.5s" }}
         />
         {/* Spinning decorative element */}
-        <div className="animate-spin-slow absolute top-[65%] right-[15%] h-14 w-14 border-[3px] border-black opacity-[0.04]" />
+        <div
+          className="absolute top-[65%] right-[15%] w-14 h-14 border-[3px] border-border opacity-[0.04] animate-spin-slow"
+        />
       </div>
 
-      <div className="relative flex flex-col items-center px-4 text-center">
+      <div className="relative flex flex-col items-center text-center px-4">
         {/* Giant 404 with glitch + stacked neo-brutalist layers */}
         <div
-          className="animate-scale-in relative mb-6"
+          className="relative mb-6 animate-scale-in"
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
           {/* Shadow layers */}
-          <div className="absolute inset-0 translate-x-3 translate-y-3 text-[180px] leading-none font-black text-black opacity-100 sm:text-[240px] lg:text-[300px]">
+          <div className="absolute inset-0 text-[180px] sm:text-[240px] lg:text-[300px] font-black leading-none text-foreground translate-x-3 translate-y-3 opacity-100">
             404
           </div>
           <div
-            className={`text-primary absolute inset-0 translate-x-1.5 translate-y-1.5 text-[180px] leading-none font-black transition-transform duration-300 sm:text-[240px] lg:text-[300px] ${
+            className={`absolute inset-0 text-[180px] sm:text-[240px] lg:text-[300px] font-black leading-none text-primary translate-x-1.5 translate-y-1.5 transition-transform duration-300 ${
               hovered ? "translate-x-2.5 translate-y-2.5" : ""
             }`}
           >
             404
           </div>
           <div
-            className="relative text-[180px] leading-none font-black text-white sm:text-[240px] lg:text-[300px]"
+            className="relative text-[180px] sm:text-[240px] lg:text-[300px] font-black leading-none text-white"
             style={{ WebkitTextStroke: "4px black" }}
           >
             <GlitchText text="404" />
@@ -98,22 +100,31 @@ export function NotFound({ onNavigate }: NotFoundProps) {
         </div>
 
         {/* Message card */}
-        <div className="animate-fade-in-up stagger-1 shimmer-on-hover max-w-md border-[3px] border-black bg-white px-8 py-6 shadow-[6px_6px_0_#000]">
-          <div className="mb-3 flex items-center justify-center gap-2">
-            <Sparkles className="text-primary h-5 w-5" />
-            <h2 className="text-2xl font-black sm:text-3xl">Lost in the chain</h2>
-            <Sparkles className="text-primary h-5 w-5" />
+        <div className="bg-background border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] px-8 py-6 max-w-md animate-fade-in-up stagger-1 shimmer-on-hover">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <Sparkles className="h-5 w-5 text-primary" />
+            <h2 className="text-2xl sm:text-3xl font-black">
+              Lost in the chain
+            </h2>
+            <Sparkles className="h-5 w-5 text-primary" />
           </div>
           <p className="text-muted-foreground mb-6 leading-relaxed">
-            This page doesn't exist on any ledger. It might have been moved, deleted, or never
-            deployed.
+            This page doesn't exist on any ledger. It might have been moved,
+            deleted, or never deployed.
           </p>
-          <div className="flex flex-col justify-center gap-3 sm:flex-row">
-            <Button onClick={() => onNavigate("landing")} className="shimmer-on-hover group">
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button
+              onClick={() => onNavigate("landing")}
+              className="shimmer-on-hover group"
+            >
               <Home className="h-4 w-4" />
               Back to Home
             </Button>
-            <Button variant="secondary" onClick={() => window.history.back()} className="group">
+            <Button
+              variant="secondary"
+              onClick={() => window.history.back()}
+              className="group"
+            >
               <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
               Go Back
             </Button>
@@ -121,8 +132,8 @@ export function NotFound({ onNavigate }: NotFoundProps) {
         </div>
 
         {/* Decorative accent blocks */}
-        <div className="bg-primary animate-fade-in-up stagger-2 absolute top-1/2 -left-6 hidden h-8 w-8 rotate-12 border-[2px] border-black shadow-[3px_3px_0_#000] sm:-left-12 sm:block sm:h-12 sm:w-12" />
-        <div className="bg-success animate-fade-in-up stagger-3 absolute top-1/2 -right-6 hidden h-6 w-6 -translate-y-8 -rotate-6 border-[2px] border-black shadow-[3px_3px_0_#000] sm:-right-12 sm:block sm:h-10 sm:w-10" />
+        <div className="absolute -left-6 sm:-left-12 top-1/2 w-8 h-8 sm:w-12 sm:h-12 bg-primary border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] rotate-12 animate-fade-in-up stagger-2 hidden sm:block" />
+        <div className="absolute -right-6 sm:-right-12 top-1/2 -translate-y-8 w-6 h-6 sm:w-10 sm:h-10 bg-success border-[2px] border-border shadow-[3px_3px_0_var(--color-border)] -rotate-6 animate-fade-in-up stagger-3 hidden sm:block" />
       </div>
     </div>
   )

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -10,7 +10,6 @@ import { formatTokens } from "@/lib/utils"
 /* ─── Generated Avatar from wallet address ─── */
 
 function WalletAvatar({ address }: { address: string }) {
-  // Generate a grid of colored blocks from the address
   const colors = ["#FACC15", "#22C55E", "#000000", "#F5F5F4", "#FFFFFF"]
   const cells = Array.from({ length: 16 }, (_, i) => {
     const charCode = address.charCodeAt(i % address.length) || 0
@@ -18,7 +17,7 @@ function WalletAvatar({ address }: { address: string }) {
   })
 
   return (
-    <div className="grid h-20 w-20 flex-shrink-0 grid-cols-4 overflow-hidden border-[3px] border-black shadow-[4px_4px_0_#000]">
+    <div className="w-20 h-20 border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] grid grid-cols-4 overflow-hidden shrink-0">
       {cells.map((color, i) => (
         <div key={i} style={{ backgroundColor: color }} />
       ))}
@@ -41,64 +40,49 @@ export function Profile() {
 
   if (!connected) {
     return (
-      <div className="relative flex min-h-[calc(100vh-67px)] items-center justify-center overflow-hidden">
-        {/* Background elements */}
-        <div className="bg-grid-dots pointer-events-none absolute inset-0" />
-        <div
-          className="bg-primary animate-float absolute top-[12%] right-[7%] h-20 w-20 rotate-12 border-[3px] border-black opacity-[0.08] shadow-[4px_4px_0_#000]"
-          style={{ animationDuration: "8s" }}
-        />
-        <div
-          className="bg-success animate-float absolute bottom-[18%] left-[5%] h-14 w-14 -rotate-6 border-[2px] border-black opacity-[0.07] shadow-[3px_3px_0_#000]"
-          style={{ animationDuration: "6s", animationDelay: "1s" }}
-        />
-        <div
-          className="bg-primary animate-float absolute top-[55%] right-[4%] h-10 w-10 rotate-45 border-[2px] border-black opacity-[0.06] shadow-[2px_2px_0_#000]"
-          style={{ animationDuration: "7s", animationDelay: "2s" }}
-        />
+      <div className="min-h-[calc(100vh-67px)] flex items-center justify-center relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid-dots pointer-events-none" />
+        <div className="absolute top-[12%] right-[7%] w-20 h-20 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] rotate-12 opacity-[0.08] animate-float" style={{ animationDuration: "8s" }} />
+        <div className="absolute bottom-[18%] left-[5%] w-14 h-14 bg-success border-2 border-border shadow-[3px_3px_0_var(--color-border)] -rotate-6 opacity-[0.07] animate-float" style={{ animationDuration: "6s", animationDelay: "1s" }} />
+        <div className="absolute top-[55%] right-[4%] w-10 h-10 bg-primary border-2 border-border shadow-[2px_2px_0_var(--color-border)] rotate-45 opacity-[0.06] animate-float" style={{ animationDuration: "7s", animationDelay: "2s" }} />
 
-        <div className="relative mx-auto max-w-lg px-4">
-          <div className="animate-scale-in overflow-hidden border-[3px] border-black bg-white shadow-[8px_8px_0_#000]">
-            <div className="bg-primary flex items-center justify-between border-b-[3px] border-black px-6 py-3">
-              <span className="text-xs font-black tracking-wider uppercase">Profile</span>
+        <div className="relative px-4 max-w-lg mx-auto">
+          <div className="bg-card text-card-foreground border-[3px] border-border shadow-[8px_8px_0_var(--color-border)] overflow-hidden animate-scale-in">
+            <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
+              <span className="text-xs font-black uppercase tracking-wider">Profile</span>
               <div className="flex items-center gap-1.5">
-                <div className="bg-destructive h-2.5 w-2.5 border border-black" />
+                <div className="w-2.5 h-2.5 bg-destructive border border-border" />
                 <span className="text-xs font-bold">Not Connected</span>
               </div>
             </div>
 
-            <div className="p-8 text-center sm:p-10">
-              <div className="bg-primary animate-fade-in-up mx-auto mb-6 flex h-20 w-20 items-center justify-center border-[3px] border-black shadow-[4px_4px_0_#000]">
+            <div className="p-8 sm:p-10 text-center">
+              <div className="w-20 h-20 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-6 mx-auto animate-fade-in-up">
                 <Wallet className="h-8 w-8" />
               </div>
-              <h2 className="animate-fade-in-up stagger-1 mb-3 text-2xl font-black sm:text-3xl">
+              <h2 className="text-2xl sm:text-3xl font-black mb-3 animate-fade-in-up stagger-1">
                 Connect your wallet
               </h2>
-              <p className="text-muted-foreground animate-fade-in-up stagger-2 mx-auto mb-8 max-w-sm">
-                Connect your Freighter wallet to view your profile, track earnings, and see your
-                quest history.
+              <p className="text-muted-foreground mb-8 max-w-sm mx-auto animate-fade-in-up stagger-2">
+                Connect your Freighter wallet to view your profile, track earnings, and see your quest history.
               </p>
-              <Button
-                size="lg"
-                onClick={connect}
-                className="shimmer-on-hover animate-fade-in-up stagger-3"
-              >
+              <Button size="lg" onClick={connect} className="shimmer-on-hover animate-fade-in-up stagger-3">
                 <Wallet className="h-4 w-4" />
                 Connect Wallet
               </Button>
 
-              <div className="animate-fade-in-up stagger-4 mt-8 border-t-[2px] border-black pt-6">
+              <div className="mt-8 pt-6 border-t-2 border-border animate-fade-in-up stagger-4">
                 <div className="flex flex-wrap justify-center gap-4">
                   {[
                     { icon: Trophy, text: "View achievements" },
                     { icon: Coins, text: "Track earnings" },
                     { icon: TrendingUp, text: "See progress" },
-                  ].map(item => (
+                  ].map((item) => (
                     <div key={item.text} className="flex items-center gap-2">
-                      <div className="bg-secondary flex h-6 w-6 items-center justify-center border-[1.5px] border-black">
+                      <div className="w-6 h-6 bg-secondary border-[1.5px] border-border flex items-center justify-center">
                         <item.icon className="h-3 w-3" />
                       </div>
-                      <span className="text-muted-foreground text-xs font-bold">{item.text}</span>
+                      <span className="text-xs font-bold text-muted-foreground">{item.text}</span>
                     </div>
                   ))}
                 </div>
@@ -106,70 +90,41 @@ export function Profile() {
             </div>
           </div>
 
-          <div className="bg-primary animate-fade-in-up stagger-5 absolute -top-4 -right-4 hidden h-10 w-10 rotate-12 border-[2px] border-black shadow-[3px_3px_0_#000] sm:block" />
-          <div className="bg-success animate-fade-in-up stagger-6 absolute -bottom-3 -left-3 hidden h-8 w-8 -rotate-6 border-[2px] border-black shadow-[2px_2px_0_#000] sm:block" />
+          <div className="absolute -top-4 -right-4 w-10 h-10 bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] rotate-12 animate-fade-in-up stagger-5 hidden sm:block" />
+          <div className="absolute -bottom-3 -left-3 w-8 h-8 bg-success border-2 border-border shadow-[2px_2px_0_var(--color-border)] -rotate-6 animate-fade-in-up stagger-6 hidden sm:block" />
         </div>
       </div>
     )
   }
 
   const earnings = [
-    {
-      milestone: "Hello World",
-      workspace: "Learn to Code with Alex",
-      amount: 50,
-      date: "2 days ago",
-    },
-    {
-      milestone: "Build a CLI Tool",
-      workspace: "Learn to Code with Alex",
-      amount: 100,
-      date: "5 days ago",
-    },
-    {
-      milestone: "Set up Stellar CLI",
-      workspace: "Stellar Dev Bootcamp",
-      amount: 100,
-      date: "1 week ago",
-    },
-    {
-      milestone: "First Soroban Contract",
-      workspace: "Stellar Dev Bootcamp",
-      amount: 200,
-      date: "2 weeks ago",
-    },
+    { milestone: "Hello World", workspace: "Learn to Code with Alex", amount: 50, date: "2 days ago" },
+    { milestone: "Build a CLI Tool", workspace: "Learn to Code with Alex", amount: 100, date: "5 days ago" },
+    { milestone: "Set up Stellar CLI", workspace: "Stellar Dev Bootcamp", amount: 100, date: "1 week ago" },
+    { milestone: "First Soroban Contract", workspace: "Stellar Dev Bootcamp", amount: 200, date: "2 weeks ago" },
   ]
 
   return (
-    <div className="relative mx-auto max-w-6xl px-4 py-8 sm:px-6">
-      {/* Background */}
-      <div className="bg-grid-dots pointer-events-none absolute inset-0 opacity-30" />
+    <div className="relative mx-auto max-w-6xl px-4 sm:px-6 py-8">
+      <div className="absolute inset-0 bg-grid-dots pointer-events-none opacity-30" />
 
-      {/* Profile header with accent banner */}
-      <div className="animate-fade-in-up relative mb-8">
-        {/* Yellow banner background */}
-        <div className="bg-primary overflow-hidden border-[3px] border-black shadow-[6px_6px_0_#000]">
-          <div className="bg-diagonal-lines pointer-events-none absolute inset-0 opacity-20" />
+      {/* Profile header */}
+      <div className="relative mb-8 animate-fade-in-up">
+        <div className="bg-primary border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] overflow-hidden">
+          <div className="absolute inset-0 bg-diagonal-lines opacity-20 pointer-events-none" />
 
-          {/* Banner top section */}
-          <div className="relative h-20 sm:h-28">
-            {/* Floating shapes in banner */}
-            <div
-              className="animate-float absolute top-3 right-6 h-10 w-10 rotate-12 border-[2px] border-black/10 bg-black/5"
-              style={{ animationDuration: "7s" }}
-            />
-            <div
-              className="animate-float absolute right-24 bottom-2 h-6 w-6 -rotate-6 border-[2px] border-black/10 bg-black/5"
-              style={{ animationDuration: "5s", animationDelay: "1s" }}
-            />
+          {/* Banner */}
+          <div className="h-20 sm:h-28 relative">
+            <div className="absolute top-3 right-6 w-10 h-10 bg-foreground/5 border-2 border-foreground/10 rotate-12 animate-float" style={{ animationDuration: "7s" }} />
+            <div className="absolute bottom-2 right-24 w-6 h-6 bg-foreground/5 border-2 border-foreground/10 -rotate-6 animate-float" style={{ animationDuration: "5s", animationDelay: "1s" }} />
           </div>
 
-          {/* Profile info - overlaps the banner */}
-          <div className="relative border-t-[3px] border-black bg-white px-6 py-5">
-            <div className="-mt-14 flex flex-col items-start gap-6 sm:-mt-16 sm:flex-row sm:items-center">
+          {/* Profile info */}
+          <div className="bg-card text-card-foreground border-t-[3px] border-border px-6 py-5 relative">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6 -mt-14 sm:-mt-16">
               <WalletAvatar address={address || ""} />
 
-              <div className="mt-2 min-w-0 flex-1 sm:mt-6">
+              <div className="flex-1 min-w-0 mt-2 sm:mt-6">
                 <div className="flex items-center gap-3">
                   <h2 className="text-xl font-black">Learner</h2>
                   <Badge variant="success" className="gap-1">
@@ -177,16 +132,16 @@ export function Profile() {
                     Active
                   </Badge>
                 </div>
-                <div className="mt-1 flex items-center gap-2">
-                  <p className="text-muted-foreground max-w-[200px] truncate font-mono text-sm font-bold sm:max-w-xs">
+                <div className="flex items-center gap-2 mt-1">
+                  <p className="font-mono text-sm text-muted-foreground font-bold truncate max-w-50 sm:max-w-xs">
                     {address}
                   </p>
                   <button
                     onClick={handleCopy}
-                    className="neo-press hover:bg-secondary flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center border-[2px] border-black bg-white shadow-[2px_2px_0_#000]"
+                    className="w-7 h-7 border-2 border-border bg-card shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center neo-press hover:bg-secondary shrink-0 cursor-pointer"
                   >
                     {copied ? (
-                      <Check className="text-success h-3 w-3" />
+                      <Check className="h-3 w-3 text-success" />
                     ) : (
                       <Copy className="h-3 w-3" />
                     )}
@@ -195,7 +150,7 @@ export function Profile() {
               </div>
 
               <div className="sm:mt-6">
-                <div className="bg-primary border-[2px] border-black px-5 py-3 shadow-[3px_3px_0_#000]">
+                <div className="bg-primary border-2 border-border shadow-[3px_3px_0_var(--color-border)] px-5 py-3">
                   <div className="flex items-center gap-2">
                     <TrendingUp className="h-4 w-4" />
                     <p className="text-2xl font-black tabular-nums">
@@ -212,9 +167,9 @@ export function Profile() {
 
       {/* Earnings history */}
       <div>
-        <div className="mb-5 flex items-center justify-between">
+        <div className="flex items-center justify-between mb-5">
           <h2 className="text-xl font-black">Earnings History</h2>
-          <span className="text-muted-foreground text-sm font-bold">
+          <span className="text-sm font-bold text-muted-foreground">
             {earnings.length} transactions
           </span>
         </div>
@@ -223,11 +178,11 @@ export function Profile() {
           {earnings.length === 0 ? (
             <Card className="animate-fade-in-up">
               <CardContent className="flex flex-col items-center py-12 text-center">
-                <div className="bg-primary mb-4 flex h-14 w-14 items-center justify-center border-[3px] border-black shadow-[4px_4px_0_#000]">
+                <div className="w-14 h-14 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-4">
                   <Coins className="h-6 w-6" />
                 </div>
-                <h3 className="mb-2 font-black">No earnings yet</h3>
-                <p className="text-muted-foreground text-sm">
+                <h3 className="font-black mb-2">No earnings yet</h3>
+                <p className="text-sm text-muted-foreground">
                   Complete milestones to start earning USDC.
                 </p>
               </CardContent>
@@ -235,24 +190,23 @@ export function Profile() {
           ) : (
             earnings.map((e, i) => (
               <div key={i} className={`animate-fade-in-up stagger-${i + 1}`}>
-                <Card className="neo-lift group hover:shadow-[7px_7px_0_#000] active:shadow-[2px_2px_0_#000]">
+                <Card className="neo-lift hover:shadow-[7px_7px_0_var(--color-border)] active:shadow-[2px_2px_0_var(--color-border)] group">
                   <CardContent className="p-5">
                     <div className="flex items-center justify-between gap-4">
                       <div className="flex items-center gap-4">
-                        {/* Earning amount circle */}
-                        <div className="bg-success/10 group-hover:bg-success/20 flex h-12 w-12 flex-shrink-0 items-center justify-center border-[2px] border-black shadow-[2px_2px_0_#000] transition-colors">
-                          <Coins className="h-5 w-5 text-green-700" />
+                        <div className="w-12 h-12 bg-success/10 border-2 border-border shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center shrink-0 group-hover:bg-success/20 transition-colors">
+                          <Coins className="h-5 w-5 text-success" />
                         </div>
                         <div>
-                          <p className="text-sm font-black">{e.milestone}</p>
-                          <p className="text-muted-foreground text-xs font-bold">{e.workspace}</p>
+                          <p className="font-black text-sm">{e.milestone}</p>
+                          <p className="text-xs font-bold text-muted-foreground">{e.workspace}</p>
                         </div>
                       </div>
-                      <div className="flex flex-col items-end gap-1 text-right">
+                      <div className="text-right flex flex-col items-end gap-1">
                         <Badge variant="success" className="tabular-nums">
                           +{e.amount} USDC
                         </Badge>
-                        <p className="text-muted-foreground text-xs font-bold">{e.date}</p>
+                        <p className="text-xs font-bold text-muted-foreground">{e.date}</p>
                       </div>
                     </div>
                   </CardContent>

--- a/frontend/src/pages/workspace.tsx
+++ b/frontend/src/pages/workspace.tsx
@@ -17,7 +17,12 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { useInView, useCountUp } from "@/hooks/use-animations"
-import { MOCK_WORKSPACES, MOCK_MILESTONES, MOCK_ENROLLEES, MOCK_COMPLETIONS } from "@/lib/mock-data"
+import {
+  MOCK_WORKSPACES,
+  MOCK_MILESTONES,
+  MOCK_ENROLLEES,
+  MOCK_COMPLETIONS,
+} from "@/lib/mock-data"
 import { formatTokens } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast"
 import { ToastContainer } from "@/components/toast"
@@ -32,9 +37,11 @@ type Tab = "milestones" | "enrollees"
 
 export function WorkspaceView({ workspaceId, onBack }: WorkspaceViewProps) {
   const [activeTab, setActiveTab] = useState<Tab>("milestones")
-  const [expandedMilestone, setExpandedMilestone] = useState<number | null>(null)
+  const [expandedMilestone, setExpandedMilestone] = useState<number | null>(
+    null
+  )
 
-  const ws = MOCK_WORKSPACES.find(w => w.id === workspaceId)
+  const ws = MOCK_WORKSPACES.find((w) => w.id === workspaceId)
   const milestones = MOCK_MILESTONES[workspaceId] || []
   const enrollees = MOCK_ENROLLEES[workspaceId] || []
   const completions = MOCK_COMPLETIONS[workspaceId] || []
@@ -43,11 +50,15 @@ const { toasts, addToast, removeToast } = useToast()
   const [contentRef, contentInView] = useInView()
 
   const totalReward = milestones.reduce((sum, m) => sum + m.rewardAmount, 0)
-  const completedMilestones = new Set(completions.filter(c => c.completed).map(c => c.milestoneId))
-    .size
-  const isComplete = completedMilestones === milestones.length && milestones.length > 0
+  const completedMilestones = new Set(
+    completions.filter((c) => c.completed).map((c) => c.milestoneId)
+  ).size
+  const isComplete =
+    completedMilestones === milestones.length && milestones.length > 0
   const earnedReward = milestones
-    .filter(m => completions.some(c => c.milestoneId === m.id && c.completed))
+    .filter((m) =>
+      completions.some((c) => c.milestoneId === m.id && c.completed)
+    )
     .reduce((sum, m) => sum + m.rewardAmount, 0)
 
   const enrolleesCount = useCountUp(enrollees.length, 400, statsInView)
@@ -57,8 +68,8 @@ const { toasts, addToast, removeToast } = useToast()
 
   if (!ws) {
     return (
-      <div className="mx-auto max-w-6xl px-4 py-20 text-center sm:px-6">
-        <h2 className="mb-4 text-2xl font-black">Quest not found</h2>
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-20 text-center">
+        <h2 className="text-2xl font-black mb-4">Quest not found</h2>
         <Button variant="outline" onClick={onBack}>
           Go back
         </Button>
@@ -67,27 +78,29 @@ const { toasts, addToast, removeToast } = useToast()
   }
 
   return (
-    <div className="relative mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="relative mx-auto max-w-6xl px-4 sm:px-6 py-8">
       {/* Background */}
-      <div className="bg-grid-dots pointer-events-none absolute inset-0 opacity-30" />
+      <div className="absolute inset-0 bg-grid-dots pointer-events-none opacity-30" />
 
       {/* Back button */}
       <button
         onClick={onBack}
-        className="text-muted-foreground hover:text-foreground group mb-6 flex cursor-pointer items-center gap-2 text-sm font-bold transition-colors"
+        className="flex items-center gap-2 text-sm font-bold text-muted-foreground hover:text-foreground mb-6 transition-colors cursor-pointer group"
       >
-        <div className="neo-press group-hover:bg-primary flex h-7 w-7 items-center justify-center border-[2px] border-black bg-white shadow-[2px_2px_0_#000] transition-colors hover:shadow-[3px_3px_0_#000] active:shadow-[1px_1px_0_#000]">
+        <div className="w-7 h-7 border-[2px] border-border bg-background shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center neo-press hover:shadow-[3px_3px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] group-hover:bg-primary transition-colors">
           <ArrowLeft className="h-3.5 w-3.5" />
         </div>
         Back to Dashboard
       </button>
 
       {/* Quest header card */}
-      <div className="animate-fade-in-up relative mb-8 overflow-hidden border-[3px] border-black bg-white shadow-[6px_6px_0_#000]">
+      <div className="relative bg-background border-[3px] border-border shadow-[6px_6px_0_var(--color-border)] overflow-hidden mb-8 animate-fade-in-up">
         {/* Header bar */}
-        <div className="bg-primary flex items-center justify-between border-b-[3px] border-black px-6 py-3">
+        <div className="bg-primary border-b-[3px] border-border px-6 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <span className="text-xs font-black tracking-wider uppercase">Quest Details</span>
+            <span className="text-xs font-black uppercase tracking-wider">
+              Quest Details
+            </span>
             {isComplete && (
               <Badge variant="success" className="gap-1">
                 <Sparkles className="h-3 w-3" />
@@ -96,19 +109,21 @@ const { toasts, addToast, removeToast } = useToast()
             )}
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="bg-success h-2.5 w-2.5 border border-black" />
+            <div className="w-2.5 h-2.5 bg-success border border-border" />
             <span className="text-xs font-bold">Live</span>
           </div>
         </div>
 
-        <div className="relative p-6">
-          <div className="bg-diagonal-lines pointer-events-none absolute inset-0 opacity-20" />
-          <div className="relative flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="p-6 relative">
+          <div className="absolute inset-0 bg-diagonal-lines pointer-events-none opacity-20" />
+          <div className="relative flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-black sm:text-3xl">{ws.name}</h1>
-              <p className="text-muted-foreground mt-1 max-w-xl text-sm">{ws.description}</p>
+              <h1 className="text-2xl sm:text-3xl font-black">{ws.name}</h1>
+              <p className="text-muted-foreground text-sm mt-1 max-w-xl">
+                {ws.description}
+              </p>
             </div>
-            <div className="flex flex-shrink-0 gap-3">
+            <div className="flex gap-3 flex-shrink-0">
               <Button variant="outline" size="sm" className="shimmer-on-hover">
                 <UserPlus className="h-4 w-4" />
                 Add Enrollee
@@ -128,7 +143,7 @@ const { toasts, addToast, removeToast } = useToast()
       </div>
 
       {/* Stats row */}
-      <div ref={statsRef} className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+      <div ref={statsRef} className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
         {[
           {
             icon: Users,
@@ -160,16 +175,20 @@ const { toasts, addToast, removeToast } = useToast()
             className={`reveal-up ${statsInView ? "in-view" : ""}`}
             style={{ transitionDelay: `${i * 100}ms` }}
           >
-            <Card className="neo-lift hover:shadow-[7px_7px_0_#000] active:shadow-[2px_2px_0_#000]">
-              <CardContent className="flex items-center gap-3 p-4">
+            <Card className="neo-lift hover:shadow-[7px_7px_0_var(--color-border)] active:shadow-[2px_2px_0_var(--color-border)]">
+              <CardContent className="p-4 flex items-center gap-3">
                 <div
-                  className={`h-10 w-10 ${stat.bg} flex flex-shrink-0 items-center justify-center border-[2px] border-black shadow-[2px_2px_0_#000]`}
+                  className={`w-10 h-10 ${stat.bg} border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center flex-shrink-0`}
                 >
                   <stat.icon className="h-4 w-4" />
                 </div>
                 <div>
-                  <p className="text-muted-foreground text-xs font-bold">{stat.label}</p>
-                  <p className="text-lg font-black tabular-nums">{stat.value}</p>
+                  <p className="text-xs font-bold text-muted-foreground">
+                    {stat.label}
+                  </p>
+                  <p className="text-lg font-black tabular-nums">
+                    {stat.value}
+                  </p>
                 </div>
               </CardContent>
             </Card>
@@ -179,9 +198,9 @@ const { toasts, addToast, removeToast } = useToast()
 
       {/* Progress section */}
       {milestones.length > 0 && (
-        <div className="animate-fade-in-up stagger-3 mb-8">
-          <div className="border-[3px] border-black bg-white p-5 shadow-[4px_4px_0_#000]">
-            <div className="mb-3 flex items-center justify-between">
+        <div className="mb-8 animate-fade-in-up stagger-3">
+          <div className="bg-background border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] p-5">
+            <div className="flex items-center justify-between mb-3">
               <span className="text-sm font-black">Overall Progress</span>
               <div className="flex items-center gap-3">
                 {earnedReward > 0 && (
@@ -200,15 +219,15 @@ const { toasts, addToast, removeToast } = useToast()
       )}
 
       {/* Tabs */}
-      <div className="mb-6 flex gap-0 border-b-[3px] border-black" ref={contentRef}>
-        {(["milestones", "enrollees"] as Tab[]).map(tab => (
+      <div className="flex gap-0 border-b-[3px] border-border mb-6" ref={contentRef}>
+        {(["milestones", "enrollees"] as Tab[]).map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
-            className={`-mb-[3px] cursor-pointer border-[3px] border-b-0 px-6 py-3 text-sm font-black tracking-wider capitalize uppercase transition-all ${
+            className={`px-6 py-3 text-sm font-black uppercase tracking-wider border-[3px] border-b-0 transition-all capitalize cursor-pointer -mb-[3px] ${
               activeTab === tab
-                ? "bg-primary border-black shadow-[2px_-2px_0_#000]"
-                : "hover:bg-secondary border-transparent"
+                ? "border-border bg-primary shadow-[2px_-2px_0_var(--color-border)]"
+                : "border-transparent hover:bg-secondary"
             }`}
           >
             {tab}
@@ -225,11 +244,11 @@ const { toasts, addToast, removeToast } = useToast()
           {milestones.length === 0 ? (
             <Card className="animate-fade-in-up">
               <CardContent className="flex flex-col items-center py-12 text-center">
-                <div className="bg-primary mb-4 flex h-14 w-14 items-center justify-center border-[3px] border-black shadow-[4px_4px_0_#000]">
+                <div className="w-14 h-14 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-4">
                   <Target className="h-6 w-6" />
                 </div>
-                <h3 className="mb-2 font-black">No milestones yet</h3>
-                <p className="text-muted-foreground mb-4 text-sm">
+                <h3 className="font-black mb-2">No milestones yet</h3>
+                <p className="text-sm text-muted-foreground mb-4">
                   Add milestones to define learning goals.
                 </p>
                 <Button size="sm" className="shimmer-on-hover">
@@ -240,10 +259,12 @@ const { toasts, addToast, removeToast } = useToast()
             </Card>
           ) : (
             milestones.map((ms, i) => {
-              const isCompleted = completions.some(c => c.milestoneId === ms.id && c.completed)
+              const isCompleted = completions.some(
+                (c) => c.milestoneId === ms.id && c.completed
+              )
               const completedBy = completions
-                .filter(c => c.milestoneId === ms.id && c.completed)
-                .map(c => c.enrollee)
+                .filter((c) => c.milestoneId === ms.id && c.completed)
+                .map((c) => c.enrollee)
               const isExpanded = expandedMilestone === ms.id
 
               return (
@@ -253,57 +274,63 @@ const { toasts, addToast, removeToast } = useToast()
                   style={{ transitionDelay: `${i * 100}ms` }}
                 >
                   <Card
-                    className={`neo-lift group cursor-pointer transition-all hover:shadow-[7px_7px_0_#000] active:shadow-[2px_2px_0_#000] ${
+                    className={`neo-lift hover:shadow-[7px_7px_0_var(--color-border)] active:shadow-[2px_2px_0_var(--color-border)] cursor-pointer group transition-all ${
                       isCompleted ? "border-success" : ""
                     }`}
-                    onClick={() => setExpandedMilestone(isExpanded ? null : ms.id)}
+                    onClick={() =>
+                      setExpandedMilestone(isExpanded ? null : ms.id)
+                    }
                   >
                     <CardContent className="p-5">
                       <div className="flex items-start gap-4">
                         <div
-                          className={`mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center border-[2px] border-black shadow-[2px_2px_0_#000] transition-all duration-300 ${
-                            isCompleted ? "bg-success" : "group-hover:bg-secondary bg-white"
+                          className={`w-8 h-8 border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center flex-shrink-0 mt-0.5 transition-all duration-300 ${
+                            isCompleted ? "bg-success" : "bg-background group-hover:bg-secondary"
                           }`}
                         >
                           {isCompleted ? (
                             <CheckCircle2 className="h-4 w-4" />
                           ) : (
-                            <Circle className="text-muted-foreground h-4 w-4" />
+                            <Circle className="h-4 w-4 text-muted-foreground" />
                           )}
                         </div>
-                        <div className="min-w-0 flex-1">
+                        <div className="flex-1 min-w-0">
                           <div className="flex items-start justify-between gap-3">
                             <h3
                               className={`font-black ${isCompleted ? "text-muted-foreground" : ""}`}
                             >
                               {ms.title}
                             </h3>
-                            <div className="flex flex-shrink-0 items-center gap-2">
-                              <Badge variant={isCompleted ? "success" : "default"}>
+                            <div className="flex items-center gap-2 flex-shrink-0">
+                              <Badge
+                                variant={isCompleted ? "success" : "default"}
+                              >
                                 {ms.rewardAmount} USDC
                               </Badge>
                               {isExpanded ? (
-                                <ChevronUp className="text-muted-foreground h-4 w-4" />
+                                <ChevronUp className="h-4 w-4 text-muted-foreground" />
                               ) : (
-                                <ChevronDown className="text-muted-foreground h-4 w-4" />
+                                <ChevronDown className="h-4 w-4 text-muted-foreground" />
                               )}
                             </div>
                           </div>
 
                           {/* Expanded content */}
                           {isExpanded && (
-                            <div className="animate-fade-in-up mt-3">
-                              <p className="text-muted-foreground mb-3 text-sm">{ms.description}</p>
+                            <div className="mt-3 animate-fade-in-up">
+                              <p className="text-sm text-muted-foreground mb-3">
+                                {ms.description}
+                              </p>
                               {completedBy.length > 0 && (
                                 <div className="mb-3">
-                                  <p className="text-muted-foreground mb-2 text-xs font-bold">
+                                  <p className="text-xs font-bold text-muted-foreground mb-2">
                                     Completed by:
                                   </p>
                                   <div className="flex flex-wrap gap-2">
-                                    {completedBy.map(addr => (
+                                    {completedBy.map((addr) => (
                                       <span
                                         key={addr}
-                                        className="bg-success/10 border-[1.5px] border-black px-2 py-1 font-mono text-xs font-bold shadow-[1px_1px_0_#000]"
+                                        className="text-xs font-mono font-bold bg-success/10 border-[1.5px] border-border px-2 py-1 shadow-[1px_1px_0_var(--color-border)]"
                                       >
                                         {addr}
                                       </span>
@@ -316,7 +343,7 @@ const { toasts, addToast, removeToast } = useToast()
                                   variant="outline"
                                   size="sm"
                                   className="shimmer-on-hover"
-                                  onClick={e => e.stopPropagation()}
+                                  onClick={(e) => e.stopPropagation()}
                                 >
                                   <CheckCircle2 className="h-3.5 w-3.5" />
                                   Verify Completion
@@ -341,11 +368,13 @@ const { toasts, addToast, removeToast } = useToast()
           {enrollees.length === 0 ? (
             <Card className="animate-fade-in-up">
               <CardContent className="flex flex-col items-center py-12 text-center">
-                <div className="bg-primary mb-4 flex h-14 w-14 items-center justify-center border-[3px] border-black shadow-[4px_4px_0_#000]">
+                <div className="w-14 h-14 bg-primary border-[3px] border-border shadow-[4px_4px_0_var(--color-border)] flex items-center justify-center mb-4">
                   <Users className="h-6 w-6" />
                 </div>
-                <h3 className="mb-2 font-black">No enrollees yet</h3>
-                <p className="text-muted-foreground mb-4 text-sm">Add learners to this quest.</p>
+                <h3 className="font-black mb-2">No enrollees yet</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Add learners to this quest.
+                </p>
                 <Button size="sm" className="shimmer-on-hover">
                   <UserPlus className="h-4 w-4" />
                   Add Enrollee
@@ -354,15 +383,21 @@ const { toasts, addToast, removeToast } = useToast()
             </Card>
           ) : (
             enrollees.map((addr, i) => {
-              const completed = completions.filter(c => c.enrollee === addr && c.completed).length
+              const completed = completions.filter(
+                (c) => c.enrollee === addr && c.completed
+              ).length
               const earned = milestones
-                .filter(m =>
+                .filter((m) =>
                   completions.some(
-                    c => c.enrollee === addr && c.milestoneId === m.id && c.completed
+                    (c) =>
+                      c.enrollee === addr &&
+                      c.milestoneId === m.id &&
+                      c.completed
                   )
                 )
                 .reduce((sum, m) => sum + m.rewardAmount, 0)
-              const isAllDone = completed === milestones.length && milestones.length > 0
+              const isAllDone =
+                completed === milestones.length && milestones.length > 0
 
               return (
                 <div
@@ -370,19 +405,23 @@ const { toasts, addToast, removeToast } = useToast()
                   className={`reveal-up ${contentInView ? "in-view" : ""}`}
                   style={{ transitionDelay: `${i * 100}ms` }}
                 >
-                  <Card className="neo-lift group hover:shadow-[7px_7px_0_#000] active:shadow-[2px_2px_0_#000]">
+                  <Card className="neo-lift hover:shadow-[7px_7px_0_var(--color-border)] active:shadow-[2px_2px_0_var(--color-border)] group">
                     <CardContent className="p-5">
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-3">
-                          <div className="bg-primary flex h-10 w-10 items-center justify-center border-[2px] border-black font-mono text-sm font-black shadow-[2px_2px_0_#000] transition-shadow group-hover:shadow-[3px_3px_0_#000]">
+                          <div className="w-10 h-10 bg-primary border-[2px] border-border shadow-[2px_2px_0_var(--color-border)] flex items-center justify-center text-sm font-mono font-black group-hover:shadow-[3px_3px_0_var(--color-border)] transition-shadow">
                             {addr.slice(0, 2)}
                           </div>
                           <div>
                             <div className="flex items-center gap-2">
-                              <p className="font-mono text-sm font-bold">{addr}</p>
-                              {isAllDone && <Sparkles className="text-primary h-3.5 w-3.5" />}
+                              <p className="font-mono text-sm font-bold">
+                                {addr}
+                              </p>
+                              {isAllDone && (
+                                <Sparkles className="h-3.5 w-3.5 text-primary" />
+                              )}
                             </div>
-                            <p className="text-muted-foreground text-xs font-bold">
+                            <p className="text-xs font-bold text-muted-foreground">
                               {completed}/{milestones.length} milestones
                             </p>
                           </div>
@@ -391,11 +430,17 @@ const { toasts, addToast, removeToast } = useToast()
                           <Badge variant="success" className="tabular-nums">
                             +{formatTokens(earned)} USDC
                           </Badge>
-                          <p className="text-muted-foreground mt-1 text-xs font-bold">earned</p>
+                          <p className="text-xs font-bold text-muted-foreground mt-1">
+                            earned
+                          </p>
                         </div>
                       </div>
                       {milestones.length > 0 && (
-                        <Progress value={completed} max={milestones.length} className="mt-4" />
+                        <Progress
+                          value={completed}
+                          max={milestones.length}
+                          className="mt-4"
+                        />
                       )}
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## What does this PR do?

Adds a dark/light mode toggle for the frontend,users can switch between themes using a button in the navbar.
The preference persists in localStorage and respects system theme on first visit.
All UI components, including cards and buttons, now adapt automatically using CSS variables for colors, borders, and shadows.

## Related Issue

Closes #24 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [x] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [x] `pnpm build` passes (if frontend changed)
- [x] `cargo fmt --all -- --check` passes (if Rust changed)
- [x] `pnpm lint` passes (if frontend changed)

## Screenshots

<img width="1769" height="953" alt="Screenshot 2026-03-24 195602" src="https://github.com/user-attachments/assets/dcb2accc-640c-4877-ab90-2c8ad124bad7" />
<img width="1919" height="953" alt="Screenshot 2026-03-24 195551" src="https://github.com/user-attachments/assets/bd82f590-2e00-4a04-b6ec-b83c6cec42fa" />
