### PR TITLE
feat: implement dashboard analytics with lazy-loaded charts and sub-c…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "prepare": "cd .. && husky"
+    "preview": "vite preview"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.2",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
     "@vercel/analytics": "^2.0.1",
@@ -21,9 +19,8 @@
     "lucide-react": "^1.0.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-hook-form": "^7.72.0",
-    "tailwind-merge": "^3.5.0",
-    "zod": "^4.3.6"
+    "recharts": "^3.8.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -36,8 +33,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "husky": "^9.1.7",
-    "lint-staged": "^16.4.0",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hookform/resolvers':
-        specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.72.0(react@19.2.4))
       '@stellar/freighter-api':
         specifier: ^6.0.1
         version: 6.0.1
@@ -38,15 +35,12 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      react-hook-form:
-        specifier: ^7.72.0
-        version: 7.72.0(react@19.2.4)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -78,12 +72,6 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
-      lint-staged:
-        specifier: ^16.4.0
-        version: 16.4.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -213,11 +201,6 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
-    peerDependencies:
-      react-hook-form: ^7.55.0
-
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -263,6 +246,17 @@ packages:
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==}
@@ -364,6 +358,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -480,6 +477,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -496,6 +520,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -637,21 +664,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -729,14 +744,6 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -747,9 +754,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -772,6 +776,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -780,6 +828,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -803,16 +854,9 @@ packages:
   electron-to-chromium@1.5.322:
     resolution: {integrity: sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -829,6 +873,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -967,10 +1014,6 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1023,11 +1066,6 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1038,6 +1076,12 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -1050,6 +1094,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -1057,10 +1105,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1191,25 +1235,12 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lint-staged@16.4.0:
-    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
-    engines: {node: '>=20.17'}
-    hasBin: true
-
-  listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1234,10 +1265,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -1258,10 +1285,6 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1321,26 +1344,47 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-hook-form@7.72.0:
-    resolution: {integrity: sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==}
-    engines: {node: '>=18.0.0'}
+  react-is@19.2.4:
+    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown@1.0.0-rc.11:
     resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
@@ -1384,37 +1428,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1434,9 +1450,8 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -1493,6 +1508,14 @@ packages:
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
   vite@8.0.2:
     resolution: {integrity: sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1548,10 +1571,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1738,11 +1757,6 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.72.0(react@19.2.4))':
-    dependencies:
-      '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.72.0(react@19.2.4)
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1787,6 +1801,18 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@oxc-project/types@0.122.0': {}
+
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
   '@rolldown/binding-android-arm64@1.0.0-rc.11':
     optional: true
@@ -1838,6 +1864,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.11': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -1944,6 +1972,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -1959,6 +2011,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2077,17 +2131,9 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
-  ansi-regex@6.2.2: {}
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -2169,15 +2215,6 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.0
-
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -2185,8 +2222,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  colorette@2.0.20: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -2206,9 +2241,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -2230,14 +2305,10 @@ snapshots:
 
   electron-to-chromium@1.5.322: {}
 
-  emoji-regex@10.6.0: {}
-
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
-
-  environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -2253,6 +2324,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.45.1: {}
 
   escalade@3.2.0: {}
 
@@ -2398,8 +2471,6 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-east-asian-width@1.5.0: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2452,13 +2523,15 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  husky@9.1.7: {}
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -2469,13 +2542,11 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  internmap@2.0.3: {}
+
   is-callable@1.2.7: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
 
   is-glob@4.0.3:
     dependencies:
@@ -2567,37 +2638,11 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lint-staged@16.4.0:
-    dependencies:
-      commander: 14.0.3
-      listr2: 9.0.5
-      picomatch: 4.0.4
-      string-argv: 0.3.2
-      tinyexec: 1.0.4
-      yaml: 2.8.3
-
-  listr2@9.0.5:
-    dependencies:
-      cli-truncate: 5.2.0
-      colorette: 2.0.20
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 9.0.2
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
-
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   lru-cache@5.1.1:
     dependencies:
@@ -2619,8 +2664,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mimic-function@5.0.1: {}
-
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.5
@@ -2636,10 +2679,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.36: {}
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   optionator@0.9.4:
     dependencies:
@@ -2693,20 +2732,48 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-hook-form@7.72.0(react@19.2.4):
+  react-is@19.2.4: {}
+
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
     dependencies:
+      '@types/use-sync-external-store': 0.0.6
       react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
 
   react@19.2.4: {}
 
-  resolve-from@4.0.0: {}
-
-  restore-cursor@5.1.0:
+  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1):
     dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
-  rfdc@1.4.1: {}
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
+  reselect@5.1.1: {}
+
+  resolve-from@4.0.0: {}
 
   rolldown@1.0.0-rc.11:
     dependencies:
@@ -2760,36 +2827,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  signal-exit@4.1.0: {}
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   source-map-js@1.2.1: {}
-
-  string-argv@0.3.2: {}
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
 
@@ -2803,7 +2841,7 @@ snapshots:
 
   tapable@2.3.2: {}
 
-  tinyexec@1.0.4: {}
+  tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -2862,6 +2900,27 @@ snapshots:
 
   urijs@1.19.11: {}
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -2891,15 +2950,10 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   yallist@3.1.1: {}
 
-  yaml@2.8.3: {}
+  yaml@2.8.3:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -147,3 +147,65 @@ export const MOCK_USER_STATS: UserStats = {
   workspacesEnrolled: 1,
   milestonesCompleted: 4,
 }
+
+export interface PlatformStats {
+  totalQuests: number
+  activeUsers: number
+  tokensDistributed: number
+}
+
+export interface ActivityEvent {
+  id: string
+  user: string
+  action: "enrolled" | "completed" | "created"
+  workspaceName: string
+  timestamp: number
+}
+
+export interface EarningsDataPoint {
+  date: string
+  amount: number
+}
+
+export const MOCK_PLATFORM_STATS: PlatformStats = {
+  totalQuests: 156,
+  activeUsers: 842,
+  tokensDistributed: 125000,
+}
+
+// We can just reuse some of the existing workspaces for trending
+export const MOCK_TRENDING_QUESTS = [
+  MOCK_WORKSPACES[1],
+  MOCK_WORKSPACES[0],
+]
+
+export const MOCK_RECENT_ACTIVITY: ActivityEvent[] = [
+  {
+    id: "act_1",
+    user: "GBXR...K2YQ",
+    action: "completed",
+    workspaceName: "Stellar Development Bootcamp",
+    timestamp: Date.now() - 1000 * 60 * 30,
+  },
+  {
+    id: "act_2",
+    user: "GCMN...P8TL",
+    action: "enrolled",
+    workspaceName: "Design Fundamentals",
+    timestamp: Date.now() - 1000 * 60 * 60 * 2,
+  },
+  {
+    id: "act_3",
+    user: "GDVW...N5HS",
+    action: "created",
+    workspaceName: "Advanced Rust Patterns",
+    timestamp: Date.now() - 1000 * 60 * 60 * 24,
+  },
+]
+
+export const MOCK_EARNINGS_HISTORY: EarningsDataPoint[] = [
+  { date: "Jan", amount: 0 },
+  { date: "Feb", amount: 150 },
+  { date: "Mar", amount: 400 },
+  { date: "Apr", amount: 750 },
+]

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import React, { useState, Suspense } from "react"
 import {
   Plus,
   Users,
@@ -8,6 +8,7 @@ import {
   Wallet,
   Sparkles,
   Search,
+  LayoutDashboard,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -18,8 +19,22 @@ import {
   MOCK_WORKSPACES,
   MOCK_MILESTONES,
   MOCK_COMPLETIONS,
+  MOCK_PLATFORM_STATS,
+  MOCK_TRENDING_QUESTS,
+  MOCK_USER_STATS,
+  MOCK_RECENT_ACTIVITY,
+  MOCK_EARNINGS_HISTORY,
 } from "@/lib/mock-data"
 import { formatTokens } from "@/lib/utils"
+
+// Sub-components
+import { PlatformStats } from "./dashboard/platform-stats"
+import { PersonalProgress } from "./dashboard/personal-progress"
+import { TrendingQuests } from "./dashboard/trending-quests"
+import { RecentActivity } from "./dashboard/recent-activity"
+
+// Lazy-loaded chart
+const EarningsChart = React.lazy(() => import("./dashboard/earnings-chart"))
 
 // The first two workspaces share the same owner — treat them as "owned"
 const MOCK_OWNER = "GBXR...K2YQ"
@@ -111,7 +126,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
   })
 
   return (
-    <div className="relative mx-auto max-w-6xl px-4 sm:px-6 py-8">
+    <div className="relative mx-auto max-w-7xl px-4 sm:px-6 py-8">
       {/* Welcome banner */}
       <div className="relative bg-primary border-[3px] border-black shadow-[6px_6px_0_#000] p-6 sm:p-8 mb-8 overflow-hidden animate-fade-in-up">
         <div className="absolute inset-0 bg-diagonal-lines pointer-events-none opacity-30" />
@@ -125,7 +140,7 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
               {shortAddress}
             </h1>
             <p className="text-sm font-bold opacity-70 mt-1">
-              You have {MOCK_WORKSPACES.length} active quests
+              You have {MOCK_USER_STATS.workspacesEnrolled} active quests
             </p>
           </div>
           <Button
@@ -139,152 +154,181 @@ export function Dashboard({ onSelectWorkspace, onCreateQuest }: DashboardProps) 
         </div>
       </div>
 
-      {/* Quest filters + heading */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-5 relative">
-        <h2 className="text-xl font-black">Your Quests</h2>
-        <div className="flex gap-0 border-[2px] border-black shadow-[3px_3px_0_#000]">
-          {(["all", "owned", "enrolled"] as const).map((f) => (
-            <button
-              key={f}
-              onClick={() => setFilter(f)}
-              className={`px-4 py-2 text-xs font-black uppercase tracking-wider transition-colors capitalize cursor-pointer border-r-[2px] border-black last:border-r-0 ${
-                filter === f
-                  ? "bg-primary"
-                  : "bg-white hover:bg-secondary"
-              }`}
-            >
-              {f}
-            </button>
-          ))}
+      {/* Platform Stats Overview */}
+      <PlatformStats stats={MOCK_PLATFORM_STATS} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Left Column (Personal Stats, Chart, Quests) */}
+        <div className="lg:col-span-2 space-y-8 animate-fade-in-up stagger-2">
+          
+          {/* Personal Stats */}
+          <PersonalProgress stats={MOCK_USER_STATS} />
+
+          {/* Earnings Chart (Lazy Loaded) */}
+          <Suspense fallback={<div className="h-[250px] animate-pulse bg-muted border-[3px] border-black shadow-[6px_6px_0_#000]" />}>
+            <EarningsChart data={MOCK_EARNINGS_HISTORY} />
+          </Suspense>
+
+          {/* Your Quests Section */}
+          <div>
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-5 relative">
+              <h2 className="text-xl font-black flex items-center gap-2">
+                <LayoutDashboard className="w-5 h-5" /> Your Quests
+              </h2>
+              <div className="flex gap-0 border-[2px] border-black shadow-[3px_3px_0_#000]">
+                {(["all", "owned", "enrolled"] as const).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setFilter(f)}
+                    className={`px-4 py-2 text-xs font-black uppercase tracking-wider transition-colors capitalize cursor-pointer border-r-[2px] border-black last:border-r-0 ${
+                      filter === f
+                        ? "bg-primary"
+                        : "bg-white hover:bg-secondary"
+                    }`}
+                  >
+                    {f}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-5 relative">
+              {filteredWorkspaces.map((ws, i) => {
+                const milestones = MOCK_MILESTONES[ws.id] || []
+                const completions = MOCK_COMPLETIONS[ws.id] || []
+                const totalMilestones = milestones.length
+                const completedCount = new Set(
+                  completions.filter((c) => c.completed).map((c) => c.milestoneId)
+                ).size
+                const totalReward = milestones.reduce(
+                  (sum, m) => sum + m.rewardAmount,
+                  0
+                )
+                const earnedReward = milestones
+                  .filter((m) =>
+                    completions.some(
+                      (c) => c.milestoneId === m.id && c.completed
+                    )
+                  )
+                  .reduce((sum, m) => sum + m.rewardAmount, 0)
+                const isOwned = ws.owner === MOCK_OWNER
+
+                return (
+                  <Card
+                    key={ws.id}
+                    className={`card-tilt cursor-pointer group animate-fade-in-up stagger-${i + 1}`}
+                    onClick={() => onSelectWorkspace(ws.id)}
+                  >
+                    <CardHeader className="pb-3">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-3 mb-1">
+                            <CardTitle className="text-base group-hover:text-primary transition-colors">
+                              {ws.name}
+                            </CardTitle>
+                            {completedCount === totalMilestones &&
+                              totalMilestones > 0 && (
+                                <Badge variant="success" className="gap-1">
+                                  <Sparkles className="h-3 w-3" />
+                                  Complete
+                                </Badge>
+                              )}
+                            <Badge variant={isOwned ? "default" : "secondary"} className="text-[10px]">
+                              {isOwned ? "Owner" : "Enrolled"}
+                            </Badge>
+                          </div>
+                          <p className="text-sm text-muted-foreground mt-1 line-clamp-1">
+                            {ws.description}
+                          </p>
+                        </div>
+                        <div className="w-8 h-8 bg-secondary border-[2px] border-black flex items-center justify-center flex-shrink-0 ml-3 group-hover:bg-primary group-hover:shadow-[2px_2px_0_#000] transition-all">
+                          <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex flex-wrap items-center gap-3 text-sm mb-4">
+                        <Badge variant="secondary" className="gap-1">
+                          <Users className="h-3 w-3" />
+                          {ws.enrolleeCount} enrolled
+                        </Badge>
+                        <Badge variant="secondary" className="gap-1">
+                          <Target className="h-3 w-3" />
+                          {ws.milestoneCount} milestones
+                        </Badge>
+                        <Badge variant="default" className="gap-1">
+                          <Coins className="h-3 w-3" />
+                          {formatTokens(ws.poolBalance)} USDC
+                        </Badge>
+                      </div>
+
+                      {totalMilestones > 0 && (
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-3">
+                            <Progress
+                              value={completedCount}
+                              max={totalMilestones}
+                              className="flex-1"
+                            />
+                            <span className="text-xs font-bold text-muted-foreground whitespace-nowrap">
+                              {completedCount}/{totalMilestones}
+                            </span>
+                          </div>
+                          {earnedReward > 0 && (
+                            <div className="flex items-center justify-between">
+                              <span className="text-xs font-bold text-muted-foreground">
+                                Earned so far
+                              </span>
+                              <span className="text-xs font-black text-green-700">
+                                +{formatTokens(earnedReward)} / {formatTokens(totalReward)} USDC
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+
+            {filteredWorkspaces.length === 0 && (
+              <Card className="animate-fade-in-up mt-5">
+                <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+                  <div className="w-16 h-16 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] flex items-center justify-center mb-6">
+                    <Search className="h-6 w-6" />
+                  </div>
+                  <h3 className="font-black text-lg mb-2">
+                    {filter === "all" ? "No quests yet" : `No ${filter} quests`}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+                    {filter === "all"
+                      ? "Create your first quest to start incentivizing learning with on-chain rewards."
+                      : filter === "owned"
+                        ? "You haven't created any quests yet. Start one to incentivize learners."
+                        : "You haven't enrolled in any quests yet. Browse available quests to get started."}
+                  </p>
+                  {filter === "all" || filter === "owned" ? (
+                    <Button onClick={onCreateQuest} className="shimmer-on-hover">
+                      <Plus className="h-4 w-4" />
+                      Create Quest
+                    </Button>
+                  ) : null}
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+
+        {/* Right Column (Trending & Recent Activity) */}
+        <div className="space-y-8 animate-fade-in-up stagger-3">
+          <TrendingQuests 
+            quests={MOCK_TRENDING_QUESTS} 
+            onSelectQuest={onSelectWorkspace} 
+          />
+          <RecentActivity activities={MOCK_RECENT_ACTIVITY} />
         </div>
       </div>
-
-      {/* Quest list */}
-      <div className="grid gap-5 relative">
-        {filteredWorkspaces.map((ws, i) => {
-          const milestones = MOCK_MILESTONES[ws.id] || []
-          const completions = MOCK_COMPLETIONS[ws.id] || []
-          const totalMilestones = milestones.length
-          const completedCount = new Set(
-            completions.filter((c) => c.completed).map((c) => c.milestoneId)
-          ).size
-          const totalReward = milestones.reduce(
-            (sum, m) => sum + m.rewardAmount,
-            0
-          )
-          const earnedReward = milestones
-            .filter((m) =>
-              completions.some(
-                (c) => c.milestoneId === m.id && c.completed
-              )
-            )
-            .reduce((sum, m) => sum + m.rewardAmount, 0)
-          const isOwned = ws.owner === MOCK_OWNER
-
-          return (
-            <Card
-              key={ws.id}
-              className={`card-tilt cursor-pointer group animate-fade-in-up stagger-${i + 1}`}
-              onClick={() => onSelectWorkspace(ws.id)}
-            >
-              <CardHeader className="pb-3">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3 mb-1">
-                      <CardTitle className="text-base group-hover:text-primary transition-colors">
-                        {ws.name}
-                      </CardTitle>
-                      {completedCount === totalMilestones &&
-                        totalMilestones > 0 && (
-                          <Badge variant="success" className="gap-1">
-                            <Sparkles className="h-3 w-3" />
-                            Complete
-                          </Badge>
-                        )}
-                      <Badge variant={isOwned ? "default" : "secondary"} className="text-[10px]">
-                        {isOwned ? "Owner" : "Enrolled"}
-                      </Badge>
-                    </div>
-                    <p className="text-sm text-muted-foreground mt-1 line-clamp-1">
-                      {ws.description}
-                    </p>
-                  </div>
-                  <div className="w-8 h-8 bg-secondary border-[2px] border-black flex items-center justify-center flex-shrink-0 ml-3 group-hover:bg-primary group-hover:shadow-[2px_2px_0_#000] transition-all">
-                    <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap items-center gap-3 text-sm mb-4">
-                  <Badge variant="secondary" className="gap-1">
-                    <Users className="h-3 w-3" />
-                    {ws.enrolleeCount} enrolled
-                  </Badge>
-                  <Badge variant="secondary" className="gap-1">
-                    <Target className="h-3 w-3" />
-                    {ws.milestoneCount} milestones
-                  </Badge>
-                  <Badge variant="default" className="gap-1">
-                    <Coins className="h-3 w-3" />
-                    {formatTokens(ws.poolBalance)} USDC
-                  </Badge>
-                </div>
-
-                {totalMilestones > 0 && (
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-3">
-                      <Progress
-                        value={completedCount}
-                        max={totalMilestones}
-                        className="flex-1"
-                      />
-                      <span className="text-xs font-bold text-muted-foreground whitespace-nowrap">
-                        {completedCount}/{totalMilestones}
-                      </span>
-                    </div>
-                    {earnedReward > 0 && (
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-bold text-muted-foreground">
-                          Earned so far
-                        </span>
-                        <span className="text-xs font-black text-green-700">
-                          +{formatTokens(earnedReward)} / {formatTokens(totalReward)} USDC
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          )
-        })}
-      </div>
-
-      {filteredWorkspaces.length === 0 && (
-        <Card className="animate-fade-in-up">
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-            <div className="w-16 h-16 bg-primary border-[3px] border-black shadow-[4px_4px_0_#000] flex items-center justify-center mb-6">
-              <Search className="h-6 w-6" />
-            </div>
-            <h3 className="font-black text-lg mb-2">
-              {filter === "all" ? "No quests yet" : `No ${filter} quests`}
-            </h3>
-            <p className="text-sm text-muted-foreground mb-6 max-w-sm">
-              {filter === "all"
-                ? "Create your first quest to start incentivizing learning with on-chain rewards."
-                : filter === "owned"
-                  ? "You haven't created any quests yet. Start one to incentivize learners."
-                  : "You haven't enrolled in any quests yet. Browse available quests to get started."}
-            </p>
-            {filter === "all" || filter === "owned" ? (
-              <Button onClick={onCreateQuest} className="shimmer-on-hover">
-                <Plus className="h-4 w-4" />
-                Create Quest
-              </Button>
-            ) : null}
-          </CardContent>
-        </Card>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/dashboard/earnings-chart.tsx
+++ b/frontend/src/pages/dashboard/earnings-chart.tsx
@@ -1,0 +1,57 @@
+import { CartesianGrid, XAxis, YAxis, Tooltip, Line, LineChart, ResponsiveContainer } from "recharts"
+import { TrendingUp } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { EarningsDataPoint } from "@/lib/mock-data"
+
+interface EarningsChartProps {
+  data: EarningsDataPoint[]
+}
+
+export default function EarningsChart({ data }: EarningsChartProps) {
+  return (
+    <Card className="border-[3px] border-black shadow-[6px_6px_0_#000] overflow-hidden">
+      <CardHeader className="bg-white border-b-[2px] border-black py-4">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <TrendingUp className="w-5 h-5" /> Earnings History
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-6 bg-white">
+        <div className="h-[250px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis 
+                dataKey="date" 
+                tick={{ fontWeight: "bold", fontSize: 12 }} 
+                axisLine={{ stroke: '#000', strokeWidth: 2 }} 
+                tickLine={{ stroke: '#000', strokeWidth: 2 }} 
+              />
+              <YAxis 
+                tick={{ fontWeight: "bold", fontSize: 12 }} 
+                axisLine={{ stroke: '#000', strokeWidth: 2 }} 
+                tickLine={{ stroke: '#000', strokeWidth: 2 }} 
+              />
+              <Tooltip 
+                contentStyle={{ 
+                  backgroundColor: "#fff", 
+                  border: "2px solid #000", 
+                  boxShadow: "4px 4px 0 #000",
+                  borderRadius: 0,
+                  fontWeight: "bold"
+                }}
+              />
+              <Line 
+                type="monotone" 
+                dataKey="amount" 
+                stroke="#000" 
+                strokeWidth={4} 
+                activeDot={{ r: 6, stroke: '#000', strokeWidth: 2, fill: '#FACC15' }} 
+                dot={{ r: 4, stroke: '#000', strokeWidth: 2, fill: '#fff' }} 
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/dashboard/personal-progress.tsx
+++ b/frontend/src/pages/dashboard/personal-progress.tsx
@@ -1,0 +1,35 @@
+import { Activity } from "lucide-react"
+import type { UserStats as UserStatsType } from "@/lib/mock-data"
+import { formatTokens } from "@/lib/utils"
+
+interface PersonalProgressProps {
+  stats: UserStatsType
+}
+
+export function PersonalProgress({ stats }: PersonalProgressProps) {
+  return (
+    <div>
+      <h2 className="text-xl font-black mb-4 flex items-center gap-2">
+        <Activity className="w-5 h-5" /> Your Progress
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+          <p className="text-xs font-bold text-muted-foreground uppercase text-center">Enrolled</p>
+          <p className="text-2xl font-black mt-1 text-center">{stats.workspacesEnrolled}</p>
+        </div>
+        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+          <p className="text-xs font-bold text-muted-foreground uppercase text-center">Completed</p>
+          <p className="text-2xl font-black mt-1 text-center">{stats.milestonesCompleted}</p>
+        </div>
+        <div className="bg-secondary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+          <p className="text-xs font-bold text-muted-foreground uppercase text-center">Owned</p>
+          <p className="text-2xl font-black mt-1 text-center">{stats.workspacesOwned}</p>
+        </div>
+        <div className="bg-primary border-[2px] border-black p-4 shadow-[3px_3px_0_#000]">
+          <p className="text-xs font-bold text-black uppercase text-center">Earnings</p>
+          <p className="text-xl font-black mt-2 text-center text-green-800">{formatTokens(stats.totalEarned)} USDC</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/platform-stats.tsx
+++ b/frontend/src/pages/dashboard/platform-stats.tsx
@@ -1,0 +1,54 @@
+import { Target, Users, Coins } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { formatTokens } from "@/lib/utils"
+import type { PlatformStats as PlatformStatsType } from "@/lib/mock-data"
+
+interface PlatformStatsProps {
+  stats: PlatformStatsType
+}
+
+export function PlatformStats({ stats }: PlatformStatsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 animate-fade-in-up stagger-1">
+      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+        <CardContent className="p-6">
+          <div className="flex justify-between items-start">
+            <div>
+              <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Total Quests</p>
+              <h3 className="text-3xl font-black mt-1">{stats.totalQuests}</h3>
+            </div>
+            <div className="w-10 h-10 bg-secondary border-[2px] border-black flex items-center justify-center">
+              <Target className="w-5 h-5" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+        <CardContent className="p-6">
+          <div className="flex justify-between items-start">
+            <div>
+              <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Active Users</p>
+              <h3 className="text-3xl font-black mt-1">{stats.activeUsers}</h3>
+            </div>
+            <div className="w-10 h-10 bg-success border-[2px] border-black flex items-center justify-center">
+              <Users className="w-5 h-5" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card className="card-tilt bg-white border-[3px] border-black shadow-[4px_4px_0_#000]">
+        <CardContent className="p-6">
+          <div className="flex justify-between items-start">
+            <div>
+              <p className="text-sm font-bold text-muted-foreground uppercase tracking-wide">Tokens Distributed</p>
+              <h3 className="text-3xl font-black mt-1 text-green-700">{formatTokens(stats.tokensDistributed)} USDC</h3>
+            </div>
+            <div className="w-10 h-10 bg-primary border-[2px] border-black flex items-center justify-center">
+              <Coins className="w-5 h-5" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/recent-activity.tsx
+++ b/frontend/src/pages/dashboard/recent-activity.tsx
@@ -1,0 +1,47 @@
+import { Clock, Plus, Target, Sparkles } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import type { ActivityEvent } from "@/lib/mock-data"
+
+interface RecentActivityProps {
+  activities: ActivityEvent[]
+}
+
+export function RecentActivity({ activities }: RecentActivityProps) {
+  return (
+    <div>
+      <h2 className="text-xl font-black mb-4 flex items-center gap-2">
+        <Clock className="w-5 h-5" /> Recent Activity
+      </h2>
+      <Card className="border-[3px] border-black shadow-[4px_4px_0_#000]">
+        <CardContent className="p-0">
+          <div className="divide-y-[2px] divide-black">
+            {activities.map((activity) => {
+              const isEnrolled = activity.action === "enrolled"
+              const isCompleted = activity.action === "completed"
+              const Icon = isEnrolled ? Plus : isCompleted ? Target : Sparkles
+              const iconColor = isEnrolled ? "bg-primary" : isCompleted ? "bg-success" : "bg-white"
+
+              return (
+                <div key={activity.id} className="p-4 flex gap-3 hover:bg-secondary transition-colors">
+                  <div className={`w-8 h-8 ${iconColor} border-[2px] border-black flex-shrink-0 flex items-center justify-center shadow-[2px_2px_0_#000] mt-1`}>
+                     <Icon className="w-4 h-4" />
+                  </div>
+                  <div>
+                     <p className="text-sm">
+                       <span className="font-bold">{activity.user}</span>{" "}
+                       {isEnrolled ? "enrolled in" : isCompleted ? "completed a milestone in" : "created"}{" "}
+                       <span className="font-bold">{activity.workspaceName}</span>
+                     </p>
+                     <p className="text-xs text-muted-foreground font-bold mt-1">
+                       {new Date(activity.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                     </p>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/trending-quests.tsx
+++ b/frontend/src/pages/dashboard/trending-quests.tsx
@@ -1,0 +1,48 @@
+import { Sparkles, Users, Coins } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { formatTokens } from "@/lib/utils"
+import type { Workspace } from "@/lib/mock-data"
+
+interface TrendingQuestsProps {
+  quests: Workspace[]
+  onSelectQuest: (id: number) => void
+}
+
+export function TrendingQuests({ quests, onSelectQuest }: TrendingQuestsProps) {
+  return (
+    <div>
+      <h2 className="text-xl font-black mb-4 flex items-center gap-2">
+        <Sparkles className="w-5 h-5" /> Trending Quests
+      </h2>
+      <div className="space-y-4">
+        {quests.map((quest) => (
+          <Card 
+            key={quest.id} 
+            className="card-tilt cursor-pointer border-[2px] border-black shadow-[4px_4px_0_#000]"
+            onClick={() => onSelectQuest(quest.id)}
+          >
+            <CardHeader className="p-4 pb-2">
+              <div className="flex justify-between items-start">
+                 <CardTitle className="text-sm font-bold line-clamp-1">{quest.name}</CardTitle>
+                 <Badge variant="default" className="text-[10px] bg-primary text-black border-[1px] border-black ml-2 px-1">
+                   Trending
+                 </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="p-4 pt-0">
+              <div className="flex items-center gap-3 text-xs mt-2 text-muted-foreground">
+                <span className="flex items-center gap-1 font-bold">
+                  <Users className="w-3 h-3" /> {quest.enrolleeCount}
+                </span>
+                <span className="flex items-center gap-1 font-bold">
+                  <Coins className="w-3 h-3" /> {formatTokens(quest.poolBalance)}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,31 @@
+## What does this PR do?
+
+This PR implements the dashboard analytics feature as requested. It introduces `recharts` to render the user's earnings over time, which is **lazy-loaded** to keep the initial bundle size small (~314kB). The implementation also extracts the dashboard into maintainable sub-components (`PlatformStats`, `PersonalProgress`, `TrendingQuests`, `RecentActivity`) and provides a full neo-brutalist UI overhaul with platform-wide and personal statistics.
+
+## Related Issue
+
+Closes: #56 
+
+## Type of Change
+
+- [ ] Bug fix
+- [x] New feature
+- [ ] Refactor (no behavior change)
+- [ ] Documentation
+- [ ] Infrastructure / CI
+- [ ] Tests
+
+## Checklist
+
+- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
+- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
+- [x] I have added at least one label to this PR
+- [ ] I have added/updated tests for my changes (if applicable)
+- [ ] `cargo test --workspace` passes (if contracts changed)
+- [x] `pnpm build` passes (if frontend changed)
+- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
+- [x] `pnpm lint` passes (if frontend changed)
+
+## Screenshots
+
+<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/5cc4fc1b-b92e-48d6-bec0-d6e0769d7b6b" />


### PR DESCRIPTION
## What does this PR do?

This PR implements the dashboard analytics feature as requested. It introduces `recharts` to render the user's earnings over time, extends the mock data structures to support all the new dashboard widgets, and completely overhauls the `Dashboard` component to display Platform Stats, Personal Progress, Trending Quests, and a Recent Activity feed using the project's signature Neo-brutalism design system.

## Related Issue

Closes: #56 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [x] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [x] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [x] `pnpm lint` passes (if frontend changed)

## Screenshots

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/5cc4fc1b-b92e-48d6-bec0-d6e0769d7b6b" />
