### PR TITLE
docs: add testnet deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pnpm dev                    # → localhost:5173
 
 Install [Freighter](https://freighter.app), switch to **Testnet**, and connect.
 
-For contract deployment to Stellar testnet, see [contracts/Deployment.README.md](contracts/Deployment.README.md).
+For contract deployment to Stellar testnet, see [docs/deploy-testnet.md](docs/deploy-testnet.md).
 
 <br />
 

--- a/docs/deploy-testnet.md
+++ b/docs/deploy-testnet.md
@@ -11,8 +11,7 @@ Contracts in this repo:
 
 ## 1. Prerequisites
 
-- Stellar CLI installed (`stellar --version`)  
-  Tested with: `stellar 25.1.0`
+- Stellar CLI v25.1.0 or later (`stellar --version`; tested with v25.2.0)
 - Rust installed (`rustc --version`, `cargo --version`)
 - Soroban WASM target available (`rustup target add wasm32-unknown-unknown`)
 - A funded Stellar testnet account (testnet XLM)
@@ -22,7 +21,7 @@ Optional checks:
 ```bash
 stellar --version
 cargo --version
-rustup target list --installed
+rustup target list | grep wasm32
 ```
 
 ## 2. Build Contracts
@@ -54,17 +53,25 @@ stellar keys generate lernza-deployer --network testnet --fund
 stellar keys fund lernza-deployer --network testnet
 ```
 
-## 4. Get Reward Token Contract Address
+## 4. Get USDC Token Contract Address
 
-Lernza rewards contract requires a token contract address at initialization.
+Lernza uses **USDC on Stellar** via its Stellar Asset Contract (SAC). The rewards contract requires a token contract address at initialization.
 
-For native testnet XLM (SAC wrapper):
+For testnet USDC (issued by the SDF test anchor):
+
+```bash
+stellar contract id asset \
+  --asset USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 \
+  --network testnet
+```
+
+If you prefer native XLM for quick testing:
 
 ```bash
 stellar contract id asset --asset native --network testnet
 ```
 
-Save this as:
+Save the output as:
 
 ```bash
 TOKEN_ID=<output_from_command_above>
@@ -235,6 +242,7 @@ A deployment run was executed on **2026-03-24** with:
 - `REWARDS_ID=CCF2BR6PDYW4BAEPXHIXDNKBBCYWURFSFACHL5SG45XTSF3CT5YY753W`
 - `WORKSPACE_ID=CAWNB5LTEXQVXRMPLYT5HTEDEIGMUHNFGYMBWEIET6FQSP47Z7XGOJUD`
 - `MILESTONE_ID=CCM6NJGQG2IST2S3BMQC6SUBKYB4WIM7AWYA4UIYOVXY5OQQZBX5GJDO`
-- `TOKEN_ID=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` (native XLM SAC)
+- `TOKEN_ID=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` (native XLM SAC used for testing)
 
 Treat these as historical proof of process, not reusable deployment targets for your environment.
+


### PR DESCRIPTION
## Summary
- Adds testnet deployment and verification guide
- Moved from `contracts/Deployment.README.md` to `docs/deploy-testnet.md`
- Fixed CLI version, USDC token docs, and rustup commands

Closes #41

Original PR: #123 by @IbrahimIjai