### PR TITLE
feat(contracts): add quest enrollment cap

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     NextId,
     Quest(u32),
     Enrollees(u32),
+    EnrollmentCap(u32),
 }
 
 #[contracttype]
@@ -41,6 +42,7 @@ pub enum Error {
     AlreadyEnrolled = 3,
     NotEnrolled = 4,
     InvalidInput = 5,
+    QuestFull = 6,
 }
 
 const BUMP: u32 = 518_400;
@@ -90,6 +92,17 @@ impl QuestContract {
         quest.owner.require_auth();
 
         let enrollees = Self::load_enrollees(&env, quest_id);
+
+        // Check enrollment cap
+        if let Some(cap) = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::EnrollmentCap(quest_id))
+        {
+            if enrollees.len() >= cap {
+                return Err(Error::QuestFull);
+            }
+        }
 
         // Check not already enrolled
         for i in 0..enrollees.len() {
@@ -202,6 +215,28 @@ impl QuestContract {
         public_quests
     }
 
+    /// Set enrollment cap for a quest. Owner only.
+    pub fn set_enrollment_cap(env: Env, quest_id: u32, max_enrollees: u32) -> Result<(), Error> {
+        let quest = Self::load_quest(&env, quest_id)?;
+        quest.owner.require_auth();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EnrollmentCap(quest_id), &max_enrollees);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::EnrollmentCap(quest_id), THRESHOLD, BUMP);
+        Ok(())
+    }
+
+    /// Get enrollment cap for a quest.
+    pub fn get_enrollment_cap(env: Env, quest_id: u32) -> Option<u32> {
+        Self::load_quest(&env, quest_id).ok()?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::EnrollmentCap(quest_id))
+    }
+
     // --- internals ---
 
     fn load_quest(env: &Env, id: u32) -> Result<QuestInfo, Error> {
@@ -226,6 +261,17 @@ impl QuestContract {
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Enrollees(quest_id), THRESHOLD, BUMP);
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::EnrollmentCap(quest_id))
+        {
+            env.storage().persistent().extend_ttl(
+                &DataKey::EnrollmentCap(quest_id),
+                THRESHOLD,
+                BUMP,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Allows quest creators to set a maximum number of enrollees for cohort-based learning or competitive quests with limited spots.

- Add optional enrollment cap via `set_enrollment_cap` function (owner only)
- Enforce cap in `add_enrollee` function
- Add `QuestFull` error variant
- Add `get_enrollment_cap` function to query cap

Closes #8