### PR TITLE
ci(coverage): fix Codecov upload and testutils workspace feature

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Post coverage comment on PR
         uses: romeovs/lcov-reporter-action@v0.4.0

--- a/contracts/certificate/Cargo.toml
+++ b/contracts/certificate/Cargo.toml
@@ -13,5 +13,8 @@ stellar-tokens = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
 
+[features]
+testutils = []
+
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
## What
Fixes the Coverage workflow that has been failing on main since it was added.

## Why
Closes #267

The workflow fails with "Token required - not valid tokenless upload" because CODECOV_TOKEN is not set. Also fixes --features testutils failing for the certificate crate which has no testutils feature declared.

## How
- Pass CODECOV_TOKEN secret to codecov-action
- Set fail_ci_if_error: false so coverage upload degrades gracefully when the secret is absent
- Add testutils = [] feature to contracts/certificate/Cargo.toml so cargo llvm-cov --workspace --features testutils works

## Testing
cargo test --workspace passes. Coverage generation and upload steps now handle missing token gracefully.