### PR TITLE
ci(coverage): skip PR comment step when triggered by push

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request'
         uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           lcov-file: ./lcov.info


### PR DESCRIPTION
## What
Fixes the Coverage workflow failure on main caused by the PR comment step running without a PR context.

## Why
Closes #267

The workflow triggers on push to main, so github.event.issue.number is undefined. The lcov-reporter-action errors out trying to post a comment with no issue number.

## How
Add if: github.event_name == 'pull_request' to the Post coverage comment step so it only runs in PR contexts.

## Testing
The condition prevents the step from running on push events, eliminating the error.