### PR TITLE
fix: align privacy docs and profile earnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git clone https://github.com/lernza/lernza.git
 cd lernza
 
 # Smart contracts
-cargo test --workspace      # 33 tests
+cargo test --workspace      # run the current contract workspace test suite
 stellar contract build      # Optimized WASM
 
 # Frontend
@@ -75,17 +75,25 @@ Install [Freighter](https://freighter.app), switch to **Testnet**, and connect.
 
 For contract deployment to Stellar testnet, see [docs/deploy-testnet.md](docs/deploy-testnet.md).
 
+### Current Delivery Stage
+
+Lernza is currently a **contract-first project with a partially wired frontend**.
+
+- The Soroban contracts are implemented and tested in the Rust workspace.
+- The frontend has working wallet flows and selected read paths, but several write flows are still simulated in the UI.
+- Profile earnings now read the aggregate on-chain total from the rewards contract, but detailed payout history is not indexable yet.
+
 <br />
 
 ## Roadmap
 
 | Milestone                     | Status      | Focus                                         |
 | :---------------------------- | :---------- | :-------------------------------------------- |
-| **M1** Quest Foundation       | In Progress | Rename workspace → quest, validation, tooling |
-| **M2** Quest Engine           | Upcoming    | Visibility, deadlines, funding models         |
-| **M3** Neo-Brutalism UI       | Upcoming    | Design system, component redesign, routing    |
-| **M4** Full Stack Integration | Upcoming    | Wire frontend to contracts                    |
-| **M5** Quality & Advanced     | Upcoming    | Security audit, docs, advanced features       |
+| **M1** Quest Foundation       | In Repo     | Core contract structure, validation, tooling  |
+| **M2** Quest Engine           | In Progress | Deadlines live, visibility is discovery-only, funding models still pending |
+| **M3** Neo-Brutalism UI       | In Repo     | Frontend screens and design system prototype  |
+| **M4** Full Stack Integration | Partial     | Wallet connected, some contract reads wired, several flows still mocked |
+| **M5** Quality & Advanced     | Planned     | Security audit, indexing, advanced features   |
 
 See the full [project board](https://github.com/orgs/lernza/projects/1) for all 64 issues.
 
@@ -142,12 +150,16 @@ The blockchain IS the backend. All state lives on Stellar's ledger. Zero infrast
 
 | Area                    | Status                  | Contract Method     |
 | :---------------------- | :---------------------- | :------------------ |
-| **Quest Creation**      | Mocked                  | `create_quest`      |
-| **Enrollment**          | Mocked                  | `add_enrollee`      |
-| **Milestone Track**     | Mocked                  | `create_milestone`  |
-| **Verification**        | Mocked                  | `verify_completion` |
-| **Reward Distribution** | Mocked                  | `distribute_reward` |
-| **Profile & Analytics** | Implemented (Mock Data) | `get_user_earnings` |
+| **Quest Creation**      | Frontend flow still simulated | `create_quest`      |
+| **Enrollment**          | Contract available, UI orchestration still incomplete | `add_enrollee`      |
+| **Milestone Track**     | Contract available, UI still partly mock-backed | `create_milestone`  |
+| **Verification**        | Contract available, not fully wired in UI | `verify_completion` |
+| **Reward Distribution** | Contract available, not fully wired in UI | `distribute_reward` |
+| **Profile & Analytics** | Aggregate earnings wired; detailed history still unavailable | `get_user_earnings` |
+
+**Privacy model**
+
+`Visibility::Private` is currently **not a confidentiality feature**. It only removes a quest from public discovery helpers such as `list_public_quests`. If a caller knows a quest id, on-chain reads like `get_quest`, `get_enrollees`, and `is_enrollee` remain queryable.
 
 </details>
 
@@ -177,10 +189,10 @@ The blockchain IS the backend. All state lives on Stellar's ledger. Zero infrast
 | `create_quest(owner, name, description, token_addr, visibility, category, tags, enrollment_cap)` | Create a new quest with a reward token |
 | `add_enrollee(quest_id, enrollee)`                                                               | Enroll a learner (owner only)          |
 | `remove_enrollee(quest_id, enrollee)`                                                            | Remove a learner (owner only)          |
-| `get_quest(quest_id)` / `get_enrollees(quest_id)`                                                | Query quest data                       |
+| `get_quest(quest_id)` / `get_enrollees(quest_id)`                                                | Query quest data by id (including quests marked `Private`) |
 | `is_enrollee(quest_id, user)`                                                                    | Check enrollment status                |
 | `archive_quest(quest_id)`                                                                        | Archive a quest (owner only)           |
-| `set_visibility(quest_id, visibility)`                                                           | Update quest visibility                |
+| `set_visibility(quest_id, visibility)`                                                           | Update public discovery visibility (not confidentiality) |
 | `list_public_quests(start, limit)`                                                               | List public quests with pagination     |
 
 **Milestone Contract** — `contracts/milestone/`

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -12,6 +12,11 @@ use soroban_sdk::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Visibility {
     Public = 0,
+    /// Discovery-only flag.
+    ///
+    /// `Private` quests are omitted from public listing helpers, but the quest
+    /// record and enrollee data remain queryable by quest id because Soroban
+    /// contract storage is publicly readable.
     Private = 1,
 }
 
@@ -308,6 +313,10 @@ impl QuestContract {
     }
 
     /// Get quest info by ID.
+    ///
+    /// Visibility does not gate direct reads. Even quests marked `Private`
+    /// remain queryable by id; the flag only affects discovery helpers such as
+    /// `list_public_quests` and `get_quests_by_category`.
     pub fn get_quest(env: Env, quest_id: u32) -> Result<QuestInfo, Error> {
         let quest = Self::load_quest(&env, quest_id)?;
         Self::bump(&env, quest_id);
@@ -315,6 +324,9 @@ impl QuestContract {
     }
 
     /// Get all enrollees for a quest.
+    ///
+    /// Like `get_quest`, this is readable for any existing quest id regardless
+    /// of visibility. `Private` means unlisted, not confidential.
     pub fn get_enrollees(env: Env, quest_id: u32) -> Result<Vec<Address>, Error> {
         Self::load_quest(&env, quest_id)?; // verify exists
         let enrollees = Self::load_enrollees(&env, quest_id);
@@ -323,6 +335,9 @@ impl QuestContract {
     }
 
     /// Check if a user is enrolled in a quest.
+    ///
+    /// Visibility does not restrict this check; callers that know the quest id
+    /// can query enrollment state directly.
     pub fn is_enrollee(env: Env, quest_id: u32, user: Address) -> Result<bool, Error> {
         Self::load_quest(&env, quest_id)?;
         let enrollees = Self::load_enrollees(&env, quest_id);
@@ -357,6 +372,9 @@ impl QuestContract {
     }
 
     /// Set visibility of a quest. Owner only.
+    ///
+    /// This only controls whether the quest appears in public discovery lists.
+    /// It does not provide on-chain confidentiality.
     pub fn set_visibility(env: Env, quest_id: u32, visibility: Visibility) -> Result<(), Error> {
         let mut quest = Self::load_quest(&env, quest_id)?;
         quest.owner.require_auth();

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -469,6 +469,23 @@ fn test_private_quest_not_in_public_listings() {
     assert_eq!(ws.visibility, Visibility::Private);
 }
 
+#[test]
+fn test_private_quest_remains_directly_queryable_by_id() {
+    let (env, client, owner, token) = setup();
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let enrollee = Address::generate(&env);
+
+    client.add_enrollee(&quest_id, &enrollee);
+
+    let quest = client.get_quest(&quest_id);
+    let enrollees = client.get_enrollees(&quest_id);
+
+    assert_eq!(quest.visibility, Visibility::Private);
+    assert_eq!(enrollees.len(), 1);
+    assert_eq!(enrollees.get(0).unwrap(), enrollee);
+    assert!(client.is_enrollee(&quest_id, &enrollee));
+}
+
 // --- Edge case tests ---
 
 #[test]

--- a/frontend/src/lib/contracts/rewards.ts
+++ b/frontend/src/lib/contracts/rewards.ts
@@ -1,61 +1,60 @@
-import { 
-  Address, 
-  Contract, 
-  nativeToScVal, 
-  scValToNative, 
+import {
+  Address,
+  Contract,
+  nativeToScVal,
+  scValToNative,
   xdr,
   TransactionBuilder,
   Keypair,
-  Account
-} from "@stellar/stellar-sdk";
-import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client";
+  Account,
+} from "@stellar/stellar-sdk"
+import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client"
 
-const CONTRACT_ID = import.meta.env.VITE_REWARDS_CONTRACT_ID || "";
+const CONTRACT_ID = import.meta.env.VITE_REWARDS_CONTRACT_ID || ""
 
 export class RewardsClient {
-  private contract: Contract;
+  private contract: Contract
 
   constructor() {
-    this.contract = new Contract(CONTRACT_ID);
+    this.contract = new Contract(CONTRACT_ID)
   }
 
   // --- Read Operations ---
 
   async getPoolBalance(questId: number): Promise<bigint> {
     const result = await this.invokeRead("get_pool_balance", [
-      nativeToScVal(questId, { type: "u32" })
-    ]);
-    return result ? BigInt(result) : 0n;
+      nativeToScVal(questId, { type: "u32" }),
+    ])
+    return result ? BigInt(result) : 0n
   }
 
-  async getUserEarnings(user: string): Promise<bigint> {
-    const result = await this.invokeRead("get_user_earnings", [
-      new Address(user).toScVal()
-    ]);
-    return result ? BigInt(result) : 0n;
+  async getUserEarnings(user: string): Promise<bigint | null> {
+    if (!CONTRACT_ID) {
+      return null
+    }
+    const result = await this.invokeRead("get_user_earnings", [new Address(user).toScVal()])
+    return result === null ? null : BigInt(result)
   }
 
   async getTotalDistributed(): Promise<bigint> {
-    const result = await this.invokeRead("get_total_distributed", []);
-    return result ? BigInt(result) : 0n;
+    const result = await this.invokeRead("get_total_distributed", [])
+    return result ? BigInt(result) : 0n
   }
 
   // --- Write Operations ---
 
   async initialize(owner: string, tokenAddr: string) {
-    const tx = await this.buildTx(owner, "initialize", [
-       new Address(tokenAddr).toScVal()
-    ]);
-    return signAndSubmit(tx);
+    const tx = await this.buildTx(owner, "initialize", [new Address(tokenAddr).toScVal()])
+    return signAndSubmit(tx)
   }
 
   async fundQuest(funder: string, questId: number, amount: bigint) {
     const tx = await this.buildTx(funder, "fund_quest", [
       new Address(funder).toScVal(),
       nativeToScVal(questId, { type: "u32" }),
-      nativeToScVal(amount, { type: "i128" })
-    ]);
-    return signAndSubmit(tx);
+      nativeToScVal(amount, { type: "i128" }),
+    ])
+    return signAndSubmit(tx)
   }
 
   async distributeReward(authority: string, questId: number, enrollee: string, amount: bigint) {
@@ -63,50 +62,50 @@ export class RewardsClient {
       new Address(authority).toScVal(),
       nativeToScVal(questId, { type: "u32" }),
       new Address(enrollee).toScVal(),
-      nativeToScVal(amount, { type: "i128" })
-    ]);
-    return signAndSubmit(tx);
+      nativeToScVal(amount, { type: "i128" }),
+    ])
+    return signAndSubmit(tx)
   }
 
   // --- Private Helpers ---
 
   private async invokeRead(method: string, args: xdr.ScVal[]) {
     try {
-      const randomKP = Keypair.random();
-      const account = new Account(randomKP.publicKey(), "0");
+      const randomKP = Keypair.random()
+      const account = new Account(randomKP.publicKey(), "0")
 
       const tx = new TransactionBuilder(account, {
         fee: "100",
-        networkPassphrase: NETWORK_PASSPHRASE
+        networkPassphrase: NETWORK_PASSPHRASE,
       })
-      .addOperation(this.contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build()
 
-      const response = await server.simulateTransaction(tx);
-      
+      const response = await server.simulateTransaction(tx)
+
       if (response && "result" in response && response.result) {
-         return scValToNative(response.result.retval);
+        return scValToNative(response.result.retval)
       }
     } catch (e) {
-      console.error(`Read error ${method}:`, e);
+      console.error(`Read error ${method}:`, e)
     }
-    return null;
+    return null
   }
 
   private async buildTx(source: string, method: string, args: xdr.ScVal[]) {
-     const account = await server.getAccount(source);
-     
-     const tx = new TransactionBuilder(account, {
-       fee: "100",
-       networkPassphrase: NETWORK_PASSPHRASE
-     })
-     .addOperation(this.contract.call(method, ...args))
-     .setTimeout(30)
-     .build();
-     
-     return await server.prepareTransaction(tx);
+    const account = await server.getAccount(source)
+
+    const tx = new TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(this.contract.call(method, ...args))
+      .setTimeout(30)
+      .build()
+
+    return await server.prepareTransaction(tx)
   }
 }
 
-export const rewardsClient = new RewardsClient();
+export const rewardsClient = new RewardsClient()

--- a/frontend/src/pages/create-quest.tsx
+++ b/frontend/src/pages/create-quest.tsx
@@ -709,6 +709,10 @@ export function CreateQuest() {
         <p className="text-muted-foreground mt-1 text-sm">
           Set up milestones and fund the reward pool to incentivize learners.
         </p>
+        <p className="text-muted-foreground mt-2 max-w-2xl text-xs font-bold">
+          Note: quest visibility on Stellar is discovery-only. Even quests marked private remain
+          readable on-chain by quest id, so do not put confidential data in quest metadata.
+        </p>
       </div>
 
       {/* Step indicator */}

--- a/frontend/src/pages/profile.test.tsx
+++ b/frontend/src/pages/profile.test.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { Profile } from "./profile"
+
+vi.mock("@/hooks/use-wallet", () => ({
+  useWallet: vi.fn(),
+}))
+
+vi.mock("@/lib/contracts/rewards", () => ({
+  rewardsClient: {
+    getUserEarnings: vi.fn(),
+  },
+}))
+
+import { useWallet } from "@/hooks/use-wallet"
+import { rewardsClient } from "@/lib/contracts/rewards"
+
+const mockUseWallet = vi.mocked(useWallet)
+const mockGetUserEarnings = vi.mocked(rewardsClient.getUserEarnings)
+
+describe("Profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("loads the aggregate earnings total from the rewards contract and shows a history placeholder", async () => {
+    mockUseWallet.mockReturnValue({
+      connected: true,
+      connect: vi.fn(),
+      address: "GABC1234567890XYZ",
+    } as ReturnType<typeof useWallet>)
+    mockGetUserEarnings.mockResolvedValue(750n)
+
+    render(<Profile />)
+
+    await waitFor(() => {
+      expect(mockGetUserEarnings).toHaveBeenCalledWith("GABC1234567890XYZ")
+    })
+
+    expect(screen.getByText("750")).toBeTruthy()
+    expect(screen.getByText("USDC earned on-chain")).toBeTruthy()
+    expect(screen.getByText("Aggregate total only")).toBeTruthy()
+    expect(
+      screen.getByText(
+        /per-milestone payout history is not indexable from the current on-chain api yet/i
+      )
+    ).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,11 +1,21 @@
-import { Wallet, Coins, TrendingUp, Trophy, Sparkles, Copy, Check } from "lucide-react"
-import { useState } from "react"
+import {
+  Wallet,
+  Coins,
+  TrendingUp,
+  Trophy,
+  Sparkles,
+  Copy,
+  Check,
+  Loader2,
+  AlertCircle,
+} from "lucide-react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { useWallet } from "@/hooks/use-wallet"
-import { MOCK_USER_STATS } from "@/lib/mock-data"
 import { formatTokens } from "@/lib/utils"
+import { rewardsClient } from "@/lib/contracts/rewards"
 
 /* ─── Generated Avatar from wallet address ─── */
 
@@ -28,8 +38,56 @@ function WalletAvatar({ address }: { address: string }) {
 
 export function Profile() {
   const { connected, connect, address } = useWallet()
-  const stats = MOCK_USER_STATS
   const [copied, setCopied] = useState(false)
+  const [totalEarned, setTotalEarned] = useState<bigint | null>(0n)
+  const [earningsLoading, setEarningsLoading] = useState(false)
+  const [earningsError, setEarningsError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadEarnings() {
+      if (!connected || !address) {
+        setTotalEarned(0n)
+        setEarningsLoading(false)
+        setEarningsError(null)
+        return
+      }
+
+      setEarningsLoading(true)
+      setEarningsError(null)
+
+      try {
+        const earnings = await rewardsClient.getUserEarnings(address)
+        if (cancelled) return
+
+        if (earnings === null) {
+          setTotalEarned(null)
+          setEarningsError(
+            "On-chain earnings are unavailable until the rewards contract is configured."
+          )
+        } else {
+          setTotalEarned(earnings)
+        }
+      } catch (error) {
+        if (cancelled) return
+        setTotalEarned(null)
+        setEarningsError(
+          error instanceof Error ? error.message : "Failed to load on-chain earnings."
+        )
+      } finally {
+        if (!cancelled) {
+          setEarningsLoading(false)
+        }
+      }
+    }
+
+    void loadEarnings()
+
+    return () => {
+      cancelled = true
+    }
+  }, [address, connected])
 
   const handleCopy = () => {
     if (address) {
@@ -38,6 +96,13 @@ export function Profile() {
       setTimeout(() => setCopied(false), 2000)
     }
   }
+
+  const formattedEarned =
+    totalEarned === null
+      ? "Unavailable"
+      : totalEarned > BigInt(Number.MAX_SAFE_INTEGER)
+        ? totalEarned.toString()
+        : formatTokens(Number(totalEarned))
 
   if (!connected) {
     return (
@@ -112,33 +177,6 @@ export function Profile() {
     )
   }
 
-  const earnings = [
-    {
-      milestone: "Hello World",
-      quest: "Learn to Code with Alex",
-      amount: 50,
-      date: "2 days ago",
-    },
-    {
-      milestone: "Build a CLI Tool",
-      quest: "Learn to Code with Alex",
-      amount: 100,
-      date: "5 days ago",
-    },
-    {
-      milestone: "Set up Stellar CLI",
-      quest: "Stellar Dev Bootcamp",
-      amount: 100,
-      date: "1 week ago",
-    },
-    {
-      milestone: "First Soroban Contract",
-      quest: "Stellar Dev Bootcamp",
-      amount: 200,
-      date: "2 weeks ago",
-    },
-  ]
-
   return (
     <div className="relative mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <div className="bg-grid-dots pointer-events-none absolute inset-0 opacity-30" />
@@ -193,12 +231,16 @@ export function Profile() {
               <div className="sm:mt-6">
                 <div className="bg-primary border-border border-2 px-5 py-3 shadow-[3px_3px_0_var(--color-border)]">
                   <div className="flex items-center gap-2">
-                    <TrendingUp className="h-4 w-4" />
-                    <p className="text-2xl font-black tabular-nums">
-                      {formatTokens(stats.totalEarned)}
-                    </p>
+                    {earningsLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <TrendingUp className="h-4 w-4" />
+                    )}
+                    <p className="text-2xl font-black tabular-nums">{formattedEarned}</p>
                   </div>
-                  <p className="text-xs font-bold">USDC earned</p>
+                  <p className="text-xs font-bold">
+                    {earningsLoading ? "Loading on-chain earnings" : "USDC earned on-chain"}
+                  </p>
                 </div>
               </div>
             </div>
@@ -210,50 +252,67 @@ export function Profile() {
       <div>
         <div className="mb-5 flex items-center justify-between">
           <h2 className="text-xl font-black">Earnings History</h2>
-          <span className="text-muted-foreground text-sm font-bold">
-            {earnings.length} transactions
-          </span>
+          <span className="text-muted-foreground text-sm font-bold">Aggregate total only</span>
         </div>
 
         <div className="space-y-4">
-          {earnings.length === 0 ? (
+          {earningsLoading ? (
+            <Card className="animate-fade-in-up">
+              <CardContent className="flex flex-col items-center py-12 text-center">
+                <div className="bg-primary border-border mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
+                <h3 className="mb-2 font-black">Loading on-chain earnings</h3>
+                <p className="text-muted-foreground text-sm">
+                  Fetching your aggregate rewards from the rewards contract.
+                </p>
+              </CardContent>
+            </Card>
+          ) : earningsError ? (
+            <Card className="animate-fade-in-up">
+              <CardContent className="flex flex-col items-center py-12 text-center">
+                <div className="bg-destructive/10 border-destructive mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
+                  <AlertCircle className="text-destructive h-6 w-6" />
+                </div>
+                <h3 className="mb-2 font-black">On-chain earnings unavailable</h3>
+                <p className="text-muted-foreground max-w-md text-sm">{earningsError}</p>
+              </CardContent>
+            </Card>
+          ) : totalEarned === 0n ? (
             <Card className="animate-fade-in-up">
               <CardContent className="flex flex-col items-center py-12 text-center">
                 <div className="bg-primary border-border mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
                   <Coins className="h-6 w-6" />
                 </div>
-                <h3 className="mb-2 font-black">No earnings yet</h3>
+                <h3 className="mb-2 font-black">No on-chain earnings yet</h3>
                 <p className="text-muted-foreground text-sm">
-                  Complete milestones to start earning USDC.
+                  Your wallet has not received rewards from the rewards contract yet.
                 </p>
               </CardContent>
             </Card>
           ) : (
-            earnings.map((e, i) => (
-              <div key={i} className={`animate-fade-in-up stagger-${i + 1}`}>
-                <Card className="neo-lift group hover:shadow-[7px_7px_0_var(--color-border)] active:shadow-[2px_2px_0_var(--color-border)]">
-                  <CardContent className="p-5">
-                    <div className="flex items-center justify-between gap-4">
-                      <div className="flex items-center gap-4">
-                        <div className="bg-success/10 border-border group-hover:bg-success/20 flex h-12 w-12 shrink-0 items-center justify-center border-2 shadow-[2px_2px_0_var(--color-border)] transition-colors">
-                          <Coins className="text-success h-5 w-5" />
-                        </div>
-                        <div>
-                          <p className="text-sm font-black">{e.milestone}</p>
-                          <p className="text-muted-foreground text-xs font-bold">{e.quest}</p>
-                        </div>
-                      </div>
-                      <div className="flex flex-col items-end gap-1 text-right">
-                        <Badge variant="success" className="tabular-nums">
-                          +{e.amount} USDC
-                        </Badge>
-                        <p className="text-muted-foreground text-xs font-bold">{e.date}</p>
-                      </div>
+            <Card className="animate-fade-in-up">
+              <CardContent className="py-10">
+                <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex items-start gap-4">
+                    <div className="bg-success/10 border-border flex h-12 w-12 shrink-0 items-center justify-center border-2 shadow-[2px_2px_0_var(--color-border)]">
+                      <Coins className="text-success h-5 w-5" />
                     </div>
-                  </CardContent>
-                </Card>
-              </div>
-            ))
+                    <div>
+                      <p className="text-sm font-black">On-chain earnings total</p>
+                      <p className="text-muted-foreground mt-1 max-w-md text-sm">
+                        The rewards contract exposes your aggregate earnings by wallet address.
+                        Per-milestone payout history is not indexable from the current on-chain API
+                        yet, so this page does not fabricate transactions.
+                      </p>
+                    </div>
+                  </div>
+                  <Badge variant="success" className="self-start tabular-nums">
+                    +{formattedEarned} USDC
+                  </Badge>
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #176
Closes #203
Closes #262

## Changes
- clarified the quest privacy model in contract docs and tests:
  - `Visibility::Private` only removes quests from public discovery helpers
  - direct reads by quest id remain queryable on-chain
- added a regression test proving private quests are still directly queryable by id
- updated README to match the current repo state instead of overstating delivery status
- removed the stale fixed test-count claim from the getting-started section
- rewrote roadmap/integration copy to distinguish implemented contracts from still-mocked frontend flows
- replaced the profile page’s hard-coded earnings total/history with a real `get_user_earnings` query for the connected wallet
- changed the profile history section to an explicit placeholder state because per-payout history is not currently indexable from the rewards contract
- added a frontend test covering the on-chain earnings/placeholder behavior

## Testing
- `cargo test --workspace`
- `npm test -- --run src/pages/profile.test.tsx src/hooks/use-wallet.test.ts`
- `npm run build`

## Notes
- the current contract workspace passes locally with 106 tests
- profile earnings now use the real aggregate on-chain total; detailed history is intentionally not fabricated
