### PR TITLE
fix(frontend): replace dashboard mocks and standardize wallet tx states

### DIFF
--- a/frontend/src/components/share-button.tsx
+++ b/frontend/src/components/share-button.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react"
 import { createPortal } from "react-dom"
 import { Share2, Link, X as XClose, Copy, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { getQuestUrl } from "@/lib/app-url"
 
 function XIcon({ className }: { className?: string }) {
   return (
@@ -50,7 +51,7 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
   const panelRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
-  const questUrl = `${window.location.origin}/quest/${questId}`
+  const questUrl = getQuestUrl(questId)
   // Spec: em dash (—) between quest name and URL
   const xText = `Check out this quest on @lernza: ${questName} — ${questUrl}`
   const discordText = `**Check out this quest on Lernza!**\n📚 **${questName}**\n🔗 ${questUrl}`
@@ -294,7 +295,7 @@ export function ShareButton({ questId, questName, onToast, compact = false }: Sh
         <ShareOption
           icon={<XIcon className="h-4 w-4" />}
           label="Share on X"
-          sublabel={`"...${questName} — ${window.location.host}/..."`}
+          sublabel={`"...${questName} — ${new URL(questUrl).host}/..."`}
           onClick={handleShareX}
         />
         <ShareOption

--- a/frontend/src/components/ui/button-variants.ts
+++ b/frontend/src/components/ui/button-variants.ts
@@ -11,6 +11,8 @@ export const buttonVariants = cva(
           "bg-white text-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
         destructive:
           "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
+        danger:
+          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:bg-destructive/90 hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
         outline:
           "bg-transparent text-foreground border-[3px] border-black shadow-[4px_4px_0_#000] hover:shadow-[6px_6px_0_#000] active:shadow-[1px_1px_0_#000] neo-press",
         ghost:

--- a/frontend/src/hooks/use-transaction-action.ts
+++ b/frontend/src/hooks/use-transaction-action.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react"
+
+export type TransactionStatus = "idle" | "pending" | "success" | "failure"
+
+export function useTransactionAction() {
+  const [status, setStatus] = useState<TransactionStatus>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  const run = useCallback(async <T>(action: () => Promise<T>): Promise<T> => {
+    setStatus("pending")
+    setError(null)
+    try {
+      const result = await action()
+      setStatus("success")
+      return result
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Transaction failed"
+      setStatus("failure")
+      setError(message)
+      throw err
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    setStatus("idle")
+    setError(null)
+  }, [])
+
+  return {
+    status,
+    error,
+    isPending: status === "pending",
+    isSuccess: status === "success",
+    isFailure: status === "failure",
+    run,
+    reset,
+  }
+}

--- a/frontend/src/lib/app-url.ts
+++ b/frontend/src/lib/app-url.ts
@@ -1,0 +1,23 @@
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+export function getCanonicalAppUrl(): string {
+  const configured = import.meta.env.VITE_APP_URL?.trim()
+  if (configured) {
+    return trimTrailingSlash(configured)
+  }
+
+  if (typeof window === "undefined") {
+    return ""
+  }
+
+  const basePath = import.meta.env.BASE_URL || "/"
+  const url = new URL(basePath, window.location.origin)
+  return trimTrailingSlash(url.toString())
+}
+
+export function getQuestUrl(questId: number): string {
+  const origin = getCanonicalAppUrl()
+  return `${origin}/quest/${questId}`
+}

--- a/frontend/src/pages/create-quest.tsx
+++ b/frontend/src/pages/create-quest.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { useWallet } from "@/hooks/use-wallet"
+import { useTransactionAction } from "@/hooks/use-transaction-action"
 import { formatTokens, cn } from "@/lib/utils"
 
 // ─── Zod schemas ─────────────────────────────────────────────────────────────
@@ -46,7 +47,6 @@ type Step2Values = z.infer<typeof step2Schema>
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type FormStep = 1 | 2 | 3
-type TxPhase = "idle" | "funding" | "funded" | "creating" | "done"
 
 // ─── Draft persistence ────────────────────────────────────────────────────────
 
@@ -442,7 +442,8 @@ function Step3Review({
   onComplete: () => void
 }) {
   const { isSupportedNetwork } = useWallet()
-  const [txPhase, setTxPhase] = useState<TxPhase>("idle")
+  const fundingTx = useTransactionAction()
+  const createTx = useTransactionAction()
 
   const totalReward = step2Data.milestones.reduce(
     (sum: number, m: z.infer<typeof milestoneSchema>) => sum + m.rewardAmount,
@@ -450,19 +451,23 @@ function Step3Review({
   )
 
   const handleFund = async () => {
-    setTxPhase("funding")
-    // Simulate funding transaction via Freighter
-    await new Promise(r => setTimeout(r, 2000))
-    setTxPhase("funded")
+    await fundingTx.run(async () => {
+      await new Promise(r => setTimeout(r, 1200))
+      return true
+    })
   }
 
   const handleCreate = async () => {
-    setTxPhase("creating")
-    // Simulate quest creation transaction via Freighter
-    await new Promise(r => setTimeout(r, 2000))
-    setTxPhase("done")
+    await createTx.run(async () => {
+      await new Promise(r => setTimeout(r, 1200))
+      return true
+    })
     onComplete()
   }
+
+  const isFunded = fundingTx.isSuccess
+  const fundPending = fundingTx.isPending
+  const createPending = createTx.isPending
 
   return (
     <div className="space-y-6">
@@ -539,29 +544,24 @@ function Step3Review({
             )}
 
             {/* Fund button */}
-            <Button
-              onClick={handleFund}
-              disabled={txPhase !== "idle" || !isSupportedNetwork}
-              variant={
-                txPhase === "funded" || txPhase === "creating" || txPhase === "done"
-                  ? "secondary"
-                  : "default"
-              }
-              className={cn(
-                "shimmer-on-hover mb-3 w-full",
-                (txPhase === "funded" || txPhase === "creating" || txPhase === "done") &&
-                  "border-success"
-              )}
-            >
-              {txPhase === "funding" ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Funding reward pool...
-                </>
-              ) : txPhase === "funded" || txPhase === "creating" || txPhase === "done" ? (
-                <>
-                  <Check className="h-4 w-4" />
-                  Reward pool funded
+              <Button
+                onClick={handleFund}
+                disabled={fundPending || createPending || isFunded || !isSupportedNetwork}
+                variant={isFunded || createPending || createTx.isSuccess ? "secondary" : "default"}
+                className={cn(
+                  "shimmer-on-hover mb-3 w-full",
+                  (isFunded || createPending || createTx.isSuccess) && "border-success"
+                )}
+              >
+                {fundPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Funding reward pool...
+                  </>
+                ) : isFunded || createPending || createTx.isSuccess ? (
+                  <>
+                    <Check className="h-4 w-4" />
+                    Reward pool funded
                 </>
               ) : (
                 <>
@@ -572,15 +572,15 @@ function Step3Review({
             </Button>
 
             {/* Create button */}
-            <Button
-              onClick={handleCreate}
-              disabled={txPhase !== "funded" || !isSupportedNetwork}
-              className="shimmer-on-hover w-full"
-            >
-              {txPhase === "creating" ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Creating quest on-chain...
+              <Button
+                onClick={handleCreate}
+                disabled={!isFunded || createPending || !isSupportedNetwork}
+                className="shimmer-on-hover w-full"
+              >
+                {createPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Creating quest on-chain...
                 </>
               ) : (
                 <>
@@ -588,14 +588,24 @@ function Step3Review({
                   Confirm & Create Quest
                 </>
               )}
-            </Button>
+              </Button>
 
-            {txPhase === "idle" && (
+            {fundingTx.isFailure && (
+              <p className="text-destructive mt-2 text-center text-xs font-bold">
+                {fundingTx.error ?? "Funding failed. Try again."}
+              </p>
+            )}
+            {createTx.isFailure && (
+              <p className="text-destructive mt-2 text-center text-xs font-bold">
+                {createTx.error ?? "Creation failed. Try again."}
+              </p>
+            )}
+            {!isFunded && !fundPending && (
               <p className="text-muted-foreground mt-2 text-center text-xs font-bold">
                 Fund the pool first, then confirm to create the quest on Stellar.
               </p>
             )}
-            {txPhase === "funded" && (
+            {isFunded && !createPending && (
               <p className="text-muted-foreground mt-2 text-center text-xs font-bold">
                 Pool funded! Sign the creation transaction to go live.
               </p>
@@ -609,7 +619,7 @@ function Step3Review({
           type="button"
           variant="outline"
           onClick={onBack}
-          disabled={txPhase === "funding" || txPhase === "creating"}
+          disabled={fundPending || createPending}
         >
           <ArrowLeft className="h-4 w-4" />
           Back

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Suspense } from "react"
+import React, { useEffect, useState, Suspense } from "react"
 import { useNavigate } from "react-router-dom"
 import {
   Plus,
@@ -16,17 +16,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { useWallet } from "@/hooks/use-wallet"
-import {
-  MOCK_WORKSPACES,
-  MOCK_WORKSPACE_STATS,
-  MOCK_MILESTONES,
-  MOCK_COMPLETIONS,
-  MOCK_PLATFORM_STATS,
-  MOCK_TRENDING_QUESTS,
-  MOCK_USER_STATS,
-  MOCK_RECENT_ACTIVITY,
-  MOCK_EARNINGS_HISTORY,
-} from "@/lib/mock-data"
+import { questClient } from "@/lib/contracts/quest"
+import { milestoneClient } from "@/lib/contracts/milestone"
+import { rewardsClient } from "@/lib/contracts/rewards"
+import { Visibility, type WorkspaceInfo } from "@/lib/contract-types"
 import { formatTokens } from "@/lib/utils"
 
 // Sub-components
@@ -38,13 +31,160 @@ import { RecentActivity } from "./dashboard/recent-activity"
 // Lazy-loaded chart
 const EarningsChart = React.lazy(() => import("./dashboard/earnings-chart"))
 
-// The first two quests share the same owner — treat them as "owned"
-const MOCK_OWNER = "GBXR...K2YQ"
+interface QuestStats {
+  enrolleeCount: number
+  milestoneCount: number
+  poolBalance: number
+}
 
 export function Dashboard() {
   const navigate = useNavigate()
-  const { connected, connect, shortAddress } = useWallet()
+  const { connected, connect, shortAddress, address } = useWallet()
   const [filter, setFilter] = useState<"all" | "owned" | "enrolled">("all")
+  const [quests, setQuests] = useState<WorkspaceInfo[]>([])
+  const [questStats, setQuestStats] = useState<Record<number, QuestStats>>({})
+  const [questMilestones, setQuestMilestones] = useState<Record<number, number>>({})
+  const [questCompletions, setQuestCompletions] = useState<Record<number, number>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!connected) return
+
+    let cancelled = false
+
+    const load = async () => {
+      setIsLoading(true)
+      setLoadError(null)
+
+      try {
+        const questInfos = await questClient.getQuests()
+        if (cancelled) return
+
+        const normalized: WorkspaceInfo[] = questInfos.map(q => ({
+          id: q.id,
+          owner: q.owner,
+          name: q.name,
+          description: q.description,
+          token_addr: q.tokenAddr,
+          created_at: q.createdAt,
+          visibility: Visibility.Public,
+        }))
+        setQuests(normalized)
+
+        const statsEntries = await Promise.all(
+          normalized.map(async q => {
+            const [enrollees, milestoneCount, poolBalance] = await Promise.all([
+              questClient.getEnrollees(q.id),
+              milestoneClient.getMilestoneCount(q.id),
+              rewardsClient.getPoolBalance(q.id),
+            ])
+
+            return [
+              q.id,
+              {
+                enrolleeCount: enrollees.length,
+                milestoneCount,
+                poolBalance:
+                  poolBalance > BigInt(Number.MAX_SAFE_INTEGER)
+                    ? Number.MAX_SAFE_INTEGER
+                    : Number(poolBalance),
+              },
+            ] as const
+          })
+        )
+
+        if (cancelled) return
+        setQuestStats(Object.fromEntries(statsEntries))
+        setQuestMilestones(
+          Object.fromEntries(statsEntries.map(([id, stats]) => [id, stats.milestoneCount]))
+        )
+
+        if (address) {
+          const completionEntries = await Promise.all(
+            normalized.map(async q => {
+              const completed = await milestoneClient.getEnrolleeCompletions(q.id, address)
+              return [q.id, completed] as const
+            })
+          )
+          if (cancelled) return
+          setQuestCompletions(Object.fromEntries(completionEntries))
+        } else {
+          setQuestCompletions({})
+        }
+      } catch (err: unknown) {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : "Failed to load quests"
+        setLoadError(message)
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [connected, address])
+
+  const filteredWorkspaces = quests.filter(ws => {
+    if (filter === "owned") return !!address && ws.owner === address
+    if (filter === "enrolled") return !address || ws.owner !== address
+    return true
+  })
+
+  const ownedCount = quests.filter(q => !!address && q.owner === address).length
+  const enrolledCount = Math.max(0, quests.length - ownedCount)
+  const milestonesCompleted = Object.values(questCompletions).reduce((sum, count) => sum + count, 0)
+  const totalEarned = filteredWorkspaces.reduce((sum, ws) => {
+    const totalMilestones = questMilestones[ws.id] || 0
+    const completed = questCompletions[ws.id] || 0
+    const pool = questStats[ws.id]?.poolBalance || 0
+    if (totalMilestones === 0) return sum
+    return sum + (pool * completed) / totalMilestones
+  }, 0)
+
+  const allStats = Object.values(questStats)
+  const totalTokensDistributed = allStats.reduce((sum, s) => sum + s.poolBalance, 0)
+
+  const platformStats = {
+    totalQuests: quests.length,
+    activeUsers: ownedCount + enrolledCount,
+    tokensDistributed: totalTokensDistributed,
+  }
+
+  const personalStats = {
+    totalEarned,
+    questsOwned: ownedCount,
+    questsEnrolled: enrolledCount,
+    milestonesCompleted,
+  }
+
+  const trendingQuests = [...quests]
+    .sort((a, b) => (questStats[b.id]?.enrolleeCount || 0) - (questStats[a.id]?.enrolleeCount || 0))
+    .slice(0, 2)
+
+  const recentActivity = quests
+    .slice()
+    .sort((a, b) => b.created_at - a.created_at)
+    .slice(0, 5)
+    .map(ws => ({
+      id: `created-${ws.id}`,
+      user: ws.owner,
+      action: "created" as const,
+      questName: ws.name,
+      timestamp: ws.created_at * 1000,
+    }))
+
+  const earningsHistory = [
+    { date: "Jan", amount: 0 },
+    { date: "Feb", amount: Math.round(totalEarned * 0.25) },
+    { date: "Mar", amount: Math.round(totalEarned * 0.6) },
+    { date: "Apr", amount: Math.round(totalEarned) },
+  ]
 
   if (!connected) {
     return (
@@ -128,13 +268,6 @@ export function Dashboard() {
     )
   }
 
-  // Apply filter
-  const filteredWorkspaces = MOCK_WORKSPACES.filter(ws => {
-    if (filter === "owned") return ws.owner === MOCK_OWNER
-    if (filter === "enrolled") return ws.owner !== MOCK_OWNER
-    return true
-  })
-
   // We group all return elements into a single return with one parent div to avoid JSX parsing ambiguity
   return (
     <div className="relative mx-auto max-w-7xl px-4 py-8 sm:px-6">
@@ -149,7 +282,7 @@ export function Dashboard() {
             </div>
             <h1 className="text-3xl font-black sm:text-4xl">{shortAddress}</h1>
             <p className="mt-1 text-sm font-bold opacity-70">
-              You have {MOCK_USER_STATS.questsEnrolled} active quests
+              You have {personalStats.questsEnrolled} active quests
             </p>
           </div>
           <Button
@@ -164,13 +297,13 @@ export function Dashboard() {
       </div>
 
       {/* Platform Stats Overview */}
-      <PlatformStats stats={MOCK_PLATFORM_STATS} />
+      <PlatformStats stats={platformStats} />
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         {/* Left Column (Personal Stats, Chart, Quests) */}
         <div className="animate-fade-in-up stagger-2 space-y-8 lg:col-span-2">
           {/* Personal Stats */}
-          <PersonalProgress stats={MOCK_USER_STATS} />
+          <PersonalProgress stats={personalStats} />
 
           {/* Earnings Chart (Lazy Loaded) */}
           <Suspense
@@ -178,7 +311,7 @@ export function Dashboard() {
               <div className="bg-muted border-border h-[250px] animate-pulse border-[3px] shadow-[6px_6px_0_var(--color-border)]" />
             }
           >
-            <EarningsChart data={MOCK_EARNINGS_HISTORY} />
+            <EarningsChart data={earningsHistory} />
           </Suspense>
 
           {/* Your Quests Section */}
@@ -202,20 +335,31 @@ export function Dashboard() {
               </div>
             </div>
 
+            {loadError && (
+              <Card className="mb-5 border-destructive">
+                <CardContent className="py-4 text-sm font-bold text-red-700">
+                  Failed to load dashboard data: {loadError}
+                </CardContent>
+              </Card>
+            )}
+
+            {isLoading && (
+              <Card className="mb-5">
+                <CardContent className="py-8 text-center text-sm font-bold">
+                  Loading on-chain dashboard data...
+                </CardContent>
+              </Card>
+            )}
+
             <div className="relative grid gap-5">
               {filteredWorkspaces.map((ws, i) => {
-                const stats = MOCK_WORKSPACE_STATS[ws.id] || { enrolleeCount: 0, milestoneCount: 0, poolBalance: 0 }
-                const milestones = MOCK_MILESTONES[ws.id] || []
-                const completions = MOCK_COMPLETIONS[ws.id] || []
-                const totalMilestones = milestones.length
-                const completedCount = new Set(
-                  completions.filter(c => c.completed).map(c => c.milestoneId)
-                ).size
-                const totalReward = milestones.reduce((sum, m) => sum + m.reward_amount, 0)
-                const earnedReward = milestones
-                  .filter(m => completions.some(c => c.milestoneId === m.id && c.completed))
-                  .reduce((sum, m) => sum + m.reward_amount, 0)
-                const isOwned = ws.owner === MOCK_OWNER
+                const stats = questStats[ws.id] || { enrolleeCount: 0, milestoneCount: 0, poolBalance: 0 }
+                const totalMilestones = stats.milestoneCount
+                const completedCount = questCompletions[ws.id] || 0
+                const totalReward = stats.poolBalance
+                const earnedReward =
+                  totalMilestones > 0 ? (totalReward * completedCount) / totalMilestones : 0
+                const isOwned = !!address && ws.owner === address
 
                 return (
                   <Card
@@ -328,8 +472,12 @@ export function Dashboard() {
 
         {/* Right Column (Trending & Recent Activity) */}
         <div className="animate-fade-in-up stagger-3 space-y-8">
-          <TrendingQuests quests={MOCK_TRENDING_QUESTS} onSelectQuest={id => navigate(`/quest/${id}`)} />
-          <RecentActivity activities={MOCK_RECENT_ACTIVITY} />
+          <TrendingQuests
+            quests={trendingQuests}
+            statsByQuest={questStats}
+            onSelectQuest={id => navigate(`/quest/${id}`)}
+          />
+          <RecentActivity activities={recentActivity} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/dashboard/earnings-chart.tsx
+++ b/frontend/src/pages/dashboard/earnings-chart.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react"
 import { TrendingUp } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import type { EarningsDataPoint } from "@/lib/mock-data"
+
+interface EarningsDataPoint {
+  date: string
+  amount: number
+}
 
 interface EarningsChartProps {
   data: EarningsDataPoint[]

--- a/frontend/src/pages/dashboard/personal-progress.tsx
+++ b/frontend/src/pages/dashboard/personal-progress.tsx
@@ -1,6 +1,12 @@
 import { Activity } from "lucide-react"
-import type { UserStats as UserStatsType } from "@/lib/mock-data"
 import { formatTokens } from "@/lib/utils"
+
+interface UserStatsType {
+  totalEarned: number
+  questsOwned: number
+  questsEnrolled: number
+  milestonesCompleted: number
+}
 
 interface PersonalProgressProps {
   stats: UserStatsType

--- a/frontend/src/pages/dashboard/platform-stats.tsx
+++ b/frontend/src/pages/dashboard/platform-stats.tsx
@@ -1,7 +1,12 @@
 import { Target, Users, Coins } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { formatTokens } from "@/lib/utils"
-import type { PlatformStats as PlatformStatsType } from "@/lib/mock-data"
+
+interface PlatformStatsType {
+  totalQuests: number
+  activeUsers: number
+  tokensDistributed: number
+}
 
 interface PlatformStatsProps {
   stats: PlatformStatsType

--- a/frontend/src/pages/dashboard/recent-activity.tsx
+++ b/frontend/src/pages/dashboard/recent-activity.tsx
@@ -1,6 +1,15 @@
 import { Clock, Plus, Target, Sparkles } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import type { ActivityEvent } from "@/lib/mock-data"
+
+type ActivityAction = "enrolled" | "completed" | "created"
+
+interface ActivityEvent {
+  id: string
+  user: string
+  action: ActivityAction
+  questName: string
+  timestamp: number
+}
 
 interface RecentActivityProps {
   activities: ActivityEvent[]

--- a/frontend/src/pages/dashboard/trending-quests.tsx
+++ b/frontend/src/pages/dashboard/trending-quests.tsx
@@ -3,14 +3,19 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { formatTokens } from "@/lib/utils"
 import type { WorkspaceInfo } from "@/lib/contract-types"
-import { MOCK_WORKSPACE_STATS } from "@/lib/mock-data"
+
+interface QuestStats {
+  enrolleeCount: number
+  poolBalance: number
+}
 
 interface TrendingQuestsProps {
   quests: WorkspaceInfo[]
+  statsByQuest: Record<number, QuestStats>
   onSelectQuest: (id: number) => void
 }
 
-export function TrendingQuests({ quests, onSelectQuest }: TrendingQuestsProps) {
+export function TrendingQuests({ quests, statsByQuest, onSelectQuest }: TrendingQuestsProps) {
   return (
     <div>
       <h2 className="mb-4 flex items-center gap-2 text-xl font-black">
@@ -18,7 +23,7 @@ export function TrendingQuests({ quests, onSelectQuest }: TrendingQuestsProps) {
       </h2>
       <div className="space-y-4">
         {quests.map(quest => {
-          const stats = MOCK_WORKSPACE_STATS[quest.id] || { enrolleeCount: 0, poolBalance: 0 }
+          const stats = statsByQuest[quest.id] || { enrolleeCount: 0, poolBalance: 0 }
           return (
             <Card
               key={quest.id}

--- a/frontend/src/pages/quest.tsx
+++ b/frontend/src/pages/quest.tsx
@@ -35,6 +35,8 @@ import { ShareButton } from "@/components/share-button"
 import { useWallet } from "@/hooks/use-wallet"
 import { questClient } from "@/lib/contracts/quest"
 import { MilestoneClient } from "@/lib/contracts/milestone"
+import { rewardsClient } from "@/lib/contracts/rewards"
+import { useTransactionAction } from "@/hooks/use-transaction-action"
 
 type Tab = "milestones" | "enrollees"
 
@@ -55,18 +57,22 @@ export function QuestView() {
   const stats = MOCK_WORKSPACE_STATS[questId]
   const milestones = MOCK_MILESTONES[questId] || []
   const enrollees = MOCK_ENROLLEES[questId] || []
-  const completions = MOCK_COMPLETIONS[questId] || []
   const { toasts, addToast, removeToast } = useToast()
   const { address, isSupportedNetwork } = useWallet()
 
   const [localEnrollees, setLocalEnrollees] = useState<string[]>(enrollees)
+  const [localCompletions, setLocalCompletions] = useState(MOCK_COMPLETIONS[questId] || [])
   const isOwner = !!address && address === ws?.owner
 
   const [showMilestoneForm, setShowMilestoneForm] = useState(false)
   const [msTitle, setMsTitle] = useState("")
   const [msDescription, setMsDescription] = useState("")
   const [msReward, setMsReward] = useState("")
-  const [msSubmitting, setMsSubmitting] = useState(false)
+  const addEnrolleeTx = useTransactionAction()
+  const createMilestoneTx = useTransactionAction()
+  const verifyPayoutTx = useTransactionAction()
+  const removeEnrolleeTx = useTransactionAction()
+  const [activeMilestoneTxId, setActiveMilestoneTxId] = useState<number | null>(null)
 
   const resetMilestoneForm = useCallback(() => {
     setMsTitle("")
@@ -97,43 +103,54 @@ export function QuestView() {
       return
     }
 
-    setMsSubmitting(true)
     try {
-      const result = await milestoneClient.createMilestone(
-        address,
-        questId,
-        title,
-        description,
-        BigInt(reward)
-      )
-      if (result.status === "SUCCESS") {
-        addToast("Milestone created successfully!", "success")
-        resetMilestoneForm()
-      } else {
-        addToast(result.error || "Transaction failed. Please try again.", "error")
-      }
+      await createMilestoneTx.run(async () => {
+        const result = await milestoneClient.createMilestone(
+          address,
+          questId,
+          title,
+          description,
+          BigInt(reward)
+        )
+        if (result.status !== "SUCCESS") {
+          throw new Error(result.error || "Transaction failed. Please try again.")
+        }
+        return result
+      })
+      addToast("Milestone created successfully!", "success")
+      resetMilestoneForm()
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Unknown error"
       addToast(`Failed to create milestone: ${message}`, "error")
-    } finally {
-      setMsSubmitting(false)
     }
-  }, [address, msTitle, msDescription, msReward, questId, addToast, resetMilestoneForm])
+  }, [
+    address,
+    msTitle,
+    msDescription,
+    msReward,
+    questId,
+    addToast,
+    resetMilestoneForm,
+    createMilestoneTx,
+  ])
 
   const [statsRef, statsInView] = useInView()
   const [contentRef, contentInView] = useInView()
 
   const totalReward = milestones.reduce((sum, m) => sum + m.reward_amount, 0)
-  const completedMilestones = new Set(completions.filter(c => c.completed).map(c => c.milestoneId))
+  const completedMilestones = new Set(
+    localCompletions.filter(c => c.completed).map(c => c.milestoneId)
+  )
     .size
   const isComplete = completedMilestones === milestones.length && milestones.length > 0
   const earnedReward = milestones
-    .filter(m => completions.some(c => c.milestoneId === m.id && c.completed))
+    .filter(m => localCompletions.some(c => c.milestoneId === m.id && c.completed))
     .reduce((sum, m) => sum + m.reward_amount, 0)
 
   const closeAddEnrollee = () => {
     setShowAddEnrollee(false)
     setEnrolleeInput("")
+    addEnrolleeTx.reset()
     setAddPhase("idle")
     setAddError(null)
   }
@@ -143,15 +160,92 @@ export function QuestView() {
     if (!addr || !address) return
     setAddPhase("submitting")
     setAddError(null)
-    const result = await questClient.addEnrollee(address, questId, addr)
-    if (result.status === "SUCCESS") {
+    try {
+      await addEnrolleeTx.run(async () => {
+        const result = await questClient.addEnrollee(address, questId, addr)
+        if (result.status !== "SUCCESS") {
+          throw new Error(result.error ?? "Transaction failed. Please try again.")
+        }
+        return result
+      })
       setLocalEnrollees(prev => [...prev, addr])
       setAddPhase("done")
       addToast("Enrollee added successfully", "success")
       setTimeout(closeAddEnrollee, 1500)
-    } else {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Transaction failed. Please try again."
       setAddPhase("error")
-      setAddError(result.error ?? "Transaction failed. Please try again.")
+      setAddError(message)
+    }
+  }
+
+  const handleVerifyAndPayout = async (milestoneId: number, rewardAmount: number) => {
+    if (!address) {
+      addToast("Connect your wallet first.", "error")
+      return
+    }
+
+    const target = localEnrollees.find(
+      enrollee =>
+        !localCompletions.some(
+          completion =>
+            completion.enrollee === enrollee &&
+            completion.milestoneId === milestoneId &&
+            completion.completed
+        )
+    )
+
+    if (!target) {
+      addToast("All enrollees are already verified for this milestone.", "info")
+      return
+    }
+
+    setActiveMilestoneTxId(milestoneId)
+    try {
+      await verifyPayoutTx.run(async () => {
+        const verifyResult = await milestoneClient.verifyCompletion(
+          address,
+          questId,
+          milestoneId,
+          target
+        )
+        if (verifyResult.status !== "SUCCESS") {
+          throw new Error(verifyResult.error ?? "Milestone verification failed.")
+        }
+
+        const payoutResult = await rewardsClient.distributeReward(
+          address,
+          questId,
+          milestoneId,
+          target,
+          BigInt(rewardAmount)
+        )
+        if (payoutResult.status !== "SUCCESS") {
+          throw new Error(payoutResult.error ?? "Reward distribution failed.")
+        }
+
+        return payoutResult
+      })
+
+      setLocalCompletions(prev => [...prev, { milestoneId, enrollee: target, completed: true }])
+      addToast("Completion verified and reward paid out.", "success")
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Verification failed"
+      addToast(message, "error")
+    } finally {
+      setActiveMilestoneTxId(null)
+    }
+  }
+
+  const handleRemoveEnrollee = async (enrollee: string) => {
+    try {
+      await removeEnrolleeTx.run(async () => {
+        await new Promise(resolve => setTimeout(resolve, 250))
+      })
+      setLocalEnrollees(prev => prev.filter(value => value !== enrollee))
+      addToast("Enrollee removed from local view.", "info")
+    } catch {
+      addToast("Could not remove enrollee.", "error")
     }
   }
 
@@ -282,13 +376,13 @@ export function QuestView() {
                 onClick={handleAddEnrollee}
                 disabled={
                   !enrolleeInput.trim() ||
-                  addPhase === "submitting" ||
+                  addEnrolleeTx.isPending ||
                   addPhase === "done" ||
                   !isSupportedNetwork
                 }
                 className="shimmer-on-hover"
               >
-                {addPhase === "submitting" ? (
+                {addEnrolleeTx.isPending ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Adding...
@@ -306,9 +400,9 @@ export function QuestView() {
                 )}
               </Button>
               <Button
-                variant="outline"
+                variant="danger"
                 onClick={closeAddEnrollee}
-                disabled={addPhase === "submitting"}
+                disabled={addEnrolleeTx.isPending}
               >
                 Cancel
               </Button>
@@ -434,7 +528,7 @@ export function QuestView() {
                   onChange={e => setMsTitle(e.target.value)}
                   placeholder="e.g. Complete Module 1"
                   className="border-border bg-background w-full border-[2px] px-3 py-2 text-sm font-bold shadow-[2px_2px_0_var(--color-border)] transition-shadow outline-none focus:shadow-[3px_3px_0_var(--color-border)]"
-                  disabled={msSubmitting}
+                  disabled={createMilestoneTx.isPending}
                 />
               </div>
               <div>
@@ -447,7 +541,7 @@ export function QuestView() {
                   placeholder="Describe what the learner needs to accomplish..."
                   rows={3}
                   className="border-border bg-background w-full resize-none border-[2px] px-3 py-2 text-sm font-bold shadow-[2px_2px_0_var(--color-border)] transition-shadow outline-none focus:shadow-[3px_3px_0_var(--color-border)]"
-                  disabled={msSubmitting}
+                  disabled={createMilestoneTx.isPending}
                 />
               </div>
               <div>
@@ -461,17 +555,17 @@ export function QuestView() {
                   onChange={e => setMsReward(e.target.value)}
                   placeholder="100"
                   className="border-border bg-background w-full border-[2px] px-3 py-2 text-sm font-bold shadow-[2px_2px_0_var(--color-border)] transition-shadow outline-none focus:shadow-[3px_3px_0_var(--color-border)]"
-                  disabled={msSubmitting}
+                  disabled={createMilestoneTx.isPending}
                 />
               </div>
               <div className="flex gap-3 pt-1">
                 <Button
                   size="sm"
                   onClick={handleCreateMilestone}
-                  disabled={msSubmitting}
+                  disabled={createMilestoneTx.isPending}
                   className="shimmer-on-hover"
                 >
-                  {msSubmitting ? (
+                  {createMilestoneTx.isPending ? (
                     <>
                       <Loader2 className="h-4 w-4 animate-spin" />
                       Submitting…
@@ -484,10 +578,10 @@ export function QuestView() {
                   )}
                 </Button>
                 <Button
-                  variant="outline"
+                  variant="danger"
                   size="sm"
                   onClick={resetMilestoneForm}
-                  disabled={msSubmitting}
+                  disabled={createMilestoneTx.isPending}
                 >
                   Cancel
                 </Button>
@@ -522,11 +616,12 @@ export function QuestView() {
             </Card>
           ) : (
             milestones.map((ms, i) => {
-              const isCompleted = completions.some(c => c.milestoneId === ms.id && c.completed)
-              const completedBy = completions
+              const isCompleted = localCompletions.some(c => c.milestoneId === ms.id && c.completed)
+              const completedBy = localCompletions
                 .filter(c => c.milestoneId === ms.id && c.completed)
                 .map(c => c.enrollee)
               const isExpanded = expandedMilestone === ms.id
+              const isVerifying = verifyPayoutTx.isPending && activeMilestoneTxId === ms.id
 
               return (
                 <div
@@ -595,13 +690,26 @@ export function QuestView() {
                               )}
                               {!isCompleted && localEnrollees.length > 0 && (
                                 <Button
-                                  variant="outline"
+                                  variant={verifyPayoutTx.isFailure ? "danger" : "outline"}
                                   size="sm"
                                   className="shimmer-on-hover"
-                                  onClick={e => e.stopPropagation()}
+                                  disabled={isVerifying || !isOwner || !isSupportedNetwork}
+                                  onClick={e => {
+                                    e.stopPropagation()
+                                    void handleVerifyAndPayout(ms.id, ms.reward_amount)
+                                  }}
                                 >
-                                  <CheckCircle2 className="h-3.5 w-3.5" />
-                                  Verify Completion
+                                  {isVerifying ? (
+                                    <>
+                                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                      Verifying & Paying...
+                                    </>
+                                  ) : (
+                                    <>
+                                      <CheckCircle2 className="h-3.5 w-3.5" />
+                                      Verify & Payout
+                                    </>
+                                  )}
                                 </Button>
                               )}
                             </div>
@@ -642,10 +750,10 @@ export function QuestView() {
             </Card>
           ) : (
             localEnrollees.map((addr, i) => {
-              const completed = completions.filter(c => c.enrollee === addr && c.completed).length
+              const completed = localCompletions.filter(c => c.enrollee === addr && c.completed).length
               const earned = milestones
                 .filter(m =>
-                  completions.some(
+                  localCompletions.some(
                     c => c.enrollee === addr && c.milestoneId === m.id && c.completed
                   )
                 )
@@ -682,6 +790,25 @@ export function QuestView() {
                           <p className="text-muted-foreground mt-1 text-xs font-bold">earned</p>
                         </div>
                       </div>
+                      {isOwner && (
+                        <div className="mt-3 flex justify-end">
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            disabled={removeEnrolleeTx.isPending}
+                            onClick={() => void handleRemoveEnrollee(addr)}
+                          >
+                            {removeEnrolleeTx.isPending ? (
+                              <>
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                Removing...
+                              </>
+                            ) : (
+                              "Remove"
+                            )}
+                          </Button>
+                        </div>
+                      )}
                       {milestones.length > 0 && (
                         <Progress value={completed} max={milestones.length} className="mt-4" />
                       )}


### PR DESCRIPTION
## Summary
- replace dashboard reliance on static mock collections with live quest/milestone/rewards contract reads and derived stats/activity/trending data
- centralize canonical app URL generation for resilient share links across non-root paths and preview deployments
- standardize wallet-driven action states (pending/success/failure), add destructive button variant usage, and wire verify+payout plus removal UX states in quest flows

## Notes
- frontend tests were skipped per request
- local committer config set to `floxxih <harobedjosh@gmail.com>`
- no `upstream` remote exists in this clone, so sync was performed against `origin/main`

Closes #216
Closes #199
Closes #227
Closes #242