### PR TITLE
fix(frontend): prevent crash when contract IDs are not configured

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,7 +4,8 @@ VITE_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # Network identifier (testnet/mainnet)
 VITE_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
-# Contract addresses (deploy your own contracts or use deployed addresses)
-VITE_QUEST_CONTRACT_ID=
-VITE_MILESTONE_CONTRACT_ID=
-VITE_REWARDS_CONTRACT_ID=
+# Contract addresses - testnet deployments (2026-03-26)
+# To deploy your own: stellar contract build && stellar contract deploy --wasm target/wasm32v1-none/release/<contract>.wasm --source <key> --network testnet
+VITE_QUEST_CONTRACT_ID=CC24Y3HPO4P4UPQ3CRORTCU6QV7YNZL4UNT4EKZUM2NIPPMH2OSTCPC6
+VITE_MILESTONE_CONTRACT_ID=CAUQGMW72Z63QD6SVUBLUXJNWTUGCKINFZMFBR7I5WFX7QUI3RE6Q2B3
+VITE_REWARDS_CONTRACT_ID=CBZN7TRWULHY6LQZH6YCSHDTPZRY6B6SQPW44JFO7EJCSWASH6ZW3TBD

--- a/frontend/src/lib/contracts/milestone.ts
+++ b/frontend/src/lib/contracts/milestone.ts
@@ -1,30 +1,36 @@
-import { 
-  Address, 
-  Contract, 
-  nativeToScVal, 
-  scValToNative, 
+import {
+  Address,
+  Contract,
+  nativeToScVal,
+  scValToNative,
   xdr,
   TransactionBuilder,
   Keypair,
-  Account
-} from "@stellar/stellar-sdk";
-import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client";
+  Account,
+} from "@stellar/stellar-sdk"
+import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client"
 
-const CONTRACT_ID = import.meta.env.VITE_MILESTONE_CONTRACT_ID || "";
+const CONTRACT_ID = import.meta.env.VITE_MILESTONE_CONTRACT_ID || ""
 
 export interface MilestoneInfo {
-  id: number;
-  questId: number;
-  title: string;
-  description: string;
-  rewardAmount: bigint;
+  id: number
+  questId: number
+  title: string
+  description: string
+  rewardAmount: bigint
 }
 
 export class MilestoneClient {
-  private contract: Contract;
+  private contract: Contract | null
 
   constructor() {
-    this.contract = new Contract(CONTRACT_ID);
+    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+  }
+
+  private getContract(): Contract {
+    if (!this.contract)
+      throw new Error("Milestone contract not configured. Set VITE_MILESTONE_CONTRACT_ID.")
+    return this.contract
   }
 
   // --- Read Operations ---
@@ -32,53 +38,59 @@ export class MilestoneClient {
   async getMilestone(questId: number, milestoneId: number): Promise<MilestoneInfo | null> {
     const result = await this.invokeRead("get_milestone", [
       nativeToScVal(questId, { type: "u32" }),
-      nativeToScVal(milestoneId, { type: "u32" })
-    ]);
-    return result || null;
+      nativeToScVal(milestoneId, { type: "u32" }),
+    ])
+    return result || null
   }
 
   async getMilestones(questId: number): Promise<MilestoneInfo[]> {
     const result = await this.invokeRead("get_milestones", [
-      nativeToScVal(questId, { type: "u32" })
-    ]);
-    return result || [];
+      nativeToScVal(questId, { type: "u32" }),
+    ])
+    return result || []
   }
 
   async getMilestoneCount(questId: number): Promise<number> {
     const result = await this.invokeRead("get_milestone_count", [
-      nativeToScVal(questId, { type: "u32" })
-    ]);
-    return result ? Number(result) : 0;
+      nativeToScVal(questId, { type: "u32" }),
+    ])
+    return result ? Number(result) : 0
   }
 
   async isCompleted(questId: number, milestoneId: number, user: string): Promise<boolean> {
     const result = await this.invokeRead("is_completed", [
       nativeToScVal(questId, { type: "u32" }),
       nativeToScVal(milestoneId, { type: "u32" }),
-      new Address(user).toScVal()
-    ]);
-    return !!result;
+      new Address(user).toScVal(),
+    ])
+    return !!result
   }
 
   async getEnrolleeCompletions(questId: number, enrollee: string): Promise<number> {
     const result = await this.invokeRead("get_enrollee_completions", [
       nativeToScVal(questId, { type: "u32" }),
-      new Address(enrollee).toScVal()
-    ]);
-    return result ? Number(result) : 0;
+      new Address(enrollee).toScVal(),
+    ])
+    return result ? Number(result) : 0
   }
 
   // --- Write Operations ---
 
-  async createMilestone(owner: string, questId: number, title: string, description: string, rewardAmount: bigint) {
+  async createMilestone(
+    owner: string,
+    questId: number,
+    title: string,
+    description: string,
+    rewardAmount: bigint
+  ) {
     const tx = await this.buildTx(owner, "create_milestone", [
       new Address(owner).toScVal(),
       nativeToScVal(questId, { type: "u32" }),
       nativeToScVal(title, { type: "string" }),
       nativeToScVal(description, { type: "string" }),
-      nativeToScVal(rewardAmount, { type: "i128" })
-    ]);
-    return signAndSubmit(tx);
+      nativeToScVal(rewardAmount, { type: "i128" }),
+    ])
+    return signAndSubmit(tx)
   }
 
   async verifyCompletion(owner: string, questId: number, milestoneId: number, enrollee: string) {
@@ -86,50 +98,50 @@ export class MilestoneClient {
       new Address(owner).toScVal(),
       nativeToScVal(questId, { type: "u32" }),
       nativeToScVal(milestoneId, { type: "u32" }),
-      new Address(enrollee).toScVal()
-    ]);
-    return signAndSubmit(tx);
+      new Address(enrollee).toScVal(),
+    ])
+    return signAndSubmit(tx)
   }
 
   // --- Private Helpers ---
 
   private async invokeRead(method: string, args: xdr.ScVal[]) {
     try {
-      const randomKP = Keypair.random();
-      const account = new Account(randomKP.publicKey(), "0");
+      const randomKP = Keypair.random()
+      const account = new Account(randomKP.publicKey(), "0")
 
       const tx = new TransactionBuilder(account, {
         fee: "100",
-        networkPassphrase: NETWORK_PASSPHRASE
+        networkPassphrase: NETWORK_PASSPHRASE,
       })
-      .addOperation(this.contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
+        .addOperation(this.getContract().call(method, ...args))
+        .setTimeout(30)
+        .build()
 
-      const response = await server.simulateTransaction(tx);
-      
+      const response = await server.simulateTransaction(tx)
+
       if (response && "result" in response && response.result) {
-         return scValToNative(response.result.retval);
+        return scValToNative(response.result.retval)
       }
     } catch (e) {
-      console.error(`Read error ${method}:`, e);
+      console.error(`Read error ${method}:`, e)
     }
-    return null;
+    return null
   }
 
   private async buildTx(source: string, method: string, args: xdr.ScVal[]) {
-     const account = await server.getAccount(source);
-     
-     const tx = new TransactionBuilder(account, {
-       fee: "100",
-       networkPassphrase: NETWORK_PASSPHRASE
-     })
-     .addOperation(this.contract.call(method, ...args))
-     .setTimeout(30)
-     .build();
-     
-     return await server.prepareTransaction(tx);
+    const account = await server.getAccount(source)
+
+    const tx = new TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(this.getContract().call(method, ...args))
+      .setTimeout(30)
+      .build()
+
+    return await server.prepareTransaction(tx)
   }
 }
 
-export const milestoneClient = new MilestoneClient();
+export const milestoneClient = new MilestoneClient()

--- a/frontend/src/lib/contracts/quest.ts
+++ b/frontend/src/lib/contracts/quest.ts
@@ -1,79 +1,81 @@
-import { 
-  Address, 
-  Contract, 
-  nativeToScVal, 
-  scValToNative, 
+import {
+  Address,
+  Contract,
+  nativeToScVal,
+  scValToNative,
   TransactionBuilder,
   Keypair,
-  Account
-} from "@stellar/stellar-sdk";
-import type { xdr } from "@stellar/stellar-sdk";
-import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client";
+  Account,
+} from "@stellar/stellar-sdk"
+import type { xdr } from "@stellar/stellar-sdk"
+import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client"
 
-const CONTRACT_ID = import.meta.env.VITE_QUEST_CONTRACT_ID || "";
+const CONTRACT_ID = import.meta.env.VITE_QUEST_CONTRACT_ID || ""
 
 export interface QuestInfo {
-  id: number;
-  owner: string;
-  name: string;
-  description: string;
-  tokenAddr: string;
-  createdAt: number;
+  id: number
+  owner: string
+  name: string
+  description: string
+  tokenAddr: string
+  createdAt: number
 }
 
 export class QuestClient {
-  private contract: Contract;
+  private contract: Contract | null
 
   constructor() {
-    this.contract = new Contract(CONTRACT_ID);
+    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+  }
+
+  private getContract(): Contract {
+    if (!this.contract)
+      throw new Error("Quest contract not configured. Set VITE_QUEST_CONTRACT_ID.")
+    return this.contract
   }
 
   // --- Read Operations ---
 
   async getQuest(questId: number): Promise<QuestInfo | null> {
-    const result = await this.invokeRead("get_quest", [
-      nativeToScVal(questId, { type: "u32" })
-    ]);
-    if (!result) return null;
-    
+    const result = await this.invokeRead("get_quest", [nativeToScVal(questId, { type: "u32" })])
+    if (!result) return null
+
     return {
       id: Number(result.id),
       owner: result.owner.toString(),
       name: result.name.toString(),
       description: result.description.toString(),
       tokenAddr: result.token_addr.toString(),
-      createdAt: Number(result.created_at)
-    };
+      createdAt: Number(result.created_at),
+    }
   }
 
   async getQuests(): Promise<QuestInfo[]> {
-    const count = await this.getQuestCount();
-    const quests: QuestInfo[] = [];
+    const count = await this.getQuestCount()
+    const quests: QuestInfo[] = []
     for (let i = 0; i < count; i++) {
-      const q = await this.getQuest(i);
-      if (q) quests.push(q);
+      const q = await this.getQuest(i)
+      if (q) quests.push(q)
     }
-    return quests;
+    return quests
   }
 
   async getQuestCount(): Promise<number> {
-    const result = await this.invokeRead("get_quest_count", []);
-    return result ? Number(result) : 0;
+    const result = await this.invokeRead("get_quest_count", [])
+    return result ? Number(result) : 0
   }
 
   async getEnrollees(questId: number): Promise<string[]> {
-    const result = await this.invokeRead("get_enrollees", [
-      nativeToScVal(questId, { type: "u32" })
-    ]);
-    return result || [];
+    const result = await this.invokeRead("get_enrollees", [nativeToScVal(questId, { type: "u32" })])
+    return result || []
   }
 
   async isEnrollee(questId: number, user: string): Promise<boolean> {
-     const result = await this.invokeRead("is_enrollee", [
-       nativeToScVal(questId, { type: "u32" }),
-       new Address(user).toScVal()
-     ]);
-     return !!result;
+    const result = await this.invokeRead("is_enrollee", [
+      nativeToScVal(questId, { type: "u32" }),
+      new Address(user).toScVal(),
+    ])
+    return !!result
   }
 
   // --- Write Operations ---
@@ -83,62 +85,62 @@ export class QuestClient {
       new Address(owner).toScVal(),
       nativeToScVal(name, { type: "string" }),
       nativeToScVal(description, { type: "string" }),
-      new Address(tokenAddr).toScVal()
-    ]);
-    return signAndSubmit(tx);
+      new Address(tokenAddr).toScVal(),
+    ])
+    return signAndSubmit(tx)
   }
 
   /**
-   * Adds an enrollee to a quest. 
+   * Adds an enrollee to a quest.
    * Note: This must be signed by the QUEST OWNER, not the enrollee.
    */
   async addEnrollee(owner: string, questId: number, enrollee: string) {
     const tx = await this.buildTx(owner, "add_enrollee", [
       nativeToScVal(questId, { type: "u32" }),
-      new Address(enrollee).toScVal()
-    ]);
-    return signAndSubmit(tx);
+      new Address(enrollee).toScVal(),
+    ])
+    return signAndSubmit(tx)
   }
 
   // --- Private Helpers ---
 
   private async invokeRead(method: string, args: xdr.ScVal[]) {
     try {
-      const randomKP = Keypair.random();
-      const account = new Account(randomKP.publicKey(), "0");
-      
+      const randomKP = Keypair.random()
+      const account = new Account(randomKP.publicKey(), "0")
+
       const tx = new TransactionBuilder(account, {
         fee: "100",
-        networkPassphrase: NETWORK_PASSPHRASE
+        networkPassphrase: NETWORK_PASSPHRASE,
       })
-      .addOperation(this.contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
+        .addOperation(this.getContract().call(method, ...args))
+        .setTimeout(30)
+        .build()
 
-      const response = await server.simulateTransaction(tx);
-      
+      const response = await server.simulateTransaction(tx)
+
       if (response && "result" in response && response.result) {
-         return scValToNative(response.result.retval);
+        return scValToNative(response.result.retval)
       }
     } catch (e: unknown) {
-      console.error(`Read error ${method}:`, e);
+      console.error(`Read error ${method}:`, e)
     }
-    return null;
+    return null
   }
 
   private async buildTx(source: string, method: string, args: xdr.ScVal[]) {
-     const account = await server.getAccount(source);
-     
-     const tx = new TransactionBuilder(account, {
-       fee: "100",
-       networkPassphrase: NETWORK_PASSPHRASE
-     })
-     .addOperation(this.contract.call(method, ...args))
-     .setTimeout(30)
-     .build();
-     
-     return await server.prepareTransaction(tx);
+    const account = await server.getAccount(source)
+
+    const tx = new TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(this.getContract().call(method, ...args))
+      .setTimeout(30)
+      .build()
+
+    return await server.prepareTransaction(tx)
   }
 }
 
-export const questClient = new QuestClient();
+export const questClient = new QuestClient()

--- a/frontend/src/lib/contracts/rewards.ts
+++ b/frontend/src/lib/contracts/rewards.ts
@@ -13,10 +13,16 @@ import { server, signAndSubmit, NETWORK_PASSPHRASE } from "./client"
 const CONTRACT_ID = import.meta.env.VITE_REWARDS_CONTRACT_ID || ""
 
 export class RewardsClient {
-  private contract: Contract
+  private contract: Contract | null
 
   constructor() {
-    this.contract = new Contract(CONTRACT_ID)
+    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+  }
+
+  private getContract(): Contract {
+    if (!this.contract)
+      throw new Error("Rewards contract not configured. Set VITE_REWARDS_CONTRACT_ID.")
+    return this.contract
   }
 
   // --- Read Operations ---
@@ -82,7 +88,7 @@ export class RewardsClient {
         fee: "100",
         networkPassphrase: NETWORK_PASSPHRASE,
       })
-        .addOperation(this.contract.call(method, ...args))
+        .addOperation(this.getContract().call(method, ...args))
         .setTimeout(30)
         .build()
 
@@ -104,7 +110,7 @@ export class RewardsClient {
       fee: "100",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(this.contract.call(method, ...args))
+      .addOperation(this.getContract().call(method, ...args))
       .setTimeout(30)
       .build()
 


### PR DESCRIPTION
## What does this PR do?

Prevents the app from crashing with "invalid contract id" on load when the `VITE_QUEST_CONTRACT_ID`, `VITE_MILESTONE_CONTRACT_ID`, and `VITE_REWARDS_CONTRACT_ID` environment variables are empty or not set. Also populates `.env.example` with deployed testnet contract addresses.

## Type of Change

- [x] Bug fix

## Root Cause

All three contract clients (`quest.ts`, `milestone.ts`, `rewards.ts`) did:

```ts
export const questClient = new QuestClient() // module-level singleton
```

And inside the constructor:

```ts
this.contract = new Contract(CONTRACT_ID) // CONTRACT_ID = "" when env var missing
```

`new Contract("")` throws synchronously at module import time, crashing the entire app before React even mounts.

## Fix

Guard construction so `Contract` is only created when the ID is present:

```ts
this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
```

Added a `getContract()` helper that throws a descriptive config error on write ops, while read ops continue to return `null` gracefully via existing try/catch blocks.

Also updated `.env.example` with the deployed testnet contract addresses so contributors can run locally without deploying their own contracts.

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes