### PR TITLE
fix(frontend): catch invalid contract ID to prevent crash on bad env var

### DIFF
--- a/frontend/src/lib/contracts/milestone.ts
+++ b/frontend/src/lib/contracts/milestone.ts
@@ -24,7 +24,16 @@ export class MilestoneClient {
   private contract: Contract | null
 
   constructor() {
-    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+    if (CONTRACT_ID) {
+      try {
+        this.contract = new Contract(CONTRACT_ID)
+      } catch {
+        this.contract = null
+        console.error(`[MilestoneClient] Invalid VITE_MILESTONE_CONTRACT_ID: "${CONTRACT_ID}"`)
+      }
+    } else {
+      this.contract = null
+    }
   }
 
   private getContract(): Contract {

--- a/frontend/src/lib/contracts/quest.ts
+++ b/frontend/src/lib/contracts/quest.ts
@@ -25,7 +25,16 @@ export class QuestClient {
   private contract: Contract | null
 
   constructor() {
-    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+    if (CONTRACT_ID) {
+      try {
+        this.contract = new Contract(CONTRACT_ID)
+      } catch {
+        this.contract = null
+        console.error(`[QuestClient] Invalid VITE_QUEST_CONTRACT_ID: "${CONTRACT_ID}"`)
+      }
+    } else {
+      this.contract = null
+    }
   }
 
   private getContract(): Contract {

--- a/frontend/src/lib/contracts/rewards.ts
+++ b/frontend/src/lib/contracts/rewards.ts
@@ -16,7 +16,16 @@ export class RewardsClient {
   private contract: Contract | null
 
   constructor() {
-    this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
+    if (CONTRACT_ID) {
+      try {
+        this.contract = new Contract(CONTRACT_ID)
+      } catch {
+        this.contract = null
+        console.error(`[RewardsClient] Invalid VITE_REWARDS_CONTRACT_ID: "${CONTRACT_ID}"`)
+      }
+    } else {
+      this.contract = null
+    }
   }
 
   private getContract(): Contract {


### PR DESCRIPTION
## What does this PR do?

Prevents the app from crashing when a `VITE_*_CONTRACT_ID` environment variable is set but contains a malformed value (truncated, wrong format, etc.).

## Related Issue

Closes #330

## Type of Change

- [x] Bug fix

## Root Cause

The previous guard only skipped construction when the env var was empty:

\`\`\`ts
this.contract = CONTRACT_ID ? new Contract(CONTRACT_ID) : null
\`\`\`

A value like \`CC24Y3HPO4P4UPQ3CRORTCU6QV7YNZL4UNT4EKZUM2NIPPMH2OSTCPC\` (truncated - missing last char) is truthy, so \`new Contract(truncatedId)\` is called and throws \`Invalid contract ID\` synchronously at module load, crashing the entire app.

## Fix

Wrap construction in try/catch so any invalid format is swallowed at startup:

\`\`\`ts
try {
  this.contract = new Contract(CONTRACT_ID)
} catch {
  this.contract = null
  console.error(\`[QuestClient] Invalid VITE_QUEST_CONTRACT_ID: "\${CONTRACT_ID}"\`)
}
\`\`\`

The app loads normally; contract calls return null for reads or throw a config error for writes. The console message names the bad value to help diagnose the misconfiguration.

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] \`pnpm build\` passes
- [x] \`pnpm lint\` passes