### PR TITLE
fix(ci): use owner PAT for auto-review

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -158,19 +158,14 @@ jobs:
             echo "REVIEW_EOF"
           } >> $GITHUB_OUTPUT
 
-      - name: Submit review
+      - name: Submit review as repo owner
         if: steps.pr.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OWNER_PAT }}
           PR_NUM: ${{ steps.pr.outputs.number }}
           ACTION: ${{ steps.review.outputs.action }}
           BODY: ${{ steps.review.outputs.body }}
         run: |
           gh pr review "$PR_NUM" \
             --"$(echo "$ACTION" | tr '[:upper:]' '[:lower:]' | tr '_' '-')" \
-            --body "**Auto-review (CI passed)**
-
-          $BODY
-
-          ---
-          *This review was generated automatically after all CI checks passed.*"
+            --body "$BODY"


### PR DESCRIPTION
Use OWNER_PAT secret instead of GITHUB_TOKEN so PR reviews come from the repo owner account, not github-actions bot.