### PR TITLE
fix(frontend): add .env.local check to prevent invalid-contract-id crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ stellar contract build      # Optimized WASM
 # Frontend
 cd frontend
 pnpm install
+cp .env.example .env.local  # configure environment variables
 pnpm dev                    # → localhost:5173
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "pnpm": "10.33.0"
   },
   "scripts": {
+    "predev": "node scripts/check-env.mjs",
     "dev": "vite",
     "validate:assets": "node scripts/validate-public-assets.mjs",
     "prebuild": "node scripts/validate-public-assets.mjs",

--- a/frontend/scripts/check-env.mjs
+++ b/frontend/scripts/check-env.mjs
@@ -1,0 +1,45 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const frontendRoot = path.resolve(scriptDir, "..")
+const envLocalPath = path.join(frontendRoot, ".env.local")
+
+const REQUIRED_VARS = [
+  "VITE_QUEST_CONTRACT_ID",
+  "VITE_MILESTONE_CONTRACT_ID",
+  "VITE_REWARDS_CONTRACT_ID",
+  "VITE_SOROBAN_RPC_URL",
+  "VITE_SOROBAN_NETWORK_PASSPHRASE",
+]
+
+if (!fs.existsSync(envLocalPath)) {
+  console.error("Environment check failed:\n")
+  console.error("  .env.local not found.")
+  console.error("\n  Copy the example file to get started:\n")
+  console.error("    cp .env.example .env.local\n")
+  process.exit(1)
+}
+
+const raw = fs.readFileSync(envLocalPath, "utf8")
+const vars = new Map()
+for (const line of raw.split("\n")) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith("#")) continue
+  const eqIndex = trimmed.indexOf("=")
+  if (eqIndex === -1) continue
+  vars.set(trimmed.slice(0, eqIndex).trim(), trimmed.slice(eqIndex + 1).trim())
+}
+
+const missing = REQUIRED_VARS.filter((v) => !vars.get(v))
+if (missing.length > 0) {
+  console.error("Environment check failed:\n")
+  console.error("  The following required variables are missing or empty in .env.local:\n")
+  for (const v of missing) console.error(`    - ${v}`)
+  console.error("\n  Copy the example file and fill in the values:\n")
+  console.error("    cp .env.example .env.local\n")
+  process.exit(1)
+}
+
+console.log("Environment check passed.")


### PR DESCRIPTION
## What does this PR do?

Summary                                                                                                     
                                                                                                              
  - Adds frontend/scripts/check-env.mjs to validate .env.local exists and contains all 5 required VITE_* vars 
  before starting the dev server                            
  - Wires it as a predev script so new contributors get a clear cp .env.example .env.local instruction instead
   of a cryptic invalid-contract-id crash                                                                     
  - Updates README.md Getting Started to include the cp step explicitly
                                                                                                              
  Test plan                                                                                                   
                                                                                                              
  - Delete `.env.local`, `run pnpm dev` → error message + cp instruction, exits 1                                 
  - Blank out a required var in `.env.local`, run pnpm dev → lists missing vars, exits 1
  - Valid `.env.local`, `run pnpm dev` → prints Environment check passed., Vite starts normally                   
  - Delete `.env.local`, run pnpm build → build proceeds (env check does NOT run on build)  

## Related Issue

Closes #373 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [x] I have added at least one label to this PR
- [x] I have added/updated tests for my changes (if applicable)
- [x] `cargo test --workspace` passes (if contracts changed)
- [x] `pnpm build` passes (if frontend changed)
- [x] `cargo fmt --all -- --check` passes (if Rust changed)
- [x] `pnpm lint` passes (if frontend changed)

