### PR TITLE
feat(frontend): add per-quest open-graph metadata (#347)

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import {
   cn,
   shortenAddress,
@@ -6,6 +6,8 @@ import {
   formatDeadlineLabel,
   isExpiredDeadline,
   isExpiringSoon,
+  setPageMeta,
+  resetPageMeta,
 } from "./utils"
 
 describe("cn", () => {
@@ -81,5 +83,80 @@ describe("deadline helpers", () => {
     expect(formatDeadlineLabel(0, nowMs)).toBe("No deadline")
     expect(formatDeadlineLabel(Math.floor(nowMs / 1000) - 60, nowMs)).toBe("Expired")
     expect(formatDeadlineLabel(Math.floor(nowMs / 1000) + 2 * 60 * 60, nowMs)).toBe("Expires in 2h")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setPageMeta / resetPageMeta
+// ---------------------------------------------------------------------------
+
+type MetaSpec = { attr: "name" | "property"; val: string; content: string }
+
+const META_SEEDS: MetaSpec[] = [
+  { attr: "name", val: "description", content: "Default desc" },
+  { attr: "property", val: "og:title", content: "Default OG title" },
+  { attr: "property", val: "og:description", content: "Default OG desc" },
+  { attr: "name", val: "twitter:title", content: "Default TW title" },
+  { attr: "name", val: "twitter:description", content: "Default TW desc" },
+  { attr: "property", val: "og:image", content: "https://lernza.com/og-image.png" },
+  { attr: "name", val: "twitter:image", content: "https://lernza.com/og-image.png" },
+  { attr: "name", val: "twitter:image:src", content: "https://lernza.com/og-image.png" },
+]
+
+function getContent(attr: "name" | "property", val: string): string | null {
+  return (
+    document.querySelector<HTMLMetaElement>(`meta[${attr}='${val}']`)?.getAttribute("content") ??
+    null
+  )
+}
+
+describe("setPageMeta / resetPageMeta", () => {
+  beforeEach(() => {
+    document.title = "Default"
+    for (const { attr, val, content } of META_SEEDS) {
+      const el = document.createElement("meta")
+      el.setAttribute(attr, val)
+      el.setAttribute("content", content)
+      document.head.appendChild(el)
+    }
+  })
+
+  afterEach(() => {
+    document.head.querySelectorAll("meta").forEach(el => el.remove())
+  })
+
+  it("updates document.title and all OG / Twitter meta tags", () => {
+    setPageMeta("Quest: Rust 101 on Lernza", "Learn Rust and earn tokens.")
+
+    expect(document.title).toBe("Quest: Rust 101 on Lernza")
+    expect(getContent("property", "og:title")).toBe("Quest: Rust 101 on Lernza")
+    expect(getContent("name", "twitter:title")).toBe("Quest: Rust 101 on Lernza")
+    expect(getContent("name", "description")).toBe("Learn Rust and earn tokens.")
+    expect(getContent("property", "og:description")).toBe("Learn Rust and earn tokens.")
+    expect(getContent("name", "twitter:description")).toBe("Learn Rust and earn tokens.")
+  })
+
+  it("does not touch image tags when imageUrl is omitted", () => {
+    setPageMeta("Quest: Rust 101 on Lernza", "Learn Rust.")
+
+    expect(getContent("property", "og:image")).toBe("https://lernza.com/og-image.png")
+    expect(getContent("name", "twitter:image")).toBe("https://lernza.com/og-image.png")
+  })
+
+  it("overrides image tags when imageUrl is provided", () => {
+    setPageMeta("Quest: Rust 101 on Lernza", "Learn Rust.", "https://lernza.com/quest-1.png")
+
+    expect(getContent("property", "og:image")).toBe("https://lernza.com/quest-1.png")
+    expect(getContent("name", "twitter:image")).toBe("https://lernza.com/quest-1.png")
+    expect(getContent("name", "twitter:image:src")).toBe("https://lernza.com/quest-1.png")
+  })
+
+  it("resets all tags back to site defaults via resetPageMeta", () => {
+    setPageMeta("Quest: Rust 101 on Lernza", "Learn Rust.")
+    resetPageMeta()
+
+    expect(document.title).toBe("Lernza \u2014 Learn. Earn. On-chain.")
+    expect(getContent("property", "og:title")).toBe("Lernza \u2014 Learn. Earn. On-chain.")
+    expect(getContent("name", "twitter:title")).toBe("Lernza \u2014 Learn. Earn. On-chain.")
   })
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -57,3 +57,41 @@ export function formatDeadlineLabel(deadline: number, nowMs = Date.now()): strin
   }
   return `Expires in ${days} day${days === 1 ? "" : "s"}`
 }
+
+// ---------------------------------------------------------------------------
+// Page metadata helpers (Open Graph / Twitter Card / document.title)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TITLE = "Lernza — Learn. Earn. On-chain."
+const DEFAULT_DESCRIPTION =
+  "The first learn-to-earn platform on Stellar. Create quests, set milestones, reward learners with tokens."
+
+function setMeta(selector: string, value: string): void {
+  const el = document.querySelector<HTMLMetaElement>(selector)
+  if (el) el.setAttribute("content", value)
+}
+
+/**
+ * Dynamically updates `document.title` and all OG / Twitter meta tags.
+ * Call with `imageUrl` to also override the share image.
+ */
+export function setPageMeta(title: string, description: string, imageUrl?: string): void {
+  document.title = title
+
+  setMeta("meta[name='description']", description)
+  setMeta("meta[property='og:title']", title)
+  setMeta("meta[property='og:description']", description)
+  setMeta("meta[name='twitter:title']", title)
+  setMeta("meta[name='twitter:description']", description)
+
+  if (imageUrl) {
+    setMeta("meta[property='og:image']", imageUrl)
+    setMeta("meta[name='twitter:image']", imageUrl)
+    setMeta("meta[name='twitter:image:src']", imageUrl)
+  }
+}
+
+/** Resets all page metadata back to the site-wide defaults from index.html. */
+export function resetPageMeta(): void {
+  setPageMeta(DEFAULT_TITLE, DEFAULT_DESCRIPTION)
+}

--- a/frontend/src/pages/quest.tsx
+++ b/frontend/src/pages/quest.tsx
@@ -38,6 +38,8 @@ import {
   getSecondsRemaining,
   isExpiredDeadline,
   isExpiringSoon,
+  setPageMeta,
+  resetPageMeta,
 } from "@/lib/utils"
 import { useInView, useCountUp } from "@/hooks/use-animations"
 import { useToast } from "@/hooks/use-toast"
@@ -318,6 +320,18 @@ export function QuestView() {
     addEnrolleeTx.reset()
     setAddPhase("idle")
   }, [addEnrolleeTx, enrolleeForm])
+
+  // Update page title and OG/Twitter meta tags when quest data is available.
+  // resetPageMeta runs as cleanup so navigating away restores the site defaults.
+  useEffect(() => {
+    if (!quest) return
+    setPageMeta(
+      `Quest: ${quest.name} on Lernza`,
+      quest.description ||
+        "Complete milestones and earn token rewards on the Lernza learn-to-earn platform."
+    )
+    return resetPageMeta
+  }, [quest])
 
   useEffect(() => {
     if (!quest || quest.deadline <= 0 || isExpiredDeadline(quest.deadline)) {


### PR DESCRIPTION
## Summary

Closes #347

Sharing a quest URL (e.g. `/quest/5`) on Twitter or Slack previously showed the generic Lernza OG title from `index.html`. This PR makes quest pages dynamically update their own title and meta tags.

## Changes

### `frontend/src/lib/utils.ts`
- **`setPageMeta(title, description, imageUrl?)`** — updates `document.title`, `og:title`, `og:description`, `twitter:title`, `twitter:description`, and optionally the image tags.
- **`resetPageMeta()`** — restores the site-wide defaults from `index.html`.

### `frontend/src/pages/quest.tsx`
- `useEffect` that calls `setPageMeta` when quest data resolves:
  - Title: `Quest: [Name] on Lernza`
  - Description: `quest.description` (with generic fallback)
  - Returns `resetPageMeta` as cleanup → navigating away restores defaults.

### `frontend/src/lib/utils.test.ts`
- 4 new Vitest tests: title+meta update, image-tag passthrough, image override, and reset.

## Acceptance criteria

- [x] Sharing a quest URL shows quest-specific title and description
- [x] Browser tab reflects current quest name
- [x] Navigating away resets to site defaults

## Test results

```
Test Files  5 passed (5)
     Tests  31 passed (31)
```
