### PR TITLE
chore(contracts): remove `// Trigger CI check` debris from quest/lib.rs (#683)

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -1,4 +1,3 @@
-// Trigger CI check
 #![no_std]
 #![allow(deprecated)]
 #![allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Closes #683.

Removes the leftover \`// Trigger CI check\` comment at line 1 of \`contracts/quest/src/lib.rs\`. After deletion the file leads with the existing \`#![no_std]\` attribute, and the first non-attribute line is now the real \`use common::{...}\` import as the issue's acceptance criteria require.

Verified locally:
- \`cargo test -p quest --lib\` (76 tests passing)
- \`cargo fmt --all -- --check\` clean