### PR TITLE
docs: add release-please status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 <p align="center">
   <a href="https://github.com/lernza/lernza"><img src="https://img.shields.io/github/stars/lernza/lernza?style=flat-square&color=FACC15&labelColor=000&logo=github&logoColor=FACC15" alt="Stars"></a>&nbsp;
   <a href="https://stellar.org"><img src="https://img.shields.io/badge/Stellar-Soroban-FACC15?style=flat-square&logo=stellar&logoColor=FACC15&labelColor=000" alt="Stellar Soroban"></a>&nbsp;
+  <a href="https://github.com/lernza/lernza/releases"><img src="https://img.shields.io/github/v/release/lernza/lernza?style=flat-square&color=FACC15&labelColor=000&label=release&logo=semver&logoColor=FACC15" alt="Latest release"></a>&nbsp;
+  <a href="https://github.com/lernza/lernza/pulls?q=is%3Apr+is%3Aopen+label%3A%22autorelease%3A+pending%22"><img src="https://img.shields.io/github/issues-pr/lernza/lernza/autorelease%3A%20pending?style=flat-square&color=FACC15&labelColor=000&label=pending%20release&logo=githubactions&logoColor=FACC15" alt="Pending release"></a>&nbsp;
   <a href="https://github.com/lernza/lernza/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"><img src="https://img.shields.io/github/issues/lernza/lernza/good%20first%20issue?style=flat-square&color=FACC15&labelColor=000&label=good%20first%20issues&logo=git&logoColor=FACC15" alt="Good First Issues"></a>&nbsp;
   <a href="https://github.com/lernza/lernza/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-FACC15?style=flat-square&labelColor=000&logo=opensourceinitiative&logoColor=FACC15" alt="MIT License"></a>&nbsp;
   <a href="https://codecov.io/gh/lernza/lernza"><img src="https://img.shields.io/codecov/c/github/lernza/lernza?style=flat-square&color=FACC15&labelColor=000&logo=codecov&logoColor=FACC15" alt="Coverage"></a>


### PR DESCRIPTION
## What does this PR do?

Adds two release-please status badges to the README badge row: a "Latest release" shield (resolves to v0.3.0 from `gh api repos/lernza/lernza/releases/latest`) and a "Pending release" shield linking to PRs labeled `autorelease: pending`. Issue #764 asked the README to reflect release state with a shield + a link to the next-pending release PR; this lands both in the existing yellow-on-black palette.

## Related Issue

Closes #764

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

Both shield URLs were verified live (status 200, content-type `image/svg+xml`):
- Latest release: `release: v0.3.0`
- Pending release: `pending release: 0 open` (will populate once release-please opens its first autorelease PR)

This contribution was developed with AI assistance (Codex).
