### PR TITLE
Add support md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,43 @@
+# Support
+
+Thanks for using Lernza — the learn-to-earn platform on Stellar. 🚀
+
+Before opening an issue, please check the resources below. Most questions
+are already answered there.
+
+---
+
+## 💬 Got a question?
+
+**Please use [GitHub Discussions](https://github.com/lernza/lernza/discussions)** instead of opening an issue.
+
+Issues are reserved for bug reports and feature requests. Questions posted
+as issues may be closed and redirected here.
+
+---
+
+## 📚 Resources
+
+- **README** — Project overview, setup, and architecture:
+  [`README.md`](./README.md)
+- **Contributing guide** — How to contribute code or docs:
+  [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- **Security policy** — Found a vulnerability? See:
+  [`SECURITY.md`](./SECURITY.md)
+- **Project board** — Track all open issues and roadmap items:
+  [Lernza Roadmap](https://github.com/orgs/lernza/projects/1)
+
+---
+
+## 🐛 Found a bug or have a feature request?
+
+[Open an issue](https://github.com/lernza/lernza/issues/new/choose) and
+use the appropriate template. Please search existing issues first to avoid
+duplicates.
+
+---
+
+## 🔒 Security issues
+
+**Do not open a public issue for security vulnerabilities.**
+Follow the process in [`SECURITY.md`](./SECURITY.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,13 @@
 # Support
 
-Thanks for using Lernza — the learn-to-earn platform on Stellar. 🚀
+Thanks for using Lernza — the learn-to-earn platform on Stellar. 
 
 Before opening an issue, please check the resources below. Most questions
 are already answered there.
 
 ---
 
-## 💬 Got a question?
+##  Got a question?
 
 **Please use [GitHub Discussions](https://github.com/lernza/lernza/discussions)** instead of opening an issue.
 
@@ -16,7 +16,7 @@ as issues may be closed and redirected here.
 
 ---
 
-## 📚 Resources
+##  Resources
 
 - **README** — Project overview, setup, and architecture:
   [`README.md`](./README.md)
@@ -29,7 +29,7 @@ as issues may be closed and redirected here.
 
 ---
 
-## 🐛 Found a bug or have a feature request?
+##  Found a bug or have a feature request?
 
 [Open an issue](https://github.com/lernza/lernza/issues/new/choose) and
 use the appropriate template. Please search existing issues first to avoid
@@ -37,7 +37,7 @@ duplicates.
 
 ---
 
-## 🔒 Security issues
+##  Security issues
 
 **Do not open a public issue for security vulnerabilities.**
 Follow the process in [`SECURITY.md`](./SECURITY.md).


### PR DESCRIPTION
Closes #682

Added SUPPORT.md to satisfy GitHub's community health profile requirement.
The file directs users with questions to GitHub Discussions, links to
existing docs (README, CONTRIBUTING, SECURITY), and explains when to open
an issue vs use Discussions.