### PR TITLE
perf/ci: TanStack Query caching, WASM size delta, macOS matrix, Codecov PR comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,420 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  # ── Detect what changed ──────────────────────────────────────────
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      contracts: ${{ steps.filter.outputs.contracts }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+            contracts:
+              - 'contracts/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
+  # ── Frontend: lint + type-check + build ──────────────────────────
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.12.0
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Type-check & build
+        run: pnpm run build
+
+      - name: Analyze bundle size
+        id: bundle
+        run: |
+          cd dist
+          TOTAL_SIZE=$(du -sh . | cut -f1)
+          ASSETS_SIZE=$(du -sh assets | cut -f1)
+          echo "total_size=$TOTAL_SIZE" >> $GITHUB_OUTPUT
+          echo "assets_size=$ASSETS_SIZE" >> $GITHUB_OUTPUT
+
+      - name: Comment bundle size
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { total_size, assets_size } = process.env;
+            const body = `## 📦 Bundle Size Report\n\n| Metric | Size |\n|--------|------|\n| Total dist | ${total_size} |\n| Assets | ${assets_size} |\n\n_This helps track frontend bundle size changes._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(c =>
+              c.user?.type === 'Bot' && c.body?.includes('Bundle Size Report')
+            );
+
+            try {
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: body
+                });
+              }
+            } catch (error) {
+              console.log("Failed to post bundle size comment.", error.message);
+            }
+        env:
+          total_size: ${{ steps.bundle.outputs.total_size }}
+          assets_size: ${{ steps.bundle.outputs.assets_size }}
+
+  # ── Contracts: fmt + clippy + test + build WASM ──────────────────
+  # Matrix covers Linux and macOS to catch platform-specific divergence.
+  contracts:
+    needs: changes
+    if: needs.changes.outputs.contracts == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stellar-cli (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          curl -fsSL https://github.com/stellar/stellar-cli/releases/download/v25.2.0/stellar-cli-25.2.0-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin
+
+      - name: Install stellar-cli (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl -fsSL https://github.com/stellar/stellar-cli/releases/download/v25.2.0/stellar-cli-25.2.0-x86_64-apple-darwin.tar.gz \
+            | tar xz -C /usr/local/bin
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown,wasm32v1-none
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Smoke-check test module syntax
+        run: cargo check --workspace --tests
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Build WASM contracts
+        run: stellar contract build
+
+      - name: Check contract WASM sizes (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          MAX_SIZE=$((256 * 1024))
+          FAILED=0
+
+          echo "=== Contract WASM Size Report ==="
+          for wasm in target/wasm32v1-none/release/*.wasm; do
+            [ -f "$wasm" ] || continue
+            SIZE=$(stat -c%s "$wasm")
+            SIZE_KB=$(echo "scale=2; $SIZE / 1024" | bc)
+            NAME=$(basename "$wasm")
+
+            if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+              echo "FAIL $NAME: ${SIZE_KB}KB (EXCEEDS 256KB limit)"
+              FAILED=1
+            else
+              echo "OK   $NAME: ${SIZE_KB}KB"
+            fi
+          done
+
+          echo "================================="
+          if [ "$FAILED" -eq 1 ]; then
+            echo "One or more contracts exceed the 256KB Soroban size limit."
+            exit 1
+          fi
+
+      - name: Check contract WASM sizes (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          MAX_SIZE=$((256 * 1024))
+          FAILED=0
+
+          echo "=== Contract WASM Size Report ==="
+          for wasm in target/wasm32v1-none/release/*.wasm; do
+            [ -f "$wasm" ] || continue
+            SIZE=$(stat -f%z "$wasm")
+            SIZE_KB=$(echo "scale=2; $SIZE / 1024" | bc)
+            NAME=$(basename "$wasm")
+
+            if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+              echo "FAIL $NAME: ${SIZE_KB}KB (EXCEEDS 256KB limit)"
+              FAILED=1
+            else
+              echo "OK   $NAME: ${SIZE_KB}KB"
+            fi
+          done
+
+          echo "================================="
+          if [ "$FAILED" -eq 1 ]; then
+            echo "One or more contracts exceed the 256KB Soroban size limit."
+            exit 1
+          fi
+
+      - name: Upload WASM artifacts
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-wasm
+          path: target/wasm32v1-none/release/*.wasm
+          retention-days: 14
+
+  # ── WASM size delta comment ───────────────────────────────────────
+  # Builds the WASM on the base branch and the PR branch, computes the
+  # per-contract delta, and posts a summary comment on the PR.
+  wasm-size:
+    needs: changes
+    if: needs.changes.outputs.contracts == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Install stellar-cli
+        run: |
+          curl -fsSL https://github.com/stellar/stellar-cli/releases/download/v25.2.0/stellar-cli-25.2.0-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32v1-none
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-wasm-size-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-size-
+
+      # Build base branch WASM
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Build base WASM
+        working-directory: base
+        run: stellar contract build
+
+      - name: Record base WASM sizes
+        working-directory: base
+        run: |
+          mkdir -p /tmp/wasm-sizes
+          for wasm in target/wasm32v1-none/release/*.wasm; do
+            [ -f "$wasm" ] || continue
+            NAME=$(basename "$wasm")
+            SIZE=$(stat -c%s "$wasm")
+            echo "$SIZE" > "/tmp/wasm-sizes/base_${NAME}.size"
+          done
+
+      # Build PR branch WASM
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+
+      - name: Build PR WASM
+        working-directory: head
+        run: stellar contract build
+
+      - name: Compute delta and post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const wasmDir = 'head/target/wasm32v1-none/release';
+            const sizeDir = '/tmp/wasm-sizes';
+
+            let rows = '';
+            let hasFiles = false;
+
+            const wasmFiles = fs.readdirSync(wasmDir).filter(f => f.endsWith('.wasm'));
+            for (const name of wasmFiles) {
+              hasFiles = true;
+              const headSize = fs.statSync(path.join(wasmDir, name)).size;
+              const baseFile = path.join(sizeDir, `base_${name}.size`);
+              let baseSize = null;
+              if (fs.existsSync(baseFile)) {
+                baseSize = parseInt(fs.readFileSync(baseFile, 'utf8').trim(), 10);
+              }
+
+              const headKB = (headSize / 1024).toFixed(2);
+              if (baseSize === null) {
+                rows += `| \`${name}\` | — | ${headKB} KB | new |\n`;
+              } else {
+                const delta = headSize - baseSize;
+                const deltaKB = (Math.abs(delta) / 1024).toFixed(2);
+                const sign = delta > 0 ? '+' : delta < 0 ? '-' : '+/-';
+                const icon = delta > 0 ? 'up' : delta < 0 ? 'down' : 'same';
+                rows += `| \`${name}\` | ${(baseSize / 1024).toFixed(2)} KB | ${headKB} KB | ${icon} ${sign}${deltaKB} KB |\n`;
+              }
+            }
+
+            if (!hasFiles) return;
+
+            const body = [
+              '## WASM Size Delta',
+              '',
+              '| Contract | Base | PR | Delta |',
+              '|----------|------|----|-------|',
+              rows.trim(),
+              '',
+              '_Release builds (wasm32v1-none) via `stellar contract build`._',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user?.type === 'Bot' && c.body?.includes('WASM Size Delta')
+            );
+
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              console.log('Could not post WASM size comment (fork PR):', error.message);
+            }
+
+  # ── Frontend: E2E tests with Playwright ─────────────────────────
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.12.0
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create .env.local for dev server
+        run: cp .env.example .env.local
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,70 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-coverage-
+
+      - name: Generate coverage report
+        run: |
+          cargo llvm-cov \
+            --workspace \
+            --lcov \
+            --output-path lcov.info \
+            --features testutils \
+            -- --test-threads=1
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          comment: true
+          override_pr: ${{ github.event.pull_request.number }}
+          threshold: 1%
+          codecov_yml_path: .github/codecov.yml
+
+      - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request'
+        uses: romeovs/lcov-reporter-action@v0.4.0
+        with:
+          lcov-file: ./lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          delete-old-comments: true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.0.1",
+    "@tanstack/react-query": "^5.100.5",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@stellar/stellar-sdk':
         specifier: ^15.0.1
         version: 15.0.1
+      '@tanstack/react-query':
+        specifier: ^5.100.5
+        version: 5.100.5(react@19.2.4)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(react@19.2.4)
@@ -757,6 +760,14 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.100.5':
+    resolution: {integrity: sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==}
+
+  '@tanstack/react-query@5.100.5':
+    resolution: {integrity: sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3146,6 +3157,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@tanstack/query-core@5.100.5': {}
+
+  '@tanstack/react-query@5.100.5(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.100.5
+      react: 19.2.4
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/frontend/src/hooks/use-quest-data.ts
+++ b/frontend/src/hooks/use-quest-data.ts
@@ -1,97 +1,128 @@
-import { useContractData } from "./use-async-data"
+import { useQuery } from "@tanstack/react-query"
 import { questClient, type QuestInfo } from "@/lib/contracts/quest"
 import { milestoneClient, type MilestoneInfo } from "@/lib/contracts/milestone"
 import { rewardsClient } from "@/lib/contracts/rewards"
 
-/**
- * Hook to fetch a single quest by ID
- */
+const CONTRACT_UNAVAILABLE = "not configured"
+
+function contractError(name: string, fallback?: string): string {
+  return fallback ?? `On-chain data is unavailable until the ${name} contract is configured.`
+}
+
+function mapError(err: unknown, fallback: string): string {
+  if (err instanceof Error) {
+    if (err.message.includes(CONTRACT_UNAVAILABLE)) return fallback
+    return err.message
+  }
+  return fallback
+}
+
 export function useQuest(id: number) {
-  return useContractData<QuestInfo | null>(
-    "quest",
-    async () => {
-      if (!Number.isInteger(id) || id < 0) {
-        throw new Error("Invalid quest id")
-      }
-
+  const enabled = Number.isInteger(id) && id >= 0
+  const query = useQuery<QuestInfo | null, Error>({
+    queryKey: ["quest", id],
+    queryFn: async () => {
+      if (!Number.isInteger(id) || id < 0) throw new Error("Invalid quest id")
       const quest = await questClient.getQuest(id)
-      if (!quest) {
-        throw new Error("Quest not found")
-      }
-
+      if (!quest) throw new Error("Quest not found")
       return quest
     },
-    {
-      enabled: Number.isInteger(id) && id >= 0,
-      dependencies: [id],
-      contractUnavailableMessage:
-        "On-chain quest data is unavailable until the quest contract is configured.",
-    }
-  )
+    enabled,
+  })
+
+  const errMsg = query.error
+    ? mapError(
+        query.error,
+        contractError("quest", "On-chain quest data is unavailable until the quest contract is configured.")
+      )
+    : null
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    error: errMsg,
+    isEmpty: !query.data,
+    refetch: () => void query.refetch(),
+  }
 }
 
-/**
- * Hook to fetch milestones for a quest
- */
 export function useMilestones(questId: number) {
-  return useContractData<MilestoneInfo[]>(
-    "milestones",
-    async () => {
-      if (!Number.isInteger(questId) || questId < 0) {
-        throw new Error("Invalid quest id")
-      }
-
-      return await milestoneClient.listMilestones(questId)
+  const enabled = Number.isInteger(questId) && questId >= 0
+  const query = useQuery<MilestoneInfo[], Error>({
+    queryKey: ["milestones", questId],
+    queryFn: async () => {
+      if (!Number.isInteger(questId) || questId < 0) throw new Error("Invalid quest id")
+      return milestoneClient.listMilestones(questId)
     },
-    {
-      enabled: Number.isInteger(questId) && questId >= 0,
-      dependencies: [questId],
-      contractUnavailableMessage:
-        "On-chain milestone data is unavailable until the milestone contract is configured.",
-    }
-  )
+    enabled,
+  })
+
+  const errMsg = query.error
+    ? mapError(
+        query.error,
+        contractError("milestone", "On-chain milestone data is unavailable until the milestone contract is configured.")
+      )
+    : null
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    error: errMsg,
+    isEmpty: !query.data || query.data.length === 0,
+    refetch: () => void query.refetch(),
+  }
 }
 
-/**
- * Hook to fetch enrollees for a quest
- */
 export function useEnrollees(questId: number) {
-  return useContractData<string[]>(
-    "enrollees",
-    async () => {
-      if (!Number.isInteger(questId) || questId < 0) {
-        throw new Error("Invalid quest id")
-      }
-
-      return await questClient.getEnrollees(questId)
+  const enabled = Number.isInteger(questId) && questId >= 0
+  const query = useQuery<string[], Error>({
+    queryKey: ["enrollees", questId],
+    queryFn: async () => {
+      if (!Number.isInteger(questId) || questId < 0) throw new Error("Invalid quest id")
+      return questClient.getEnrollees(questId)
     },
-    {
-      enabled: Number.isInteger(questId) && questId >= 0,
-      dependencies: [questId],
-      contractUnavailableMessage:
-        "On-chain enrollee data is unavailable until the quest contract is configured.",
-    }
-  )
+    enabled,
+  })
+
+  const errMsg = query.error
+    ? mapError(
+        query.error,
+        contractError("quest", "On-chain enrollee data is unavailable until the quest contract is configured.")
+      )
+    : null
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    error: errMsg,
+    isEmpty: !query.data || query.data.length === 0,
+    refetch: () => void query.refetch(),
+  }
 }
 
-/**
- * Hook to fetch reward pool balance for a quest
- */
 export function useRewardPool(questId: number) {
-  return useContractData<bigint>(
-    "rewardPool",
-    async () => {
-      if (!Number.isInteger(questId) || questId < 0) {
-        throw new Error("Invalid quest id")
-      }
-
-      return await rewardsClient.getPoolBalance(questId)
+  const enabled = Number.isInteger(questId) && questId >= 0
+  const query = useQuery<bigint, Error>({
+    queryKey: ["rewardPool", questId],
+    queryFn: async () => {
+      if (!Number.isInteger(questId) || questId < 0) throw new Error("Invalid quest id")
+      return rewardsClient.getPoolBalance(questId)
     },
-    {
-      enabled: Number.isInteger(questId) && questId >= 0,
-      dependencies: [questId],
-      contractUnavailableMessage:
-        "On-chain reward pool data is unavailable until the rewards contract is configured.",
-    }
-  )
+    enabled,
+  })
+
+  const errMsg = query.error
+    ? mapError(
+        query.error,
+        contractError("rewards", "On-chain reward pool data is unavailable until the rewards contract is configured.")
+      )
+    : null
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    error: errMsg,
+    isEmpty: !query.data,
+    refetch: () => void query.refetch(),
+  }
 }

--- a/frontend/src/hooks/use-token-metadata.ts
+++ b/frontend/src/hooks/use-token-metadata.ts
@@ -1,37 +1,23 @@
-import { useState, useEffect } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { TokenClient, type TokenMetadata } from "@/lib/contracts/token"
 
 export function useTokenMetadata(tokenAddress?: string) {
-  const [metadata, setMetadata] = useState<TokenMetadata | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const query = useQuery<TokenMetadata, Error>({
+    queryKey: ["tokenMetadata", tokenAddress],
+    queryFn: async () => {
+      const client = new TokenClient(tokenAddress!)
+      return client.getTokenMetadata()
+    },
+    enabled: Boolean(tokenAddress),
+  })
 
-  useEffect(() => {
-    if (!tokenAddress) {
-      setMetadata(null)
-      setError("No token address provided")
-      return
-    }
+  if (!tokenAddress) {
+    return { metadata: null, isLoading: false, error: "No token address provided" }
+  }
 
-    const tokenClient = new TokenClient(tokenAddress)
-
-    const fetchMetadata = async () => {
-      try {
-        setIsLoading(true)
-        setError(null)
-        const tokenMetadata = await tokenClient.getTokenMetadata()
-        setMetadata(tokenMetadata)
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "Failed to fetch token metadata"
-        setError(errorMessage)
-        setMetadata(null)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchMetadata()
-  }, [tokenAddress])
-
-  return { metadata, isLoading, error }
+  return {
+    metadata: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error?.message ?? null,
+  }
 }

--- a/frontend/src/hooks/use-wallet-balance.ts
+++ b/frontend/src/hooks/use-wallet-balance.ts
@@ -1,11 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { rewardsClient } from "@/lib/contracts/rewards"
 
-// Stellar Horizon endpoints
 const HORIZON_MAINNET = "https://horizon.stellar.org"
 const HORIZON_TESTNET = "https://horizon-testnet.stellar.org"
-
-// Reward token decimals — Stellar SAC tokens use 7 decimal places by default
 const REWARD_TOKEN_DECIMALS = 7
 
 export interface WalletBalance {
@@ -29,7 +26,6 @@ function formatBalance(raw: string): string {
 }
 
 function formatRewardBalance(raw: bigint, decimals: number): string {
-  // bigint raw units → human-readable (e.g. 50_000_000n with 7 decimals → "5.00")
   const divisor = BigInt(10 ** decimals)
   const whole = raw / divisor
   const fraction = raw % divisor
@@ -37,103 +33,62 @@ function formatRewardBalance(raw: bigint, decimals: number): string {
   return `${whole.toLocaleString()}.${fractionStr}`
 }
 
-/**
- * Fetches XLM balance from Stellar Horizon API and reward token balance
- * from the on-chain rewards contract for a connected wallet address.
- *
- * @param address     - The connected Stellar wallet address (null when disconnected)
- * @param networkName - The current network name from useWallet (e.g. "Testnet", "mainnet")
- */
+interface BalanceResult {
+  xlmBalance: string | null
+  rewardBalance: string | null
+}
+
+async function fetchBalances(address: string, networkName: string | null): Promise<BalanceResult> {
+  const horizonUrl = getHorizonUrl(networkName)
+
+  const [accountResponse, earnings] = await Promise.allSettled([
+    fetch(`${horizonUrl}/accounts/${address}`),
+    rewardsClient.getUserEarnings(address),
+  ])
+
+  let xlmBalance: string | null = null
+  if (accountResponse.status === "fulfilled") {
+    const res = accountResponse.value
+    if (res.ok) {
+      const data = await res.json()
+      const balances: Array<{ asset_type: string; balance: string }> = data.balances ?? []
+      const xlm = balances.find(b => b.asset_type === "native")
+      xlmBalance = xlm ? formatBalance(xlm.balance) : "0.00"
+    } else if (res.status === 404) {
+      xlmBalance = "0.00"
+    }
+  }
+  if (xlmBalance === null) {
+    throw new Error("Could not fetch balance")
+  }
+
+  let rewardBalance: string | null = null
+  if (earnings.status === "fulfilled" && earnings.value > 0n) {
+    rewardBalance = formatRewardBalance(earnings.value, REWARD_TOKEN_DECIMALS)
+  }
+
+  return { xlmBalance, rewardBalance }
+}
+
 export function useWalletBalance(
   address: string | null,
   networkName: string | null
 ): WalletBalance {
-  const [xlmBalance, setXlmBalance] = useState<string | null>(null)
-  const [rewardBalance, setRewardBalance] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const query = useQuery<BalanceResult, Error>({
+    queryKey: ["walletBalance", address, networkName],
+    queryFn: () => fetchBalances(address!, networkName),
+    enabled: Boolean(address),
+    staleTime: 15_000,
+  })
 
-  // Track the latest fetch so stale responses from prior addresses are discarded
-  const fetchIdRef = useRef(0)
+  if (!address) {
+    return { xlmBalance: null, rewardBalance: null, isLoading: false, error: null }
+  }
 
-  const fetchBalances = useCallback(async () => {
-    if (!address) {
-      setXlmBalance(null)
-      setRewardBalance(null)
-      setIsLoading(false)
-      setError(null)
-      return
-    }
-
-    const fetchId = ++fetchIdRef.current
-    setIsLoading(true)
-    setError(null)
-
-    try {
-      const horizonUrl = getHorizonUrl(networkName)
-
-      // Run both fetches in parallel for speed
-      const [accountResponse, earnings] = await Promise.allSettled([
-        fetch(`${horizonUrl}/accounts/${address}`),
-        rewardsClient.getUserEarnings(address),
-      ])
-
-      // Guard: if a newer fetch started while we awaited, discard this result
-      if (fetchId !== fetchIdRef.current) return
-
-      // --- XLM balance ---
-      if (accountResponse.status === "fulfilled") {
-        const res = accountResponse.value
-
-        if (res.ok) {
-          const data = await res.json()
-          const balances: Array<{ asset_type: string; balance: string }> = data.balances ?? []
-          const xlm = balances.find(b => b.asset_type === "native")
-          setXlmBalance(xlm ? formatBalance(xlm.balance) : "0.00")
-        } else if (res.status === 404) {
-          // Account exists on ledger but has no funded entry (0 XLM)
-          setXlmBalance("0.00")
-        } else {
-          setXlmBalance(null)
-          setError("Could not fetch balance")
-        }
-      } else {
-        setXlmBalance(null)
-        setError("Could not reach Horizon")
-      }
-
-      // --- Reward token balance ---
-      if (earnings.status === "fulfilled" && earnings.value > 0n) {
-        setRewardBalance(formatRewardBalance(earnings.value, REWARD_TOKEN_DECIMALS))
-      } else {
-        // No earnings yet or contract not configured — silently hide the badge
-        setRewardBalance(null)
-      }
-    } catch {
-      if (fetchId !== fetchIdRef.current) return
-      setXlmBalance(null)
-      setRewardBalance(null)
-      setError("Balance fetch failed")
-    } finally {
-      if (fetchId === fetchIdRef.current) {
-        setIsLoading(false)
-      }
-    }
-  }, [address, networkName])
-
-  useEffect(() => {
-    void fetchBalances()
-  }, [fetchBalances])
-
-  // Clear immediately when wallet disconnects
-  useEffect(() => {
-    if (!address) {
-      setXlmBalance(null)
-      setRewardBalance(null)
-      setError(null)
-      setIsLoading(false)
-    }
-  }, [address])
-
-  return { xlmBalance, rewardBalance, isLoading, error }
+  return {
+    xlmBalance: query.data?.xlmBalance ?? null,
+    rewardBalance: query.data?.rewardBalance ?? null,
+    isLoading: query.isLoading,
+    error: query.error?.message ?? null,
+  }
 }

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from "@tanstack/react-query"
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
+import { QueryClientProvider } from "@tanstack/react-query"
 import { HelmetProvider } from "react-helmet-async"
+import { queryClient } from "@/lib/query-client"
 import "./index.css"
 import App from "./App.tsx"
 
@@ -14,8 +16,10 @@ if (import.meta.env.DEV) {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <HelmetProvider>
-      <App />
-    </HelmetProvider>
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <App />
+      </HelmetProvider>
+    </QueryClientProvider>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary

- Migrate `use-quest-data`, `use-wallet-balance`, and `use-token-metadata` to `@tanstack/react-query` so repeated page navigations hit the in-memory cache instead of re-fetching on every render; wire `QueryClientProvider` at the app root and set a 30-second stale time with a 5-minute garbage-collection window
- Add `macos-latest` alongside `ubuntu-latest` in the contracts build matrix so CI catches platform-specific Soroban toolchain divergence; use OS-conditional steps for `stellar-cli` download and `stat` syntax differences
- Add a `wasm-size` CI job that builds the WASM on both the PR head and base commits, computes the per-contract byte delta, and posts (or updates) a summary table as a PR comment
- Activate `coverage.yml` for `pull_request` events in addition to `push`; upgrade to `codecov/codecov-action@v5` with `comment: true`, `fail_ci_if_error: false`, and a 1 % threshold; add `.github/codecov.yml` defining project and patch coverage status checks (informational) and a diff-focused comment layout

## Test plan

- [ ] `pnpm build` succeeds in `frontend/` with the new `@tanstack/react-query` dependency
- [ ] `useQuest`, `useMilestones`, `useEnrollees`, `useRewardPool` return the same shape as before (`data`, `isLoading`, `error`, `isEmpty`, `refetch`)
- [ ] `useWalletBalance` and `useTokenMetadata` return the same shape as before
- [ ] Navigating between pages that call the same hook does not trigger duplicate network requests (cache hit)
- [ ] CI contracts job runs on both `ubuntu-latest` and `macos-latest`
- [ ] A PR that modifies contracts receives a "WASM Size Delta" comment from the bot
- [ ] Coverage comments appear on PRs via `romeovs/lcov-reporter-action` and Codecov

Closes #748
Closes #761
Closes #765
Closes #766