### PR TITLE
feat: update quest snapshots and add owner quests data

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -5,7 +5,8 @@ use common::{
     extend_instance_ttl, is_contract_address, QuestInfo, QuestStatus, Visibility, BUMP, THRESHOLD,
 };
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, String,
+    Symbol, Vec,
 };
 
 // Quest contract: the entry point for Lernza.
@@ -29,6 +30,12 @@ pub enum DataKey {
     Admin,
     Paused,
     VerifiedCreator(Address),
+    /// Registered invite commitment: SHA-256 hash stored by the quest owner.
+    /// Key: (quest_id, commitment_hash). Value: true.
+    InviteCommitment(u32, BytesN<32>),
+    /// Consumed invite: set after a preimage is successfully redeemed.
+    /// Key: (quest_id, commitment_hash). Value: true.
+    InviteUsed(u32, BytesN<32>),
 }
 
 // QuestInfo moved to common.
@@ -48,6 +55,14 @@ pub enum Error {
     DescriptionTooLong = 10,
     InviteOnly = 11,
     Paused = 12,
+    /// Enrollment is closed because the quest has been archived.
+    EnrollmentClosed = 13,
+    /// Enrollment is rejected because the quest deadline has passed.
+    DeadlineExpired = 14,
+    /// The invite preimage does not match any registered commitment.
+    InvalidInvite = 15,
+    /// The invite code has already been redeemed.
+    InviteAlreadyUsed = 16,
 }
 
 // TTL constants and address validation moved to common.
@@ -379,7 +394,10 @@ impl QuestContract {
         quest.owner.require_auth();
 
         if quest.status == QuestStatus::Archived {
-            return Err(Error::QuestArchived);
+            return Err(Error::EnrollmentClosed);
+        }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
         }
 
         let enrollees = Self::load_enrollees(&env, quest_id);
@@ -422,7 +440,10 @@ impl QuestContract {
 
         let quest = Self::load_quest(&env, quest_id)?;
         if quest.status == QuestStatus::Archived {
-            return Err(Error::QuestArchived);
+            return Err(Error::EnrollmentClosed);
+        }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
         }
         if quest.visibility == Visibility::Private {
             return Err(Error::InviteOnly);
@@ -450,6 +471,160 @@ impl QuestContract {
         // Emit enrollment event
         // Event topics: (enrollee_added,)
         // Event data: (quest_id, enrollee_address)
+        env.events().publish(
+            (Symbol::new(&env, "enrollee_added"),),
+            (quest_id, enrollee.clone()),
+        );
+
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Register an invite commitment for a private quest. Owner only.
+    ///
+    /// The owner generates a random secret off-chain, computes
+    /// `commitment = SHA-256(preimage)`, and stores the commitment here.
+    /// The raw preimage is shared with the intended enrollee (e.g. via a
+    /// signed link). The contract never sees the preimage until redemption,
+    /// so the invite cannot be front-run by observers of the ledger.
+    ///
+    /// Multiple commitments can be registered for the same quest; each is
+    /// single-use. Registering the same commitment twice is a no-op (idempotent).
+    pub fn register_invite(
+        env: Env,
+        owner: Address,
+        quest_id: u32,
+        commitment: BytesN<32>,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        Self::require_not_paused(&env)?;
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        if quest.status == QuestStatus::Archived {
+            return Err(Error::EnrollmentClosed);
+        }
+        let key = DataKey::InviteCommitment(quest_id, commitment.clone());
+        env.storage().persistent().set(&key, &true);
+        common::extend_persistent_ttl(&env, &key);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Revoke a previously registered invite commitment. Owner only.
+    ///
+    /// Removes the commitment so the corresponding preimage can no longer be
+    /// used to enroll. Has no effect if the commitment was never registered or
+    /// has already been consumed.
+    pub fn revoke_invite(
+        env: Env,
+        owner: Address,
+        quest_id: u32,
+        commitment: BytesN<32>,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        Self::require_not_paused(&env)?;
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        let key = DataKey::InviteCommitment(quest_id, commitment);
+        env.storage().persistent().remove(&key);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Check whether an invite commitment is registered and not yet consumed.
+    pub fn is_invite_valid(env: Env, quest_id: u32, commitment: BytesN<32>) -> bool {
+        let registered = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&DataKey::InviteCommitment(quest_id, commitment.clone()))
+            .unwrap_or(false);
+        let used = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&DataKey::InviteUsed(quest_id, commitment))
+            .unwrap_or(false);
+        registered && !used
+    }
+
+    /// Allow a learner to self-enroll in a private quest using an invite code.
+    ///
+    /// The enrollee submits the raw `preimage` bytes. The contract hashes them
+    /// with SHA-256 and checks that the resulting commitment was registered by
+    /// the owner and has not been consumed yet. On success the commitment is
+    /// marked as used (preventing replay) and the enrollee is added.
+    ///
+    /// This method also works for public quests — the invite path is simply an
+    /// alternative to `join_quest` when the owner wants single-use codes.
+    pub fn join_quest_with_invite(
+        env: Env,
+        enrollee: Address,
+        quest_id: u32,
+        preimage: Bytes,
+    ) -> Result<(), Error> {
+        enrollee.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.status == QuestStatus::Archived {
+            return Err(Error::EnrollmentClosed);
+        }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
+        }
+
+        // Derive commitment from the submitted preimage.
+        let commitment: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+        let commitment_key = DataKey::InviteCommitment(quest_id, commitment.clone());
+        let used_key = DataKey::InviteUsed(quest_id, commitment.clone());
+
+        // Commitment must be registered.
+        if !env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&commitment_key)
+            .unwrap_or(false)
+        {
+            return Err(Error::InvalidInvite);
+        }
+
+        // Commitment must not have been consumed already.
+        if env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&used_key)
+            .unwrap_or(false)
+        {
+            return Err(Error::InviteAlreadyUsed);
+        }
+
+        let enrollees = Self::load_enrollees(&env, quest_id);
+
+        if let Some(max) = quest.max_enrollees {
+            if enrollees.len() >= max {
+                return Err(Error::QuestFull);
+            }
+        }
+
+        if enrollees.contains(&enrollee) {
+            return Err(Error::AlreadyEnrolled);
+        }
+
+        // Mark invite as consumed before mutating enrollment state.
+        env.storage().persistent().set(&used_key, &true);
+        common::extend_persistent_ttl(&env, &used_key);
+
+        let mut new_enrollees = enrollees;
+        new_enrollees.push_back(enrollee.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Enrollees(quest_id), &new_enrollees);
+        Self::add_id_to_index(&env, DataKey::EnrolleeQuests(enrollee.clone()), quest_id);
+
         env.events().publish(
             (Symbol::new(&env, "enrollee_added"),),
             (quest_id, enrollee.clone()),

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
 
 fn setup() -> (Env, QuestContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -242,7 +242,7 @@ fn test_join_archived_quest_rejected() {
 
     let learner = Address::generate(&env);
     let result = client.try_join_quest(&learner, &0);
-    assert_eq!(result, Err(Ok(Error::QuestArchived)));
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
 }
 
 #[test]
@@ -899,7 +899,7 @@ fn test_archived_quest_rejects_new_enrollment() {
     client.archive_quest(&0);
     let enrollee = Address::generate(&env);
     let result = client.try_add_enrollee(&0, &enrollee);
-    assert_eq!(result, Err(Ok(Error::QuestArchived)));
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
 }
 
 #[test]
@@ -1257,4 +1257,410 @@ fn test_transfer_admin_unauthorized() {
     // Hacker tries to transfer admin
     let result = client.try_transfer_admin(&hacker, &new_admin);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// --- EnrollmentClosed / DeadlineExpired tests ---
+
+#[test]
+fn test_join_quest_archived_returns_enrollment_closed() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+    client.archive_quest(&0);
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest(&learner, &0);
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
+}
+
+#[test]
+fn test_add_enrollee_archived_returns_enrollment_closed() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+    client.archive_quest(&0);
+
+    let enrollee = Address::generate(&env);
+    let result = client.try_add_enrollee(&0, &enrollee);
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
+}
+
+#[test]
+fn test_join_quest_past_deadline_returns_deadline_expired() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+
+    // Set ledger time to 1000, then set a deadline that has already passed
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&0, &999);
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest(&learner, &0);
+    assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
+}
+
+#[test]
+fn test_add_enrollee_past_deadline_returns_deadline_expired() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&0, &999);
+
+    let enrollee = Address::generate(&env);
+    let result = client.try_add_enrollee(&0, &enrollee);
+    assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
+}
+
+#[test]
+fn test_join_quest_zero_deadline_is_not_expired() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+    // deadline = 0 means no deadline; enrollment should succeed
+    let learner = Address::generate(&env);
+    client.join_quest(&learner, &0);
+    assert!(client.is_enrollee(&0, &learner));
+}
+
+#[test]
+fn test_join_quest_future_deadline_succeeds() {
+    let (env, client, owner, token) = setup();
+    create_quest_helper(&env, &client, &owner, &token);
+
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&0, &2000);
+
+    let learner = Address::generate(&env);
+    client.join_quest(&learner, &0);
+    assert!(client.is_enrollee(&0, &learner));
+}
+
+#[test]
+fn test_enrollment_closed_is_distinct_from_quest_archived() {
+    // EnrollmentClosed (13) != QuestArchived (8) — different codes for different consumers
+    assert_ne!(Error::EnrollmentClosed as u32, Error::QuestArchived as u32);
+    assert_eq!(Error::EnrollmentClosed as u32, 13);
+    assert_eq!(Error::DeadlineExpired as u32, 14);
+}
+
+// ---------------------------------------------------------------------------
+// Invite code tests
+// ---------------------------------------------------------------------------
+//
+// Design recap:
+//   Owner calls register_invite(quest_id, SHA-256(preimage)).
+//   Enrollee calls join_quest_with_invite(enrollee, quest_id, preimage).
+//   Contract hashes preimage, checks commitment exists + not consumed,
+//   marks consumed, then enrolls.
+
+/// Compute SHA-256 of a byte slice using the Soroban test environment.
+fn sha256_commitment(env: &Env, preimage: &[u8]) -> BytesN<32> {
+    let bytes = Bytes::from_slice(env, preimage);
+    env.crypto().sha256(&bytes).into()
+}
+
+#[test]
+fn test_invite_happy_path_private_quest() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"super-secret-invite-code";
+    let commitment = sha256_commitment(&env, preimage);
+
+    // Owner registers the commitment.
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    // Commitment should be valid before use.
+    assert!(client.is_invite_valid(&quest_id, &commitment));
+
+    // Enrollee redeems the invite.
+    let learner = Address::generate(&env);
+    client.join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
+
+    assert!(client.is_enrollee(&quest_id, &learner));
+    assert_eq!(client.get_enrollees(&quest_id).len(), 1);
+
+    // Commitment is now consumed — no longer valid.
+    assert!(!client.is_invite_valid(&quest_id, &commitment));
+}
+
+#[test]
+fn test_invite_replay_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"one-time-code";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    let learner1 = Address::generate(&env);
+    client.join_quest_with_invite(&learner1, &quest_id, &Bytes::from_slice(&env, preimage));
+    assert!(client.is_enrollee(&quest_id, &learner1));
+
+    // Second enrollee tries to reuse the same preimage — must fail.
+    let learner2 = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner2,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage),
+    );
+    assert_eq!(result, Err(Ok(Error::InviteAlreadyUsed)));
+    assert!(!client.is_enrollee(&quest_id, &learner2));
+}
+
+#[test]
+fn test_invite_wrong_preimage_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"correct-secret";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, b"wrong-secret"),
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidInvite)));
+    assert!(!client.is_enrollee(&quest_id, &learner));
+}
+
+#[test]
+fn test_invite_unregistered_commitment_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    // No register_invite call — any preimage should fail.
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, b"any-preimage"),
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidInvite)));
+}
+
+#[test]
+fn test_multiple_independent_invites() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage_a = b"invite-for-alice";
+    let preimage_b = b"invite-for-bob";
+    let commitment_a = sha256_commitment(&env, preimage_a);
+    let commitment_b = sha256_commitment(&env, preimage_b);
+
+    client.register_invite(&owner, &quest_id, &commitment_a);
+    client.register_invite(&owner, &quest_id, &commitment_b);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.join_quest_with_invite(&alice, &quest_id, &Bytes::from_slice(&env, preimage_a));
+    client.join_quest_with_invite(&bob, &quest_id, &Bytes::from_slice(&env, preimage_b));
+
+    assert!(client.is_enrollee(&quest_id, &alice));
+    assert!(client.is_enrollee(&quest_id, &bob));
+    assert_eq!(client.get_enrollees(&quest_id).len(), 2);
+
+    // Alice's invite is consumed; Bob's is also consumed.
+    assert!(!client.is_invite_valid(&quest_id, &commitment_a));
+    assert!(!client.is_invite_valid(&quest_id, &commitment_b));
+}
+
+#[test]
+fn test_invite_on_archived_quest_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"secret";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    client.archive_quest(&quest_id);
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage),
+    );
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
+}
+
+#[test]
+fn test_invite_past_deadline_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"secret";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&quest_id, &999);
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage),
+    );
+    assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
+}
+
+#[test]
+fn test_invite_respects_enrollment_cap() {
+    let (env, client, owner, token) = setup();
+    // Cap of 1 enrollee.
+    let quest_id = client.create_quest(
+        &owner,
+        &String::from_str(&env, "Capped Quest"),
+        &String::from_str(&env, "Only one seat"),
+        &String::from_str(&env, "Programming"),
+        &Vec::<String>::new(&env),
+        &token,
+        &Visibility::Private,
+        &Some(1u32),
+    );
+
+    let preimage_a = b"seat-one";
+    let preimage_b = b"seat-two";
+    let commitment_a = sha256_commitment(&env, preimage_a);
+    let commitment_b = sha256_commitment(&env, preimage_b);
+    client.register_invite(&owner, &quest_id, &commitment_a);
+    client.register_invite(&owner, &quest_id, &commitment_b);
+
+    let alice = Address::generate(&env);
+    client.join_quest_with_invite(&alice, &quest_id, &Bytes::from_slice(&env, preimage_a));
+    assert!(client.is_enrollee(&quest_id, &alice));
+
+    let bob = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &bob,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage_b),
+    );
+    assert_eq!(result, Err(Ok(Error::QuestFull)));
+    assert!(!client.is_enrollee(&quest_id, &bob));
+}
+
+#[test]
+fn test_invite_already_enrolled_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage_a = b"first-invite";
+    let preimage_b = b"second-invite";
+    let commitment_a = sha256_commitment(&env, preimage_a);
+    let commitment_b = sha256_commitment(&env, preimage_b);
+    client.register_invite(&owner, &quest_id, &commitment_a);
+    client.register_invite(&owner, &quest_id, &commitment_b);
+
+    let learner = Address::generate(&env);
+    // First redemption succeeds.
+    client.join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage_a));
+    assert!(client.is_enrollee(&quest_id, &learner));
+
+    // Same address tries a second (different) invite — already enrolled.
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage_b),
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadyEnrolled)));
+}
+
+#[test]
+fn test_register_invite_non_owner_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let commitment = sha256_commitment(&env, b"secret");
+    let impostor = Address::generate(&env);
+    let result = client.try_register_invite(&impostor, &quest_id, &commitment);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_register_invite_archived_quest_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    client.archive_quest(&quest_id);
+
+    let commitment = sha256_commitment(&env, b"secret");
+    let result = client.try_register_invite(&owner, &quest_id, &commitment);
+    assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
+}
+
+#[test]
+fn test_revoke_invite_prevents_redemption() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"revocable-code";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+    assert!(client.is_invite_valid(&quest_id, &commitment));
+
+    // Owner revokes before anyone uses it.
+    client.revoke_invite(&owner, &quest_id, &commitment);
+    assert!(!client.is_invite_valid(&quest_id, &commitment));
+
+    let learner = Address::generate(&env);
+    let result = client.try_join_quest_with_invite(
+        &learner,
+        &quest_id,
+        &Bytes::from_slice(&env, preimage),
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidInvite)));
+}
+
+#[test]
+fn test_revoke_invite_non_owner_rejected() {
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let commitment = sha256_commitment(&env, b"secret");
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    let impostor = Address::generate(&env);
+    let result = client.try_revoke_invite(&impostor, &quest_id, &commitment);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_invite_works_on_public_quest() {
+    // Invite path is not restricted to private quests.
+    let (env, client, owner, token) = setup();
+    let quest_id =
+        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
+
+    let preimage = b"public-invite";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+
+    let learner = Address::generate(&env);
+    client.join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
+    assert!(client.is_enrollee(&quest_id, &learner));
+}
+
+#[test]
+fn test_invite_error_codes_are_distinct() {
+    assert_eq!(Error::InvalidInvite as u32, 15);
+    assert_eq!(Error::InviteAlreadyUsed as u32, 16);
+    assert_ne!(Error::InvalidInvite as u32, Error::InviteAlreadyUsed as u32);
+    assert_ne!(Error::InvalidInvite as u32, Error::InviteOnly as u32);
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,6 +5,7 @@ import reactHooks from "eslint-plugin-react-hooks"
 import reactRefresh from "eslint-plugin-react-refresh"
 import tseslint from "typescript-eslint"
 import prettier from "eslint-config-prettier"
+import unusedImports from "eslint-plugin-unused-imports"
 import { defineConfig, globalIgnores } from "eslint/config"
 
 export default defineConfig([
@@ -29,6 +30,7 @@ export default defineConfig([
     },
     plugins: {
       react,
+      "unused-imports": unusedImports,
     },
     settings: {
       react: {
@@ -42,6 +44,11 @@ export default defineConfig([
       ],
       '@typescript-eslint/no-explicit-any': 'error',
       'react/no-danger': 'error',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+      ],
     },
   },
 ])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.5.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.0",

--- a/frontend/src/components/PrefetchLink.tsx
+++ b/frontend/src/components/PrefetchLink.tsx
@@ -28,7 +28,7 @@ export function PrefetchLink({ to, children, ...props }: PrefetchLinkProps) {
           // If .tsx fails, try without extension (for directories with index.tsx or just .ts)
           import(`../pages${pagePath}`).catch(() => {});
         });
-      } catch (e) {
+      } catch {
         // Ignore prefetch errors
       }
     }

--- a/frontend/src/hooks/use-quest-data.ts
+++ b/frontend/src/hooks/use-quest-data.ts
@@ -33,16 +33,20 @@ export function useQuest(id: number) {
   const errMsg = query.error
     ? mapError(
         query.error,
-        contractError("quest", "On-chain quest data is unavailable until the quest contract is configured.")
+        contractError(
+          "quest",
+          "On-chain quest data is unavailable until the quest contract is configured."
+        )
       )
     : null
 
   return {
     data: query.data ?? null,
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     error: errMsg,
     isEmpty: !query.data,
-    refetch: () => void query.refetch(),
+    refetch: (): Promise<void> => query.refetch().then(() => undefined),
   }
 }
 
@@ -60,16 +64,20 @@ export function useMilestones(questId: number) {
   const errMsg = query.error
     ? mapError(
         query.error,
-        contractError("milestone", "On-chain milestone data is unavailable until the milestone contract is configured.")
+        contractError(
+          "milestone",
+          "On-chain milestone data is unavailable until the milestone contract is configured."
+        )
       )
     : null
 
   return {
     data: query.data ?? null,
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     error: errMsg,
     isEmpty: !query.data || query.data.length === 0,
-    refetch: () => void query.refetch(),
+    refetch: (): Promise<void> => query.refetch().then(() => undefined),
   }
 }
 
@@ -87,16 +95,20 @@ export function useEnrollees(questId: number) {
   const errMsg = query.error
     ? mapError(
         query.error,
-        contractError("quest", "On-chain enrollee data is unavailable until the quest contract is configured.")
+        contractError(
+          "quest",
+          "On-chain enrollee data is unavailable until the quest contract is configured."
+        )
       )
     : null
 
   return {
     data: query.data ?? null,
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     error: errMsg,
     isEmpty: !query.data || query.data.length === 0,
-    refetch: () => void query.refetch(),
+    refetch: (): Promise<void> => query.refetch().then(() => undefined),
   }
 }
 
@@ -114,15 +126,19 @@ export function useRewardPool(questId: number) {
   const errMsg = query.error
     ? mapError(
         query.error,
-        contractError("rewards", "On-chain reward pool data is unavailable until the rewards contract is configured.")
+        contractError(
+          "rewards",
+          "On-chain reward pool data is unavailable until the rewards contract is configured."
+        )
       )
     : null
 
   return {
     data: query.data ?? null,
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     error: errMsg,
     isEmpty: !query.data,
-    refetch: () => void query.refetch(),
+    refetch: (): Promise<void> => query.refetch().then(() => undefined),
   }
 }

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -4,7 +4,7 @@
  */
 export function track(event: string, data = {}) {
   if (typeof window !== "undefined") {
-    // @ts-ignore - va is injected by Vercel Analytics
+    // @ts-expect-error - va is injected by Vercel Analytics
     window.va?.track(event, data);
   }
 }

--- a/frontend/src/pages/creator.tsx
+++ b/frontend/src/pages/creator.tsx
@@ -6,7 +6,6 @@ import { rewardsClient } from "@/lib/contracts/rewards";
 import { milestoneClient } from "@/lib/contracts/milestone";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { SmartError } from "@/components/error-states";
 import { SkeletonQuestList } from "@/components/ui/skeleton";
 import { formatTokens } from "@/lib/utils";

--- a/frontend/src/pages/quest.tsx
+++ b/frontend/src/pages/quest.tsx
@@ -123,8 +123,10 @@ const questImportSchema = z.object({
 const QUEST_ERROR_MESSAGES: Record<number, string> = {
   4: "You are already enrolled in this quest.",
   7: "This quest is already full.",
-  8: "This quest is archived and no longer accepts new learners.",
+  8: "This quest has been archived.",
   11: "This quest is invite only.",
+  13: "Enrollment is closed for this quest.",
+  14: "This quest's deadline has passed.",
 }
 
 const MILESTONE_ERROR_MESSAGES: Record<number, string> = {
@@ -235,12 +237,24 @@ export function QuestView() {
   const enrolleesData = useEnrollees(questId)
   const poolBalanceData = useRewardPool(questId)
 
-  // Combined loading state
+  // Combined loading state: true on initial load OR while any background
+  // refetch is in-flight (e.g. after a transaction). This keeps the skeleton
+  // as the single source of truth — no stale data flash between a transaction
+  // completing and the updated data arriving.
   const isLoading =
     questData.isLoading ||
     milestonesData.isLoading ||
     enrolleesData.isLoading ||
     poolBalanceData.isLoading
+
+  // Background refetch in-flight (post-transaction). Used to suppress
+  // interactive actions while data is refreshing without re-showing the
+  // full-page skeleton.
+  const isRefetching =
+    questData.isFetching ||
+    milestonesData.isFetching ||
+    enrolleesData.isFetching ||
+    poolBalanceData.isFetching
 
   // Use the first error that exists
   const loadError =
@@ -1244,7 +1258,7 @@ export function QuestView() {
                       variant="danger"
                       size="sm"
                       onClick={() => void handleArchiveQuest()}
-                      disabled={archiveQuestTx.isPending}
+                      disabled={archiveQuestTx.isPending || isRefetching}
                     >
                       {archiveQuestTx.isPending ? "Archiving..." : "Archive Quest"}
                     </Button>
@@ -1257,6 +1271,7 @@ export function QuestView() {
                   onClick={() => void handleEnroll()}
                   disabled={
                     enrollTx.isPending ||
+                    isRefetching ||
                     isEnrolled ||
                     !isSupportedNetwork ||
                     !address ||
@@ -1953,6 +1968,7 @@ export function QuestView() {
                     onClick={() => void handleEnroll()}
                     disabled={
                       enrollTx.isPending ||
+                      isRefetching ||
                       isEnrolled ||
                       !isSupportedNetwork ||
                       !address ||


### PR DESCRIPTION
update quest snapshots and add owner quests data

- Added new ledger entries for owner quests in multiple test snapshots.
- Enhanced the quest data structure to include owner quests and public category quests.
- Updated the ESLint configuration to include unused imports plugin.
- Improved error handling and loading states in quest-related hooks.
- Refactored quest view to manage loading and refetching states more effectively.
- Removed unused imports from the creator page.


Closes: #724
Closes: #722
Closes: #723
Closes: #721