### PR TITLE
fix: stabilize quest error numbering, validate milestone distribution mode, and strengthen pause coverage

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -136,6 +136,7 @@ pub enum Error {
     NotFound = 1,
     Unauthorized = 2,
     AlreadyCompleted = 4,
+    Reserved5 = 5, // reserved for stable ABI; do not reuse
     InvalidAmount = 6,
     OwnerMismatch = 7,
     NotInitialized = 8,
@@ -438,6 +439,10 @@ impl MilestoneContract {
 
         if matches!(mode, DistributionMode::Flat) && flat_reward <= 0 {
             return Err(Error::InvalidAmount);
+        }
+
+        if matches!(mode, DistributionMode::Competitive(max_winners) if max_winners == 0) {
+            return Err(Error::InvalidInput);
         }
 
         let mode_key = DataKey::Mode(quest_id);

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -409,6 +409,20 @@ fn test_flat_mode_fails_with_zero_reward() {
 
     let result = client.try_set_distribution_mode(&owner, &q_id, &DistributionMode::Flat, &0);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    assert_eq!(client.get_distribution_mode(&q_id), DistributionMode::Custom);
+    assert_eq!(client.get_flat_reward(&q_id), None);
+}
+
+#[test]
+fn test_competitive_mode_fails_with_zero_winners() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q_id, "Task", 100);
+
+    let result = client.try_set_distribution_mode(&owner, &q_id, &DistributionMode::Competitive(0), &0);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+    assert_eq!(client.get_distribution_mode(&q_id), DistributionMode::Custom);
+    assert_eq!(client.get_flat_reward(&q_id), None);
 }
 
 #[test]

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -48,6 +48,7 @@ pub enum Error {
     Unauthorized = 2,
     InvalidInput = 3,
     AlreadyEnrolled = 4,
+    Reserved5 = 5, // reserved for stable ABI; do not reuse
     NotEnrolled = 6,
     QuestFull = 7,
     QuestArchived = 8,

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Bytes, BytesN, Env, String};
 
 fn setup() -> (Env, QuestContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -1016,6 +1016,46 @@ fn test_pause_blocks_state_changes_until_unpaused() {
     assert!(!client.is_paused());
     client.add_enrollee(&quest_id, &enrollee);
     assert!(client.is_enrollee(&quest_id, &enrollee));
+}
+
+#[test]
+fn test_pause_blocks_all_write_endpoints_until_unpaused() {
+    let (env, client, owner, token) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let quest_id = create_quest_helper(&env, &client, &owner, &token);
+    let enrollee = Address::generate(&env);
+    let random_enrollee = Address::generate(&env);
+    let preimage = Bytes::from_array(&env, &[0u8; 32]);
+    let commitment: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+    client.add_enrollee(&quest_id, &enrollee);
+    client.pause(&admin);
+
+    assert_eq!(
+        client.try_update_quest(
+            &quest_id,
+            &owner,
+            &Some(String::from_str(&env, "Paused Quest")),
+            &Some(String::from_str(&env, "Description")),
+            &Some(String::from_str(&env, "Programming")),
+            &Some(Vec::<String>::new(&env)),
+            &Some(Visibility::Private),
+            &Some(10),
+        ),
+        Err(Ok(Error::Paused))
+    );
+    assert_eq!(client.try_archive_quest(&quest_id), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_add_enrollee(&quest_id, &random_enrollee), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_join_quest(&random_enrollee, &quest_id), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_register_invite(&owner, &quest_id, &commitment), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_revoke_invite(&owner, &quest_id, &commitment), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_join_quest_with_invite(&random_enrollee, &quest_id, &preimage), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_remove_enrollee(&quest_id, &enrollee), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_leave_quest(&enrollee, &quest_id), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_set_deadline(&quest_id, &123456), Err(Ok(Error::Paused)));
+    assert_eq!(client.try_set_visibility(&quest_id, &Visibility::Private), Err(Ok(Error::Paused)));
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes contract stability and validation coverage across the Quest and Milestone contracts.

- Reserve error variant 5 in the Quest error enum for ABI stability
- Reserve error variant 5 in the Milestone error enum for consistent ABI numbering
- Validate `DistributionMode::Competitive(0)` before any storage write in `milestone::set_distribution_mode`
- Strengthen milestone tests to assert no mode state is written when invalid distribution mode setup fails
- Add a comprehensive paused-state regression test in the Quest contract covering multiple write endpoints

closes #705 
closes #706 
closes #707 
closes #708