### PR TITLE
fix: coordinate Paused error codes, add proptests, docs, panic-resili…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -179,6 +185,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -291,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -515,7 +542,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -540,7 +567,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -551,6 +578,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -565,12 +602,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -591,6 +634,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -617,13 +666,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -644,9 +718,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -695,6 +784,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -778,6 +873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +889,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -807,6 +914,7 @@ version = "0.0.0"
 dependencies = [
  "certificate",
  "common",
+ "proptest",
  "quest",
  "soroban-sdk",
 ]
@@ -934,12 +1042,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "quest"
 version = "0.0.0"
 dependencies = [
  "common",
+ "proptest",
  "soroban-sdk",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -951,14 +1085,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -968,7 +1124,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -977,7 +1143,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -999,6 +1183,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rewards"
@@ -1031,10 +1221,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1187,7 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1224,7 +1439,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1252,7 +1467,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1260,8 +1475,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1270,7 +1485,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1313,7 +1528,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1353,7 +1568,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1498,6 +1713,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,10 +1783,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1567,10 +1807,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1618,6 +1885,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1930,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1711,6 +2012,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
     AlreadyIssued = 3,
     NotFound = 4,
     InvalidQuest = 5,
-    AlreadyRevoked = 6,  // Issue #720
-    MetadataBaseNotSet = 7,  // Issue #719
+    AlreadyRevoked = 6,     // Issue #720
+    MetadataBaseNotSet = 7, // Issue #719
 }
 
 const BUMP: u32 = 518_400;
@@ -290,13 +290,9 @@ impl CertificateContract {
     /// Trade-off: centralised control — consider moving to IPFS to decentralise.
     #[only_owner]
     pub fn set_metadata_base(env: Env, uri: String) -> Result<(), Error> {
-        env.storage()
-            .instance()
-            .set(&DataKey::MetadataBase, &uri);
-        env.events().publish(
-            (Symbol::new(&env, "metadata_base_updated"),),
-            uri,
-        );
+        env.storage().instance().set(&DataKey::MetadataBase, &uri);
+        env.events()
+            .publish((Symbol::new(&env, "metadata_base_updated"),), uri);
         Ok(())
     }
 

--- a/contracts/milestone/Cargo.toml
+++ b/contracts/milestone/Cargo.toml
@@ -16,6 +16,7 @@ common = { path = "../common" }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 quest = { path = "../quest" }
 certificate = { path = "../certificate" }
+proptest = "1"
 
 [features]
 testutils = []

--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -148,7 +148,9 @@ pub enum Error {
     TitleTooLong = 15,
     DescriptionTooLong = 16,
     BatchTooLarge = 17,
-    Paused = 18,
+    /// Contract is administratively paused; all mutating calls are rejected.
+    /// System band: code 400 is identical across all Lernza contracts.
+    Paused = 400,
     Overflow = 19,
     InvalidInput = 3,
 }

--- a/contracts/milestone/tests/id_monotonicity_proptest.rs
+++ b/contracts/milestone/tests/id_monotonicity_proptest.rs
@@ -1,0 +1,94 @@
+//! Property test: NextMilestoneId is strictly monotonic across all milestone flows.
+//!
+//! Randomly interleaves create_milestone and verify_completion operations and
+//! asserts that every returned milestone ID is strictly greater than the previous
+//! one within a given quest.
+
+use certificate::CertificateContract;
+use common::Visibility;
+use milestone::{MilestoneContract, MilestoneContractClient};
+use proptest::prelude::*;
+use quest::{QuestContract, QuestContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+#[derive(Debug, Clone)]
+enum Action {
+    CreateMilestone,
+    Verify(usize), // verify milestone at `index % created.len()`
+}
+
+fn arb_action() -> impl Strategy<Value = Action> {
+    prop_oneof![
+        Just(Action::CreateMilestone),
+        (0usize..100).prop_map(Action::Verify),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+    #[test]
+    fn next_milestone_id_is_strictly_monotonic(
+        actions in proptest::collection::vec(arb_action(), 1..50)
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let quest_id = env.register(QuestContract, ());
+        let quest_client = QuestContractClient::new(&env, &quest_id);
+
+        let milestone_id = env.register(MilestoneContract, ());
+        let milestone_client = MilestoneContractClient::new(&env, &milestone_id);
+
+        let cert_id = env.register(CertificateContract, (milestone_id.clone(),));
+
+        let admin = Address::generate(&env);
+        milestone_client.initialize(&admin, &quest_id, &cert_id);
+
+        let owner = Address::generate(&env);
+        let fake_token = env.register(QuestContract, ());
+
+        let qid = quest_client.create_quest(
+            &owner,
+            &String::from_str(&env, "Quest"),
+            &String::from_str(&env, "Description"),
+            &String::from_str(&env, "Programming"),
+            &Vec::<String>::new(&env),
+            &fake_token,
+            &Visibility::Public,
+            &None,
+        );
+
+        // Enroll a learner so verify_completion can succeed
+        let learner = Address::generate(&env);
+        quest_client.add_enrollee(&qid, &learner);
+
+        let mut created: std::vec::Vec<u32> = std::vec::Vec::new();
+        let mut prev_id: Option<u32> = None;
+
+        for action in &actions {
+            match action {
+                Action::CreateMilestone => {
+                    let mid = milestone_client.create_milestone(
+                        &owner,
+                        &qid,
+                        &String::from_str(&env, "Milestone"),
+                        &String::from_str(&env, "Description"),
+                        &100,
+                        &false,
+                    );
+                    if let Some(prev) = prev_id {
+                        prop_assert!(mid > prev, "milestone id {} not > prev {}", mid, prev);
+                    }
+                    prev_id = Some(mid);
+                    created.push(mid);
+                }
+                Action::Verify(idx) => {
+                    if created.is_empty() { continue; }
+                    let mid = created[*idx % created.len()];
+                    // ignore errors (already completed, etc.)
+                    let _ = milestone_client.try_verify_completion(&owner, &qid, &mid, &learner);
+                }
+            }
+        }
+    }
+}

--- a/contracts/quest/Cargo.toml
+++ b/contracts/quest/Cargo.toml
@@ -14,6 +14,7 @@ common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = []

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -54,7 +54,6 @@ pub enum Error {
     NameTooLong = 9,
     DescriptionTooLong = 10,
     InviteOnly = 11,
-    Paused = 12,
     /// Enrollment is closed because the quest has been archived.
     EnrollmentClosed = 13,
     /// Enrollment is rejected because the quest deadline has passed.
@@ -63,6 +62,9 @@ pub enum Error {
     InvalidInvite = 15,
     /// The invite code has already been redeemed.
     InviteAlreadyUsed = 16,
+    /// Contract is administratively paused; all mutating calls are rejected.
+    /// System band: code 400 is identical across all Lernza contracts.
+    Paused = 400,
 }
 
 // TTL constants and address validation moved to common.

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1360,8 +1360,7 @@ fn sha256_commitment(env: &Env, preimage: &[u8]) -> BytesN<32> {
 #[test]
 fn test_invite_happy_path_private_quest() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"super-secret-invite-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1386,8 +1385,7 @@ fn test_invite_happy_path_private_quest() {
 #[test]
 fn test_invite_replay_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"one-time-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1399,11 +1397,8 @@ fn test_invite_replay_rejected() {
 
     // Second enrollee tries to reuse the same preimage — must fail.
     let learner2 = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner2,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner2, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::InviteAlreadyUsed)));
     assert!(!client.is_enrollee(&quest_id, &learner2));
 }
@@ -1411,8 +1406,7 @@ fn test_invite_replay_rejected() {
 #[test]
 fn test_invite_wrong_preimage_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"correct-secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1431,8 +1425,7 @@ fn test_invite_wrong_preimage_rejected() {
 #[test]
 fn test_invite_unregistered_commitment_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     // No register_invite call — any preimage should fail.
     let learner = Address::generate(&env);
@@ -1447,8 +1440,7 @@ fn test_invite_unregistered_commitment_rejected() {
 #[test]
 fn test_multiple_independent_invites() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage_a = b"invite-for-alice";
     let preimage_b = b"invite-for-bob";
@@ -1476,8 +1468,7 @@ fn test_multiple_independent_invites() {
 #[test]
 fn test_invite_on_archived_quest_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1486,19 +1477,15 @@ fn test_invite_on_archived_quest_rejected() {
     client.archive_quest(&quest_id);
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
 }
 
 #[test]
 fn test_invite_past_deadline_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1508,11 +1495,8 @@ fn test_invite_past_deadline_rejected() {
     client.set_deadline(&quest_id, &999);
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
 }
 
@@ -1543,11 +1527,8 @@ fn test_invite_respects_enrollment_cap() {
     assert!(client.is_enrollee(&quest_id, &alice));
 
     let bob = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &bob,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage_b),
-    );
+    let result =
+        client.try_join_quest_with_invite(&bob, &quest_id, &Bytes::from_slice(&env, preimage_b));
     assert_eq!(result, Err(Ok(Error::QuestFull)));
     assert!(!client.is_enrollee(&quest_id, &bob));
 }
@@ -1555,8 +1536,7 @@ fn test_invite_respects_enrollment_cap() {
 #[test]
 fn test_invite_already_enrolled_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage_a = b"first-invite";
     let preimage_b = b"second-invite";
@@ -1582,8 +1562,7 @@ fn test_invite_already_enrolled_rejected() {
 #[test]
 fn test_register_invite_non_owner_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let commitment = sha256_commitment(&env, b"secret");
     let impostor = Address::generate(&env);
@@ -1594,8 +1573,7 @@ fn test_register_invite_non_owner_rejected() {
 #[test]
 fn test_register_invite_archived_quest_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
     client.archive_quest(&quest_id);
 
     let commitment = sha256_commitment(&env, b"secret");
@@ -1606,8 +1584,7 @@ fn test_register_invite_archived_quest_rejected() {
 #[test]
 fn test_revoke_invite_prevents_redemption() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"revocable-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1619,19 +1596,15 @@ fn test_revoke_invite_prevents_redemption() {
     assert!(!client.is_invite_valid(&quest_id, &commitment));
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::InvalidInvite)));
 }
 
 #[test]
 fn test_revoke_invite_non_owner_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let commitment = sha256_commitment(&env, b"secret");
     client.register_invite(&owner, &quest_id, &commitment);
@@ -1645,8 +1618,7 @@ fn test_revoke_invite_non_owner_rejected() {
 fn test_invite_works_on_public_quest() {
     // Invite path is not restricted to private quests.
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
 
     let preimage = b"public-invite";
     let commitment = sha256_commitment(&env, preimage);

--- a/contracts/quest/tests/id_monotonicity_proptest.rs
+++ b/contracts/quest/tests/id_monotonicity_proptest.rs
@@ -1,0 +1,82 @@
+//! Property test: NextId is strictly monotonic across all quest flows.
+//!
+//! Randomly interleaves create_quest and archive_quest operations and asserts
+//! that every returned quest ID is strictly greater than the previous one.
+
+use proptest::prelude::*;
+use quest::{QuestContract, QuestContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+use common::Visibility;
+
+/// Actions that can be applied to the quest contract.
+#[derive(Debug, Clone)]
+enum Action {
+    Create,
+    Archive(usize), // archive the quest at position `index % created.len()`
+    Enroll(usize),  // enroll a random address into quest at `index % created.len()`
+}
+
+fn arb_action() -> impl Strategy<Value = Action> {
+    prop_oneof![
+        Just(Action::Create),
+        (0usize..100).prop_map(Action::Archive),
+        (0usize..100).prop_map(Action::Enroll),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+    #[test]
+    fn next_id_is_strictly_monotonic(actions in proptest::collection::vec(arb_action(), 1..50)) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(QuestContract, ());
+        let client = QuestContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let _token = Address::generate(&env);
+
+        // token must look like a contract address (starts with 'C', len 56)
+        // Use a fixed valid-looking address via register
+        let fake_token = env.register(QuestContract, ()); // any contract address works
+
+        let mut created: Vec<u32> = Vec::new(&env);
+        let mut prev_id: Option<u32> = None;
+
+        for action in &actions {
+            match action {
+                Action::Create => {
+                    let id = client.create_quest(
+                        &owner,
+                        &String::from_str(&env, "Quest"),
+                        &String::from_str(&env, "Description"),
+                        &String::from_str(&env, "Programming"),
+                        &soroban_sdk::Vec::<String>::new(&env),
+                        &fake_token,
+                        &Visibility::Public,
+                        &None,
+                    );
+                    // Each new ID must be strictly greater than the previous
+                    if let Some(prev) = prev_id {
+                        prop_assert!(id > prev, "id {} not > prev {}", id, prev);
+                    }
+                    prev_id = Some(id);
+                    created.push_back(id);
+                }
+                Action::Archive(idx) => {
+                    if created.is_empty() { continue; }
+                    let quest_id = created.get(*idx as u32 % created.len()).unwrap();
+                    // archive may fail if already archived — ignore errors
+                    let _ = client.try_archive_quest(&quest_id);
+                }
+                Action::Enroll(idx) => {
+                    if created.is_empty() { continue; }
+                    let quest_id = created.get(*idx as u32 % created.len()).unwrap();
+                    let enrollee = Address::generate(&env);
+                    let _ = client.try_add_enrollee(&quest_id, &enrollee);
+                }
+            }
+        }
+    }
+}

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -507,11 +507,7 @@ impl RewardsContract {
     ///   - Quest is `Archived`
     ///   - 7-day refund window has elapsed
     ///   - There is actually something to refund
-    pub fn refund_unused_pool(
-        env: Env,
-        authority: Address,
-        quest_id: u32,
-    ) -> Result<i128, Error> {
+    pub fn refund_unused_pool(env: Env, authority: Address, quest_id: u32) -> Result<i128, Error> {
         authority.require_auth();
 
         // Verify authority
@@ -586,11 +582,9 @@ impl RewardsContract {
         env.storage()
             .persistent()
             .set(&DataKey::QuestPool(quest_id), &new_pool);
-        env.storage().persistent().extend_ttl(
-            &DataKey::QuestPool(quest_id),
-            THRESHOLD,
-            BUMP,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::QuestPool(quest_id), THRESHOLD, BUMP);
 
         // Emit event — reuse reward_refunded topic for indexer compatibility
         env.events().publish(

--- a/contracts/rewards/tests/panic_resilience_test.rs
+++ b/contracts/rewards/tests/panic_resilience_test.rs
@@ -1,0 +1,204 @@
+//! Panic-resilience tests: a contract panic must not corrupt sibling contract state.
+//!
+//! Soroban rolls back all storage mutations when a contract invocation returns
+//! an error or panics. These tests verify that a failing call to contract B
+//! leaves contract A's pre-call state intact across the full 4-contract stack.
+
+use certificate::CertificateContract;
+use common::Visibility;
+use milestone::{MilestoneContract, MilestoneContractClient};
+use quest::{QuestContract, QuestContractClient};
+use rewards::{RewardsContract, RewardsContractClient};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    Address, Env, String, Vec,
+};
+
+// ── Shared setup ─────────────────────────────────────────────────────────────
+
+struct Ctx {
+    env: Env,
+    token_addr: Address,
+    quest_id: Address,
+    milestone_id: Address,
+    rewards_id: Address,
+}
+
+impl Ctx {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let token_admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+        let token_addr = token_contract.address();
+
+        let quest_id = env.register(QuestContract, ());
+        let milestone_id = env.register(MilestoneContract, ());
+        let cert_id = env.register(CertificateContract, (milestone_id.clone(),));
+        let rewards_id = env.register(RewardsContract, ());
+
+        let admin = Address::generate(&env);
+        MilestoneContractClient::new(&env, &milestone_id).initialize(&admin, &quest_id, &cert_id);
+        RewardsContractClient::new(&env, &rewards_id).initialize(
+            &token_addr,
+            &quest_id,
+            &milestone_id,
+        );
+
+        Self {
+            env,
+            token_addr,
+            quest_id,
+            milestone_id,
+            rewards_id,
+        }
+    }
+
+    fn quest(&self) -> QuestContractClient<'_> {
+        QuestContractClient::new(&self.env, &self.quest_id)
+    }
+
+    fn milestone(&self) -> MilestoneContractClient<'_> {
+        MilestoneContractClient::new(&self.env, &self.milestone_id)
+    }
+
+    fn rewards(&self) -> RewardsContractClient<'_> {
+        RewardsContractClient::new(&self.env, &self.rewards_id)
+    }
+
+    fn mint(&self, to: &Address, amount: i128) {
+        StellarAssetClient::new(&self.env, &self.token_addr).mint(to, &amount);
+    }
+
+    fn balance(&self, of: &Address) -> i128 {
+        TokenClient::new(&self.env, &self.token_addr).balance(of)
+    }
+
+    fn create_quest(&self, owner: &Address) -> u32 {
+        self.quest().create_quest(
+            owner,
+            &String::from_str(&self.env, "Quest"),
+            &String::from_str(&self.env, "Description"),
+            &String::from_str(&self.env, "Programming"),
+            &Vec::<String>::new(&self.env),
+            &self.token_addr,
+            &Visibility::Public,
+            &None,
+        )
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Quest state (A) is unchanged when a milestone call (B) fails.
+///
+/// Flow: create quest → fund pool → attempt verify_completion for a
+/// non-enrolled address (B panics) → assert quest enrollee list and pool
+/// balance are unchanged.
+#[test]
+fn quest_state_intact_after_milestone_panic() {
+    let ctx = Ctx::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+    let stranger = Address::generate(&ctx.env);
+
+    ctx.mint(&owner, 5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.milestone().create_milestone(
+        &owner,
+        &q_id,
+        &String::from_str(&ctx.env, "MS"),
+        &String::from_str(&ctx.env, "Desc"),
+        &500,
+        &false,
+    );
+
+    // Snapshot A state before the failing call
+    let enrollees_before = ctx.quest().get_enrollees(&q_id);
+    let pool_before = ctx.rewards().get_pool_balance(&q_id);
+
+    // B: verify_completion for a stranger (not enrolled) — must fail
+    let result = ctx
+        .milestone()
+        .try_verify_completion(&owner, &q_id, &ms_id, &stranger);
+    assert!(result.is_err(), "expected error for non-enrolled stranger");
+
+    // A state must be identical to the snapshot
+    assert_eq!(ctx.quest().get_enrollees(&q_id), enrollees_before);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), pool_before);
+    assert!(!ctx.milestone().is_completed(&q_id, &ms_id, &stranger));
+}
+
+/// Rewards pool (A) is unchanged when distribute_reward (C) fails because
+/// the milestone (B) was never completed.
+///
+/// Flow: create quest → fund pool → create milestone → attempt distribute
+/// without verify_completion → assert pool balance unchanged.
+#[test]
+fn rewards_pool_intact_after_distribute_without_completion() {
+    let ctx = Ctx::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+
+    ctx.mint(&owner, 5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.milestone().create_milestone(
+        &owner,
+        &q_id,
+        &String::from_str(&ctx.env, "MS"),
+        &String::from_str(&ctx.env, "Desc"),
+        &500,
+        &false,
+    );
+
+    let pool_before = ctx.rewards().get_pool_balance(&q_id);
+    let earnings_before = ctx.rewards().get_user_earnings(&enrollee);
+    let enrollee_balance_before = ctx.balance(&enrollee);
+
+    // C: distribute without prior verify_completion — must fail
+    let result = ctx
+        .rewards()
+        .try_distribute_reward(&owner, &q_id, &ms_id, &enrollee, &500);
+    assert!(result.is_err(), "expected error: milestone not completed");
+
+    // A (rewards pool) must be unchanged
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), pool_before);
+    assert_eq!(ctx.rewards().get_user_earnings(&enrollee), earnings_before);
+    assert_eq!(ctx.balance(&enrollee), enrollee_balance_before);
+}
+
+/// Quest enrollment list (A) is unchanged when a rewards fund_quest call (C)
+/// fails due to insufficient token balance.
+///
+/// This exercises the A → C path (skipping B) to confirm cross-contract
+/// rollback isolation is not limited to adjacent contracts.
+#[test]
+fn quest_enrollment_intact_after_failed_fund() {
+    let ctx = Ctx::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+
+    // owner has no tokens — fund_quest will fail
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+
+    let enrollees_before = ctx.quest().get_enrollees(&q_id);
+
+    // C: fund_quest with no token balance — must fail
+    let result = ctx.rewards().try_fund_quest(&owner, &q_id, &1_000);
+    assert!(result.is_err(), "expected error: no token balance");
+
+    // A state unchanged
+    assert_eq!(ctx.quest().get_enrollees(&q_id), enrollees_before);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 0);
+}

--- a/docs/contracts/ERROR_CONVENTIONS.md
+++ b/docs/contracts/ERROR_CONVENTIONS.md
@@ -1,0 +1,102 @@
+# Contract Error Code Conventions
+
+## Overview
+
+Each Lernza contract defines its own `Error` enum with `#[contracterror]` and
+`#[repr(u32)]`. Error codes are the wire format returned to clients; they must
+be stable across upgrades.
+
+## Bands
+
+| Range | Owner | Purpose |
+|-------|-------|---------|
+| 1 – 99 | Per-contract | Contract-specific errors (may differ between contracts) |
+| 400 – 499 | System / cross-cutting | Identical semantics across **all** contracts |
+
+### System band (400+)
+
+These variants carry the **same numeric code and the same meaning** in every
+contract that uses them. Frontends and SDKs can catch them without knowing
+which contract raised the error.
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 400 | `Paused` | The contract has been administratively paused; all mutating calls are rejected |
+
+> **Rule:** any new cross-cutting concern (e.g. `RateLimited`, `Deprecated`)
+> must be assigned the next free code in the 400–499 band and documented here
+> before being added to any contract.
+
+## Per-contract error tables
+
+### Quest contract (`contracts/quest`)
+
+| Code | Variant |
+|------|---------|
+| 1 | `NotFound` |
+| 2 | `Unauthorized` |
+| 3 | `InvalidInput` |
+| 4 | `AlreadyEnrolled` |
+| 6 | `NotEnrolled` |
+| 7 | `QuestFull` |
+| 8 | `QuestArchived` |
+| 9 | `NameTooLong` |
+| 10 | `DescriptionTooLong` |
+| 11 | `InviteOnly` |
+| 13 | `EnrollmentClosed` |
+| 14 | `DeadlineExpired` |
+| 15 | `InvalidInvite` |
+| 16 | `InviteAlreadyUsed` |
+| 400 | `Paused` *(system band)* |
+
+### Milestone contract (`contracts/milestone`)
+
+| Code | Variant |
+|------|---------|
+| 1 | `NotFound` |
+| 2 | `Unauthorized` |
+| 3 | `InvalidInput` |
+| 4 | `AlreadyCompleted` |
+| 6 | `InvalidAmount` |
+| 7 | `OwnerMismatch` |
+| 8 | `NotInitialized` |
+| 9 | `AlreadySubmitted` |
+| 10 | `NotSubmitted` |
+| 11 | `AlreadyApproved` |
+| 12 | `NotEnrolled` |
+| 13 | `InvalidApprover` |
+| 14 | `MilestoneNotUnlocked` |
+| 15 | `TitleTooLong` |
+| 16 | `DescriptionTooLong` |
+| 17 | `BatchTooLarge` |
+| 19 | `Overflow` |
+| 400 | `Paused` *(system band)* |
+
+### Rewards contract (`contracts/rewards`)
+
+| Code | Variant |
+|------|---------|
+| 1 | `AlreadyInitialized` |
+| 2 | `NotInitialized` |
+| 3 | `Unauthorized` |
+| 4 | `InsufficientPool` |
+| 5 | `InvalidAmount` |
+| 6 | `QuestNotFunded` |
+| 7 | `QuestLookupFailed` |
+| 8 | `MilestoneNotCompleted` |
+| 9 | `MilestoneContractNotInitialized` |
+| 10 | `ArithmeticOverflow` |
+| 11 | `AlreadyPaid` |
+| 12 | `InvalidToken` |
+| 13 | `RewardAmountMismatch` |
+| 14 | `QuestNotArchived` |
+| 15 | `RefundWindowNotOpen` |
+
+## Adding new errors
+
+1. Decide: is this cross-cutting (same meaning in ≥2 contracts)?
+   - **Yes** → assign the next free code in 400–499, add it to this doc, then
+     add the variant to every affected contract with that exact code.
+   - **No** → assign the next free code in 1–99 for that contract only.
+2. Never reuse a retired code.
+3. Update this document in the same PR as the code change.

--- a/docs/contracts/INIT_ORDER.md
+++ b/docs/contracts/INIT_ORDER.md
@@ -1,0 +1,94 @@
+# Contract Initialisation Order
+
+## Why order matters
+
+`milestone::initialize` and `rewards::initialize` each store the address of
+another contract at init time. If you pass a wrong or not-yet-deployed address
+the stored pointer is permanently wrong and every cross-contract call will
+fail. There is no re-initialise function.
+
+## Exact deploy + init sequence
+
+```
+Step 1  Deploy  quest
+Step 2  Deploy  certificate  (constructor arg: milestone address — see note)
+Step 3  Deploy  milestone
+Step 4  Deploy  rewards
+Step 5  Init    milestone    milestone::initialize(admin, quest_addr, certificate_addr)
+Step 6  Init    rewards      rewards::initialize(token_addr, quest_addr, milestone_addr)
+```
+
+> **Note on step 2 vs 3:** The `certificate` contract constructor takes the
+> address of the contract that is allowed to mint certificates (i.e. the
+> milestone contract). Because Soroban contract addresses are deterministic
+> from the deployer account + salt, you can pre-compute the milestone address
+> before deploying it and pass that pre-computed address to the certificate
+> constructor. Alternatively, deploy certificate *after* milestone and pass the
+> real address. Either approach is valid; the important constraint is that the
+> address stored in certificate must equal the address of the deployed
+> milestone contract.
+
+## Failure modes if order is violated
+
+| Mistake | Symptom |
+|---------|---------|
+| `milestone::initialize` called before quest is deployed | Stored quest address is invalid; `create_milestone` cross-contract call panics on first use |
+| `rewards::initialize` called before milestone is deployed | Stored milestone address is invalid; `distribute_reward` panics when checking completion |
+| `milestone::initialize` called twice | Returns `Error::AlreadyInitialized`; second call is a no-op (state unchanged) |
+| `rewards::initialize` called twice | Returns `Error::AlreadyInitialized`; second call is a no-op (state unchanged) |
+| Certificate constructor given wrong milestone address | `mint_quest_certificate` cross-contract call fails auth check at runtime |
+
+## Testnet deploy example
+
+```bash
+# 1. Deploy quest
+QUEST_ADDR=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/quest.wasm \
+  --source <DEPLOYER_KEY> --network testnet)
+
+# 2. Deploy milestone (address needed for certificate constructor)
+MILESTONE_ADDR=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/milestone.wasm \
+  --source <DEPLOYER_KEY> --network testnet)
+
+# 3. Deploy certificate with milestone address as owner
+CERT_ADDR=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/certificate.wasm \
+  --source <DEPLOYER_KEY> --network testnet \
+  -- --owner $MILESTONE_ADDR)
+
+# 4. Deploy rewards
+REWARDS_ADDR=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/rewards.wasm \
+  --source <DEPLOYER_KEY> --network testnet)
+
+# 5. Init milestone
+stellar contract invoke --id $MILESTONE_ADDR \
+  --source <DEPLOYER_KEY> --network testnet \
+  -- initialize \
+  --admin <ADMIN_ADDR> \
+  --quest_contract $QUEST_ADDR \
+  --certificate_contract $CERT_ADDR
+
+# 6. Init rewards
+stellar contract invoke --id $REWARDS_ADDR \
+  --source <DEPLOYER_KEY> --network testnet \
+  -- initialize \
+  --token_addr <TOKEN_ADDR> \
+  --quest_contract $QUEST_ADDR \
+  --milestone_contract $MILESTONE_ADDR
+```
+
+## Verification
+
+After deploying, confirm the stored addresses are correct:
+
+```bash
+stellar contract invoke --id $MILESTONE_ADDR --network testnet \
+  -- get_quest_contract
+
+stellar contract invoke --id $REWARDS_ADDR --network testnet \
+  -- get_milestone_contract
+```
+
+Both should return the addresses you passed during initialisation.


### PR DESCRIPTION
Title: fix: coordinate Paused codes, proptests, init-order doc, panic-resilience tests (#709 #710 #711 #712)

Body:

### #712 — Coordinate Paused error codes
- Moved `Paused` to system band **400** in both `quest` and `milestone` (was 12 and 18)
- Added `docs/contracts/ERROR_CONVENTIONS.md` with 1–99 per-contract band and 400–499 cross-cutting band

### #711 — Document init order
- Added `docs/contracts/INIT_ORDER.md` with exact deploy/init sequence, failure modes, and testnet example

### #710 — ID monotonicity proptests
- `contracts/quest/tests/id_monotonicity_proptest.rs` — 1000 cases, NextId strictly monotonic
- `contracts/milestone/tests/id_monotonicity_proptest.rs` — 1000 cases, NextMilestoneId strictly monotonic

### #709 — Panic resilience tests
- `contracts/rewards/tests/panic_resilience_test.rs` — 3 tests verify sibling state unchanged after failing cross-contract calls

## Closes 

Closes #709
Closes #710
Closes #711 
Closes #712



All tests pass.