### PR TITLE
fix: reduced-motion guard, 404 noindex, broadened e2e, deterministic leaderboard tests

### DIFF
--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
     AlreadyIssued = 3,
     NotFound = 4,
     InvalidQuest = 5,
-    AlreadyRevoked = 6,  // Issue #720
-    MetadataBaseNotSet = 7,  // Issue #719
+    AlreadyRevoked = 6,     // Issue #720
+    MetadataBaseNotSet = 7, // Issue #719
 }
 
 const BUMP: u32 = 518_400;
@@ -290,13 +290,9 @@ impl CertificateContract {
     /// Trade-off: centralised control — consider moving to IPFS to decentralise.
     #[only_owner]
     pub fn set_metadata_base(env: Env, uri: String) -> Result<(), Error> {
-        env.storage()
-            .instance()
-            .set(&DataKey::MetadataBase, &uri);
-        env.events().publish(
-            (Symbol::new(&env, "metadata_base_updated"),),
-            uri,
-        );
+        env.storage().instance().set(&DataKey::MetadataBase, &uri);
+        env.events()
+            .publish((Symbol::new(&env, "metadata_base_updated"),), uri);
         Ok(())
     }
 

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1360,8 +1360,7 @@ fn sha256_commitment(env: &Env, preimage: &[u8]) -> BytesN<32> {
 #[test]
 fn test_invite_happy_path_private_quest() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"super-secret-invite-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1386,8 +1385,7 @@ fn test_invite_happy_path_private_quest() {
 #[test]
 fn test_invite_replay_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"one-time-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1399,11 +1397,8 @@ fn test_invite_replay_rejected() {
 
     // Second enrollee tries to reuse the same preimage — must fail.
     let learner2 = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner2,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner2, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::InviteAlreadyUsed)));
     assert!(!client.is_enrollee(&quest_id, &learner2));
 }
@@ -1411,8 +1406,7 @@ fn test_invite_replay_rejected() {
 #[test]
 fn test_invite_wrong_preimage_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"correct-secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1431,8 +1425,7 @@ fn test_invite_wrong_preimage_rejected() {
 #[test]
 fn test_invite_unregistered_commitment_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     // No register_invite call — any preimage should fail.
     let learner = Address::generate(&env);
@@ -1447,8 +1440,7 @@ fn test_invite_unregistered_commitment_rejected() {
 #[test]
 fn test_multiple_independent_invites() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage_a = b"invite-for-alice";
     let preimage_b = b"invite-for-bob";
@@ -1476,8 +1468,7 @@ fn test_multiple_independent_invites() {
 #[test]
 fn test_invite_on_archived_quest_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1486,19 +1477,15 @@ fn test_invite_on_archived_quest_rejected() {
     client.archive_quest(&quest_id);
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::EnrollmentClosed)));
 }
 
 #[test]
 fn test_invite_past_deadline_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"secret";
     let commitment = sha256_commitment(&env, preimage);
@@ -1508,11 +1495,8 @@ fn test_invite_past_deadline_rejected() {
     client.set_deadline(&quest_id, &999);
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
 }
 
@@ -1543,11 +1527,8 @@ fn test_invite_respects_enrollment_cap() {
     assert!(client.is_enrollee(&quest_id, &alice));
 
     let bob = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &bob,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage_b),
-    );
+    let result =
+        client.try_join_quest_with_invite(&bob, &quest_id, &Bytes::from_slice(&env, preimage_b));
     assert_eq!(result, Err(Ok(Error::QuestFull)));
     assert!(!client.is_enrollee(&quest_id, &bob));
 }
@@ -1555,8 +1536,7 @@ fn test_invite_respects_enrollment_cap() {
 #[test]
 fn test_invite_already_enrolled_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage_a = b"first-invite";
     let preimage_b = b"second-invite";
@@ -1582,8 +1562,7 @@ fn test_invite_already_enrolled_rejected() {
 #[test]
 fn test_register_invite_non_owner_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let commitment = sha256_commitment(&env, b"secret");
     let impostor = Address::generate(&env);
@@ -1594,8 +1573,7 @@ fn test_register_invite_non_owner_rejected() {
 #[test]
 fn test_register_invite_archived_quest_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
     client.archive_quest(&quest_id);
 
     let commitment = sha256_commitment(&env, b"secret");
@@ -1606,8 +1584,7 @@ fn test_register_invite_archived_quest_rejected() {
 #[test]
 fn test_revoke_invite_prevents_redemption() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let preimage = b"revocable-code";
     let commitment = sha256_commitment(&env, preimage);
@@ -1619,19 +1596,15 @@ fn test_revoke_invite_prevents_redemption() {
     assert!(!client.is_invite_valid(&quest_id, &commitment));
 
     let learner = Address::generate(&env);
-    let result = client.try_join_quest_with_invite(
-        &learner,
-        &quest_id,
-        &Bytes::from_slice(&env, preimage),
-    );
+    let result =
+        client.try_join_quest_with_invite(&learner, &quest_id, &Bytes::from_slice(&env, preimage));
     assert_eq!(result, Err(Ok(Error::InvalidInvite)));
 }
 
 #[test]
 fn test_revoke_invite_non_owner_rejected() {
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
 
     let commitment = sha256_commitment(&env, b"secret");
     client.register_invite(&owner, &quest_id, &commitment);
@@ -1645,8 +1618,7 @@ fn test_revoke_invite_non_owner_rejected() {
 fn test_invite_works_on_public_quest() {
     // Invite path is not restricted to private quests.
     let (env, client, owner, token) = setup();
-    let quest_id =
-        create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
 
     let preimage = b"public-invite";
     let commitment = sha256_commitment(&env, preimage);

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -507,11 +507,7 @@ impl RewardsContract {
     ///   - Quest is `Archived`
     ///   - 7-day refund window has elapsed
     ///   - There is actually something to refund
-    pub fn refund_unused_pool(
-        env: Env,
-        authority: Address,
-        quest_id: u32,
-    ) -> Result<i128, Error> {
+    pub fn refund_unused_pool(env: Env, authority: Address, quest_id: u32) -> Result<i128, Error> {
         authority.require_auth();
 
         // Verify authority
@@ -586,11 +582,9 @@ impl RewardsContract {
         env.storage()
             .persistent()
             .set(&DataKey::QuestPool(quest_id), &new_pool);
-        env.storage().persistent().extend_ttl(
-            &DataKey::QuestPool(quest_id),
-            THRESHOLD,
-            BUMP,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::QuestPool(quest_id), THRESHOLD, BUMP);
 
         // Emit event — reuse reward_refunded topic for indexer compatibility
         env.events().publish(

--- a/frontend/e2e/landing.spec.ts
+++ b/frontend/e2e/landing.spec.ts
@@ -7,7 +7,6 @@ test.describe("Landing page", () => {
 
   test("loads and renders the hero section", async ({ page }) => {
     await expect(page).toHaveTitle(/Lernza/i)
-    // Hero heading contains the brand name or tagline
     const heading = page.getByRole("heading", { level: 1 })
     await expect(heading).toBeVisible()
   })
@@ -18,16 +17,50 @@ test.describe("Landing page", () => {
   })
 
   test("shows navigation button for Leaderboard", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /leaderboard/i })).toBeVisible()
-  })
-
-  test("has a call-to-action button", async ({ page }) => {
-    // Landing page should have at least one primary CTA button
-    const cta = page.getByRole("button").first()
-    await expect(cta).toBeVisible()
+    await expect(page.getByRole("link", { name: /leaderboard/i })).toBeVisible()
   })
 
   test("page has no broken layout — main content is visible", async ({ page }) => {
     await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("hero has a Launch App CTA button", async ({ page }) => {
+    const launchBtn = page.getByRole("button", { name: /launch app/i })
+    await expect(launchBtn).toBeVisible()
+  })
+
+  test("hero has a How it works button that scrolls to the section", async ({ page }) => {
+    const howBtn = page.getByRole("button", { name: /how it works/i })
+    await expect(howBtn).toBeVisible()
+
+    await howBtn.click()
+
+    const section = page.locator("#how-it-works")
+    await expect(section).toBeVisible()
+  })
+
+  test("Connect Wallet button is present in the navbar", async ({ page }) => {
+    const connectBtn = page.getByRole("button", { name: /connect wallet/i })
+    await expect(connectBtn).toBeVisible()
+  })
+
+  test("dark mode toggle switches the colour scheme", async ({ page }) => {
+    const toggle = page.getByRole("button", { name: /switch to (dark|light) mode/i })
+    await expect(toggle).toBeVisible()
+
+    const html = page.locator("html")
+    const before = await html.getAttribute("class")
+
+    await toggle.click()
+
+    const after = await html.getAttribute("class")
+    expect(after).not.toBe(before)
+  })
+
+  test("feature grid renders the three how-it-works steps", async ({ page }) => {
+    const section = page.locator("#how-it-works")
+    await expect(section.getByText("Create a Quest")).toBeVisible()
+    await expect(section.getByText("Set Milestones")).toBeVisible()
+    await expect(section.getByText("Verify & Reward")).toBeVisible()
   })
 })

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -111,6 +117,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-unused-imports:
+        specifier: ^4.4.1
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
       globals:
         specifier: ^17.5.0
         version: 17.5.0
@@ -147,8 +156,14 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3)))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@apideck/better-ajv-errors@0.3.7':
     resolution: {integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==}
@@ -1268,6 +1283,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -1674,6 +1693,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -1739,6 +1762,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1803,6 +1829,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1901,6 +1930,15 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-unused-imports@4.4.1:
+    resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^10.0.0 || ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2188,6 +2226,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2491,6 +2533,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -2551,6 +2596,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2840,6 +2889,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3082,6 +3135,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3315,6 +3372,11 @@ packages:
       yaml:
         optional: true
 
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
+
   vitest@4.1.5:
     resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -3490,6 +3552,8 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@apideck/better-ajv-errors@0.3.7(ajv@8.20.0)':
     dependencies:
@@ -4637,6 +4701,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -5051,6 +5124,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -5106,6 +5181,8 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
 
@@ -5167,6 +5244,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5369,6 +5448,12 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5652,6 +5737,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -5953,6 +6040,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.merge@4.6.2: {}
@@ -6004,6 +6093,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6221,6 +6312,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6529,6 +6625,10 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
@@ -6725,6 +6825,16 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.2
       yaml: 2.8.3
+
+  vitest-axe@0.1.0(vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3))):
+    dependencies:
+      aria-query: 5.3.0
+      axe-core: 4.11.3
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3))
 
   vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(yaml@2.8.3)):
     dependencies:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { RouterProvider } from "react-router-dom"
+import { MotionConfig } from "framer-motion"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { ThemeProvider } from "@/contexts/theme-context"
 import { router } from "@/routes"
@@ -15,13 +16,15 @@ import { SpeedInsights } from "@vercel/speed-insights/react"
  */
 function App() {
   return (
-    <ThemeProvider>
-      <ErrorBoundary githubRepo="https://github.com/lernza/lernza">
-        <RouterProvider router={router} />
-      </ErrorBoundary>
-      <Analytics />
-      <SpeedInsights />
-    </ThemeProvider>
+    <MotionConfig reducedMotion="user">
+      <ThemeProvider>
+        <ErrorBoundary githubRepo="https://github.com/lernza/lernza">
+          <RouterProvider router={router} />
+        </ErrorBoundary>
+        <Analytics />
+        <SpeedInsights />
+      </ThemeProvider>
+    </MotionConfig>
   )
 }
 

--- a/frontend/src/pages/leaderboard.test.tsx
+++ b/frontend/src/pages/leaderboard.test.tsx
@@ -1,17 +1,7 @@
 import React from "react"
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
-
-const mockNavigate = vi.fn()
-
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
-})
 
 vi.mock("@/hooks/use-async-data", () => ({
   useAsyncData: vi.fn(),
@@ -22,56 +12,53 @@ import { Leaderboard } from "./leaderboard"
 
 const mockUseAsyncData = vi.mocked(useAsyncData)
 
+const EARNER_DATA = {
+  data: [{ address: "GCLICKEDUSER123456789", totalEarned: 250n, rank: 1 }],
+  isLoading: false,
+  error: null,
+  isEmpty: false,
+  refetch: async () => {},
+}
+
+const QUEST_DATA = {
+  data: [{ id: 42, name: "Quest Alpha", enrolleeCount: 10, rank: 1 }],
+  isLoading: false,
+  error: null,
+  isEmpty: false,
+  refetch: async () => {},
+}
+
 describe("Leaderboard", () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
 
+    // The component calls useAsyncData twice per render (once for earners, once for quests).
+    // Calls alternate: even indices → earners hook, odd indices → quests hook.
+    let callIndex = 0
     mockUseAsyncData.mockImplementation(() => {
-      if (mockUseAsyncData.mock.calls.length === 1) {
-        return {
-          data: [
-            {
-              address: "GCLICKEDUSER123456789",
-              totalEarned: 250n,
-              rank: 1,
-            },
-          ],
-          isLoading: false,
-          error: null,
-          isEmpty: false,
-          refetch: async () => {},
-        }
-      }
-
-      return {
-        data: [
-          {
-            id: 42,
-            name: "Quest Alpha",
-            enrolleeCount: 10,
-            rank: 1,
-          },
-        ],
-        isLoading: false,
-        error: null,
-        isEmpty: false,
-        refetch: async () => {},
-      }
+      const data = callIndex % 2 === 0 ? EARNER_DATA : QUEST_DATA
+      callIndex++
+      return data
     })
   })
 
-  it("does not navigate when an earner row is clicked", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("earner row links to the creator profile page", () => {
     render(
       <MemoryRouter>
         <Leaderboard />
       </MemoryRouter>
     )
 
-    fireEvent.click(screen.getByText(/gclick/i))
-    expect(mockNavigate).not.toHaveBeenCalled()
+    const earnerLink = screen.getByText(/gclick/i).closest("a")
+    expect(earnerLink).toHaveAttribute("href", "/creator/GCLICKEDUSER123456789")
   })
 
-  it("still navigates to quest pages from the quests tab", () => {
+  it("quest row links to the quest detail page", async () => {
     render(
       <MemoryRouter>
         <Leaderboard />
@@ -79,8 +66,12 @@ describe("Leaderboard", () => {
     )
 
     fireEvent.click(screen.getByRole("button", { name: /most active quests/i }))
-    fireEvent.click(screen.getByText("Quest Alpha"))
 
-    expect(mockNavigate).toHaveBeenCalledWith("/quest/42")
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const questLink = screen.getByText("Quest Alpha").closest("a")
+    expect(questLink).toHaveAttribute("href", "/quest/42")
   })
 })

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
+import { Helmet } from "react-helmet-async"
 import { ArrowLeft, Home, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
@@ -36,95 +37,100 @@ export function NotFound() {
   const canGoBack = window.history.length > 1
 
   return (
-    <div className="relative flex min-h-[calc(100vh-67px)] items-center justify-center overflow-hidden">
-      {/* Animated background grid */}
-      <div className="bg-grid-dots pointer-events-none absolute inset-0" />
+    <>
+      <Helmet>
+        <meta name="robots" content="noindex" />
+      </Helmet>
+      <div className="relative flex min-h-[calc(100vh-67px)] items-center justify-center overflow-hidden">
+        {/* Animated background grid */}
+        <div className="bg-grid-dots pointer-events-none absolute inset-0" />
 
-      {/* Floating background shapes */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div
-          className="bg-primary border-border animate-float absolute top-[8%] left-[5%] h-28 w-28 rotate-12 border-[3px] opacity-[0.08] shadow-[5px_5px_0_var(--color-border)]"
-          style={{ animationDuration: "7s" }}
-        />
-        <div
-          className="bg-destructive border-border animate-float absolute top-[15%] right-[8%] h-20 w-20 -rotate-6 border-[3px] opacity-[0.07] shadow-[4px_4px_0_var(--color-border)]"
-          style={{ animationDuration: "9s", animationDelay: "1s" }}
-        />
-        <div
-          className="bg-primary border-border animate-float absolute bottom-[12%] left-[10%] h-16 w-16 rotate-45 border-[2px] opacity-[0.06] shadow-[3px_3px_0_var(--color-border)]"
-          style={{ animationDuration: "8s", animationDelay: "2s" }}
-        />
-        <div
-          className="bg-primary border-border animate-float absolute right-[6%] bottom-[20%] h-24 w-24 -rotate-12 border-[3px] opacity-[0.07] shadow-[4px_4px_0_var(--color-border)]"
-          style={{ animationDuration: "6s", animationDelay: "0.5s" }}
-        />
-        <div
-          className="bg-success border-border animate-float absolute top-[50%] left-[50%] h-10 w-10 rotate-6 border-[2px] opacity-[0.08] shadow-[3px_3px_0_var(--color-border)]"
-          style={{ animationDuration: "10s", animationDelay: "3s" }}
-        />
-        <div
-          className="bg-success border-border animate-float absolute top-[30%] left-[25%] h-8 w-8 -rotate-45 border-[2px] opacity-[0.06] shadow-[2px_2px_0_var(--color-border)]"
-          style={{ animationDuration: "11s", animationDelay: "1.5s" }}
-        />
-        {/* Spinning decorative element */}
-        <div className="border-border animate-spin-slow absolute top-[65%] right-[15%] h-14 w-14 border-[3px] opacity-[0.04]" />
-      </div>
-
-      <div className="relative flex flex-col items-center px-4 text-center">
-        {/* Giant 404 with glitch + stacked neo-brutalist layers */}
-        <div
-          className="animate-scale-in relative mb-6"
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
-        >
-          {/* Shadow layers */}
-          <div className="text-foreground absolute inset-0 translate-x-3 translate-y-3 text-[180px] leading-none font-black opacity-100 sm:text-[240px] lg:text-[300px]">
-            404
-          </div>
+        {/* Floating background shapes */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <div
-            className={`text-primary absolute inset-0 translate-x-1.5 translate-y-1.5 text-[180px] leading-none font-black transition-transform duration-300 sm:text-[240px] lg:text-[300px] ${
-              hovered ? "translate-x-2.5 translate-y-2.5" : ""
-            }`}
-          >
-            404
-          </div>
+            className="bg-primary border-border animate-float absolute top-[8%] left-[5%] h-28 w-28 rotate-12 border-[3px] opacity-[0.08] shadow-[5px_5px_0_var(--color-border)]"
+            style={{ animationDuration: "7s" }}
+          />
           <div
-            className="relative text-[180px] leading-none font-black text-white sm:text-[240px] lg:text-[300px]"
-            style={{ WebkitTextStroke: "4px black" }}
-          >
-            <GlitchText text="404" />
-          </div>
+            className="bg-destructive border-border animate-float absolute top-[15%] right-[8%] h-20 w-20 -rotate-6 border-[3px] opacity-[0.07] shadow-[4px_4px_0_var(--color-border)]"
+            style={{ animationDuration: "9s", animationDelay: "1s" }}
+          />
+          <div
+            className="bg-primary border-border animate-float absolute bottom-[12%] left-[10%] h-16 w-16 rotate-45 border-[2px] opacity-[0.06] shadow-[3px_3px_0_var(--color-border)]"
+            style={{ animationDuration: "8s", animationDelay: "2s" }}
+          />
+          <div
+            className="bg-primary border-border animate-float absolute right-[6%] bottom-[20%] h-24 w-24 -rotate-12 border-[3px] opacity-[0.07] shadow-[4px_4px_0_var(--color-border)]"
+            style={{ animationDuration: "6s", animationDelay: "0.5s" }}
+          />
+          <div
+            className="bg-success border-border animate-float absolute top-[50%] left-[50%] h-10 w-10 rotate-6 border-[2px] opacity-[0.08] shadow-[3px_3px_0_var(--color-border)]"
+            style={{ animationDuration: "10s", animationDelay: "3s" }}
+          />
+          <div
+            className="bg-success border-border animate-float absolute top-[30%] left-[25%] h-8 w-8 -rotate-45 border-[2px] opacity-[0.06] shadow-[2px_2px_0_var(--color-border)]"
+            style={{ animationDuration: "11s", animationDelay: "1.5s" }}
+          />
+          {/* Spinning decorative element */}
+          <div className="border-border animate-spin-slow absolute top-[65%] right-[15%] h-14 w-14 border-[3px] opacity-[0.04]" />
         </div>
 
-        {/* Message card */}
-        <div className="bg-background border-border animate-fade-in-up stagger-1 shimmer-on-hover max-w-md border-[3px] px-8 py-6 shadow-[6px_6px_0_var(--color-border)]">
-          <div className="mb-3 flex items-center justify-center gap-2">
-            <Sparkles className="text-primary h-5 w-5" />
-            <h1 className="text-2xl font-black sm:text-3xl">Lost in the chain</h1>
-            <Sparkles className="text-primary h-5 w-5" />
+        <div className="relative flex flex-col items-center px-4 text-center">
+          {/* Giant 404 with glitch + stacked neo-brutalist layers */}
+          <div
+            className="animate-scale-in relative mb-6"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+          >
+            {/* Shadow layers */}
+            <div className="text-foreground absolute inset-0 translate-x-3 translate-y-3 text-[180px] leading-none font-black opacity-100 sm:text-[240px] lg:text-[300px]">
+              404
+            </div>
+            <div
+              className={`text-primary absolute inset-0 translate-x-1.5 translate-y-1.5 text-[180px] leading-none font-black transition-transform duration-300 sm:text-[240px] lg:text-[300px] ${
+                hovered ? "translate-x-2.5 translate-y-2.5" : ""
+              }`}
+            >
+              404
+            </div>
+            <div
+              className="relative text-[180px] leading-none font-black text-white sm:text-[240px] lg:text-[300px]"
+              style={{ WebkitTextStroke: "4px black" }}
+            >
+              <GlitchText text="404" />
+            </div>
           </div>
-          <p className="text-muted-foreground mb-6 leading-relaxed">
-            This page doesn't exist on any ledger. It might have been moved, deleted, or never
-            deployed.
-          </p>
-          <div className="flex flex-col justify-center gap-3 sm:flex-row">
-            <Button onClick={() => navigate("/")} className="shimmer-on-hover group">
-              <Home className="h-4 w-4" />
-              Back to Home
-            </Button>
-            {canGoBack && (
-              <Button variant="secondary" onClick={() => navigate(-1)} className="group">
-                <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
-                Go Back
+
+          {/* Message card */}
+          <div className="bg-background border-border animate-fade-in-up stagger-1 shimmer-on-hover max-w-md border-[3px] px-8 py-6 shadow-[6px_6px_0_var(--color-border)]">
+            <div className="mb-3 flex items-center justify-center gap-2">
+              <Sparkles className="text-primary h-5 w-5" />
+              <h1 className="text-2xl font-black sm:text-3xl">Lost in the chain</h1>
+              <Sparkles className="text-primary h-5 w-5" />
+            </div>
+            <p className="text-muted-foreground mb-6 leading-relaxed">
+              This page doesn't exist on any ledger. It might have been moved, deleted, or never
+              deployed.
+            </p>
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <Button onClick={() => navigate("/")} className="shimmer-on-hover group">
+                <Home className="h-4 w-4" />
+                Back to Home
               </Button>
-            )}
+              {canGoBack && (
+                <Button variant="secondary" onClick={() => navigate(-1)} className="group">
+                  <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+                  Go Back
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
 
-        {/* Decorative accent blocks */}
-        <div className="bg-primary border-border animate-fade-in-up stagger-2 absolute top-1/2 -left-6 hidden h-8 w-8 rotate-12 border-[2px] shadow-[3px_3px_0_var(--color-border)] sm:-left-12 sm:block sm:h-12 sm:w-12" />
-        <div className="bg-success border-border animate-fade-in-up stagger-3 absolute top-1/2 -right-6 hidden h-6 w-6 -translate-y-8 -rotate-6 border-[2px] shadow-[3px_3px_0_var(--color-border)] sm:-right-12 sm:block sm:h-10 sm:w-10" />
+          {/* Decorative accent blocks */}
+          <div className="bg-primary border-border animate-fade-in-up stagger-2 absolute top-1/2 -left-6 hidden h-8 w-8 rotate-12 border-[2px] shadow-[3px_3px_0_var(--color-border)] sm:-left-12 sm:block sm:h-12 sm:w-12" />
+          <div className="bg-success border-border animate-fade-in-up stagger-3 absolute top-1/2 -right-6 hidden h-6 w-6 -translate-y-8 -rotate-6 border-[2px] shadow-[3px_3px_0_var(--color-border)] sm:-right-12 sm:block sm:h-10 sm:w-10" />
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,14 @@
 import "@testing-library/jest-dom/vitest"
-import { expect } from "vitest"
+import { expect, vi } from "vitest"
 import * as axeMatchers from "vitest-axe/matchers"
 import "vitest-axe/extend-expect"
 
 expect.extend(axeMatchers)
+
+// jsdom does not implement IntersectionObserver
+class MockIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,8 @@
 {
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "^/(|dashboard|profile|leaderboard|quest/create)$", "dest": "/index.html" },
+    { "src": "^/(quest|creator|workspace)/.+$", "dest": "/index.html" },
+    { "src": "/(.*)", "dest": "/index.html", "status": 404 }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #733, #734, #735, #736

- **#736 — framer-motion reduced-motion**: Wraps the app root in `<MotionConfig reducedMotion="user">` so the OS *prefers-reduced-motion* setting suppresses all framer-motion animations app-wide without touching individual components.
- **#735 — 404 noindex + Vercel status**: Adds `<meta name="robots" content="noindex">` to `NotFound` via `react-helmet-async`. Replaces the catch-all `rewrites` in `vercel.json` with an explicit `routes` table: known SPA paths return 200, everything else hits the 404-status fallback while still serving `index.html`.
- **#734 — e2e landing coverage**: Expands `e2e/landing.spec.ts` to cover the hero "Launch App" CTA, the "How it works" scroll-to-section, the "Connect Wallet" navbar button, the dark-mode toggle (verifies `<html>` class flips), and all three feature-grid steps.
- **#733 — leaderboard timer flakiness**: Adds `vi.useFakeTimers()` / `vi.useRealTimers()` around each test, adds a global `IntersectionObserver` class stub to `src/test/setup.ts` (jsdom doesn't implement it), rewrites the `useAsyncData` mock to alternate earner/quest data by call-index instead of the fragile `calls.length` check, and updates assertions to match the `PrefetchLink` `href` rather than `useNavigate` (the component now navigates via `<Link>`, not imperative `navigate()`).
- Also runs `cargo fmt` on three contract files that had upstream formatting drift.

## Test plan

- [ ] `pnpm test` — 87 tests pass; the 2 pre-existing `dashboard.a11y` failures (`No QueryClient`) are unrelated to this PR
- [ ] `pnpm exec tsc --noEmit` — zero type errors
- [ ] `cargo fmt --all -- --check` — clean
- [ ] Manually toggle OS reduced-motion in System Settings → confirm animations stop
- [ ] Navigate to a non-existent path → page shows 404 and `<meta name="robots" content="noindex">` is present in the DOM