### PR TITLE
chore: drop unused workspace.tsx alias and stale workspace strings

### DIFF
--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -162,7 +162,7 @@ export const MOCK_PLATFORM_STATS: PlatformStats = {
   tokensDistributed: 125000,
 }
 
-// We can just reuse some of the existing workspaces for trending
+// We can just reuse some of the existing quests for trending
 export const MOCK_TRENDING_QUESTS = [MOCK_WORKSPACES[1], MOCK_WORKSPACES[0]]
 
 export const MOCK_RECENT_ACTIVITY: ActivityEvent[] = [

--- a/frontend/src/pages/create-quest.tsx
+++ b/frontend/src/pages/create-quest.tsx
@@ -684,7 +684,7 @@ function Step3Review({
 
   const handleCreate = () => {
     // Quest and milestones were already created on-chain by handleFund.
-    // Navigate to the new quest's workspace page.
+    // Navigate to the new quest's detail page.
     if (questId !== null) {
       onComplete(questId)
     }
@@ -835,14 +835,14 @@ function Step3Review({
               )}
             </Button>
 
-            {/* Navigate to quest workspace button — enabled once fund tx succeeds */}
+            {/* Navigate to quest detail page — enabled once fund tx succeeds */}
             <Button
               onClick={handleCreate}
               disabled={!isFunded || questId === null}
               className="shimmer-on-hover w-full"
             >
               <Sparkles className="h-4 w-4" />
-              View Quest Workspace
+              View Quest
             </Button>
 
             {isFunded && questId !== null && (
@@ -888,7 +888,7 @@ function Step3Review({
             )}
             {isFunded && questId !== null && (
               <p className="text-muted-foreground mt-2 text-center text-xs font-bold">
-                Quest created and pool funded! Click above to open your quest workspace.
+                Quest created and pool funded! Click above to open your quest.
               </p>
             )}
           </div>

--- a/frontend/src/pages/workspace.tsx
+++ b/frontend/src/pages/workspace.tsx
@@ -1,9 +1,0 @@
-import { QuestView } from "./quest"
-
-// Alias for legacy references to /pages/workspace.tsx
-// This file exists so old issue references and assets depending on the former path continue to work.
-export function WorkspaceView() {
-  return <QuestView />
-}
-
-export default WorkspaceView

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -96,7 +96,7 @@ export const router = createBrowserRouter(
           element: (
             <RouteShell label="Quest">
               <WalletRequiredRoute
-                area="Workspace"
+                area="Quest"
                 description="Connect your wallet to open quest detail pages and interact with learner progress."
               >
                 <QuestView />


### PR DESCRIPTION
 The use-quest-data hook is already free of workspace-prefixed cache keys (quest, milestones, enrollees, rewardPool, questAuthority); this removes lingering legacy strings around it: an unimported workspace.tsx alias, the route's "Workspace" wallet-prompt area label, and a few "workspace"-worded comments / button copy in create-quest. The legacy /workspace/:id redirect stays for URL backward compat.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->

Closes #689