### PR TITLE
docs: update CLAUDE.md to describe all five crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Smart Contracts (Rust/Soroban)
 ```bash
-cargo test --workspace              # Run all 33 contract tests
-cargo test -p workspace             # Run tests for one contract (workspace, milestone, or rewards)
+cargo test --workspace              # Run all contract tests
+cargo test -p quest                 # Run tests for one crate (certificate, milestone, quest, or rewards)
 cargo test -p milestone -- test_name # Run a single test by name
 cargo fmt --all -- --check          # Check formatting
 cargo clippy --workspace --all-targets  # Lint
@@ -27,13 +27,15 @@ pnpm lint                            # ESLint
 
 Lernza is a learn-to-earn platform on Stellar. A creator makes a Quest, enrolls learners, sets milestones with token rewards. Completed milestones trigger on-chain token distribution. There is no backend — all state lives on Stellar's ledger.
 
-### Three Soroban Contracts (`contracts/`)
+### Five Crates (`contracts/`)
 
-Each contract is `#![no_std]`, compiled to WASM, and has its own `lib.rs` + `test.rs`:
+The Cargo workspace contains four `#![no_std]` Soroban contracts (each compiled to WASM with its own `lib.rs` + `test.rs`) and one shared library crate:
 
-1. **workspace** (being renamed to **quest**) — Quest creation, enrollee management, stores `WorkspaceInfo` and enrollee lists. Auto-incrementing IDs via `NextId` counter.
-2. **milestone** — Milestone definition per workspace, owner-verified completion tracking. Caches workspace owner on first milestone creation for auth. Returns `reward_amount` on verification so frontend can trigger rewards.
-3. **rewards** — SAC-based token pools. `fund_workspace()` deposits tokens (funder becomes authority), `distribute_reward()` transfers from pool to enrollee. Uses `soroban_sdk::token::Client` for transfers.
+1. **quest** — Entry point. Quest creation/update/archive, enrollee management (open join, owner add, invite-commitment redeem), admin pause/unpause, creator verification, and queries (`get_quest`, `get_enrollees`, `is_expired`). Stores `QuestInfo` and enrollee lists keyed by auto-incrementing IDs (`NextId`).
+2. **milestone** — Per-quest milestone definition (single + batch create), owner- or peer-review verification modes, distribution modes (flat/custom/competitive), submission/approval flow, and completion tracking. Returns `reward_amount` on verification so the frontend can trigger reward transfers.
+3. **rewards** — SAC-based token pools. `fund_quest()` deposits tokens (funder becomes authority), `distribute_reward()` transfers from pool to enrollee. Uses `soroban_sdk::token::Client` for transfers.
+4. **certificate** — Soroban non-fungible token (`stellar-tokens`) for quest-completion certificates. Owner-gated `mint_certificate` / `mint_quest_certificate`, metadata lookup, revocation tombstones (issue #720), and configurable base URI (issue #719).
+5. **common** — Pure library crate (not a contract; no WASM, no `test.rs`). Houses shared types (`QuestInfo`, `Visibility`, `QuestStatus`), TTL constants (`BUMP`, `THRESHOLD`), reward bounds (`MAX_REWARD_AMOUNT`), shared error codes, the `IsDataKey` marker trait, and helpers like `is_contract_address` / `extend_persistent_ttl`. Imported by the four contract crates.
 
 **Contract patterns:**
 - Auth: `address.require_auth()` + storage-based ownership checks
@@ -47,7 +49,7 @@ Each contract is `#![no_std]`, compiled to WASM, and has its own `lib.rs` + `tes
 - Path alias: `@/` maps to `src/` (configured in `vite.config.ts`)
 - `hooks/use-wallet.ts` — Freighter wallet integration (`@stellar/freighter-api`)
 - `components/ui/` — shadcn/ui components (button, card, badge, progress)
-- `pages/` — Landing, Dashboard, Workspace, Profile
+- `pages/` — Landing, Dashboard, Quest, Create Quest, Creator, Leaderboard, Profile, Not Found
 - `lib/mock-data.ts` — Mock data (contracts not wired to frontend yet)
 
 ## Conventions
@@ -60,4 +62,4 @@ Each contract is `#![no_std]`, compiled to WASM, and has its own `lib.rs` + `tes
 
 ## Key Naming Context
 
-"Workspace" is being renamed to "Quest" throughout the codebase. The contract directory is `contracts/workspace/` but the entity concept is "Quest." GitHub issues track this rename.
+"Workspace" → "Quest" rename is largely complete: the contract crate and directory are `contracts/quest/`, and on-chain APIs use `create_quest` / `fund_quest` / `QuestInfo`. Stragglers may still appear in mock-data identifiers (`MOCK_WORKSPACES`), the legacy `/workspace/:id` redirect route, and a handful of test names — these are intentional or out-of-scope and tracked in their own issues.


### PR DESCRIPTION
Closes #687. The architecture section claimed "Three Soroban Contracts" but the workspace has five crates: certificate, common, milestone, quest, rewards. Replaces the section with descriptions of each, distinguishes the four contract crates from the shared common library (no WASM, no test.rs), and refreshes adjacent details:

- cargo test commands now reference real crate names (no stale -p workspace)
- Drops the hardcoded "33 contract tests" count (long since outpaced)
- Updates rewards API name to fund_quest (was fund_workspace)
- Updates frontend pages list to current set
- Refreshes Key Naming Context: rename is largely done; remaining references are in mock data and the legacy /workspace/:id redirect

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->

Closes #687 
