### PR TITLE
docs(rewards): document quest-only naming and migrate indexer-facing …

### DIFF
--- a/docs/EVENT_REFERENCE.md
+++ b/docs/EVENT_REFERENCE.md
@@ -199,6 +199,14 @@ Emitted by the milestone contract when a learner completes all milestones in a q
 
 ## Rewards Contract (`contracts/rewards/`)
 
+> **Indexer migration note (workspace → quest).** Earlier deployments of the rewards contract (pre-PR #412 / commit `1bcc507`) used `workspace_*` naming for the public surface. The current contract emits **only the `reward_funded` / `reward_distributed` / `reward_refunded` events documented below — `workspace_*` event symbols never existed in any released build.** Indexers should:
+>
+> - Filter on `Symbol("reward_funded" | "reward_distributed" | "reward_refunded")`. No backwards-compatible aliases are emitted; nothing to migrate at the event topic layer.
+> - Update any function-call references the indexer reads from operation envelopes: `fund_workspace` → `fund_quest`, parameter `workspace_id` → `quest_id`.
+> - Update storage-key probes if the indexer reads `DataKey` ledger entries directly: `WorkspaceAuthority(u32)` → `QuestAuthority(u32)`, `WorkspacePool(u32)` → `QuestPool(u32)`.
+>
+> Old testnet deployments still on the pre-rename WASM should be redeployed; the on-chain interface is incompatible.
+
 ### `reward_funded`
 
 Emitted when a quest pool is funded via `fund_quest`.

--- a/docs/funding-flow.md
+++ b/docs/funding-flow.md
@@ -5,27 +5,27 @@ This flow shows the quest owner funding a quest pool through the rewards contrac
 ```mermaid
 sequenceDiagram
     autonumber
-    actor Authority as Workspace Authority
+    actor Authority as Quest Authority
     participant FE as Frontend
     participant Quest as Quest Contract
     participant Wallet as Freighter Wallet
     participant Rewards as Rewards Contract
     participant Token as Stellar Asset Contract
 
-    Note over Rewards: Assumes initialize(token_addr) already ran during setup
+    Note over Rewards: Assumes initialize(token_addr, quest_addr, milestone_addr) already ran during setup
 
     Authority->>FE: Open funding screen for a quest
-    FE->>Quest: get_workspace(workspace_id)
+    FE->>Quest: get_quest(quest_id)
     Quest-->>FE: token_addr and quest metadata
-    FE->>Rewards: get_pool_balance(workspace_id)
+    FE->>Rewards: get_pool_balance(quest_id)
     Rewards-->>FE: Current pool balance
-    FE->>Wallet: Request signature for fund_workspace(funder, workspace_id, amount)
-    Wallet->>Rewards: fund_workspace(funder, workspace_id, amount)
+    FE->>Wallet: Request signature for fund_quest(funder, quest_id, amount)
+    Wallet->>Rewards: fund_quest(funder, quest_id, amount)
     Rewards->>Token: transfer(funder, rewards_contract, amount)
     Token-->>Rewards: Transfer succeeds
     Rewards-->>Wallet: Pool balance credited
     Wallet-->>FE: Funding transaction confirmed
-    FE->>Rewards: get_pool_balance(workspace_id)
+    FE->>Rewards: get_pool_balance(quest_id)
     Rewards-->>FE: Updated pool balance
     FE-->>Authority: Show funded quest pool
 ```

--- a/docs/milestone-reward-flow.md
+++ b/docs/milestone-reward-flow.md
@@ -18,18 +18,18 @@ sequenceDiagram
 
     Learner->>FE: Submit completion proof or request review
     Owner->>FE: Open pending milestone review
-    FE->>Quest: is_enrollee(workspace_id, learner)
+    FE->>Quest: is_enrollee(quest_id, learner)
     Quest-->>FE: true
-    FE->>Milestone: is_completed(workspace_id, milestone_id, learner)
+    FE->>Milestone: is_completed(quest_id, milestone_id, learner)
     Milestone-->>FE: false
-    FE->>Wallet: Request owner signature for verify_completion(owner, workspace_id, milestone_id, learner)
-    Wallet->>Milestone: verify_completion(owner, workspace_id, milestone_id, learner)
+    FE->>Wallet: Request owner signature for verify_completion(owner, quest_id, milestone_id, learner)
+    Wallet->>Milestone: verify_completion(owner, quest_id, milestone_id, learner)
     Milestone-->>Wallet: reward_amount
     Wallet-->>FE: Verification confirmed with reward_amount
-    FE->>Rewards: get_pool_balance(workspace_id)
+    FE->>Rewards: get_pool_balance(quest_id)
     Rewards-->>FE: Available balance
-    FE->>Wallet: Request authority signature for distribute_reward(authority, workspace_id, learner, reward_amount)
-    Wallet->>Rewards: distribute_reward(authority, workspace_id, learner, reward_amount)
+    FE->>Wallet: Request authority signature for distribute_reward(authority, quest_id, milestone_id, learner, reward_amount)
+    Wallet->>Rewards: distribute_reward(authority, quest_id, milestone_id, learner, reward_amount)
     Rewards->>Token: transfer(rewards_contract, learner, reward_amount)
     Token-->>Rewards: Transfer succeeds
     Rewards-->>Wallet: Pool debited and earnings updated


### PR DESCRIPTION
…flows

Closes #688. The rewards contract source itself has been free of "workspace" references since the rename in commit 1bcc507. This change addresses the second half of the issue (indexer-facing surface):

- Adds a migration note at the top of the Rewards section in EVENT_REFERENCE.md. Clarifies that workspace_* event symbols never existed in any released build, so no on-chain event aliasing is needed; provides explicit fund_workspace -> fund_quest and storage key (WorkspaceAuthority/Pool -> QuestAuthority/Pool) mappings for any indexer that probed the contract by name or DataKey.
- Updates funding-flow.md and milestone-reward-flow.md, which still documented the rewards integration with stale fund_workspace / workspace_id / get_workspace names. While renaming, also fixes a pre-existing correctness bug in milestone-reward-flow.md: the distribute_reward call was missing the milestone_id argument (signature is authority, quest_id, milestone_id, enrollee, amount).

Out of scope (left for separate issues): test_snapshots/ JSON files under contracts/rewards/ contain legacy fund_workspace strings; they are auto-generated and will refresh on the next UPDATE_SNAPSHOTS run. The Quest- and enrollment-flow docs still have stragglers but are about the Quest contract, not Rewards.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->

Closes #688 