### PR TITLE
Fix/gitignore changelog eslint badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,29 @@
 # Rust
-target
+target/
 contracts/**/test_snapshots/
+
+# Rust backup files produced by rustfmt
+*.rs.bk
 
 # Stellar
 .soroban
 .stellar
 
 # Frontend
-frontend/node_modules
-frontend/dist
+node_modules/
+frontend/node_modules/
+frontend/dist/
+frontend/.vercel/
+
+# TypeScript incremental build info
+*.tsbuildinfo
 
 # OS
 .DS_Store
 
 # IDE
-.idea
-.vscode
+.idea/
+.vscode/
 .claude/
 
 # Environment
@@ -24,15 +32,14 @@ frontend/dist
 pr.md
 issue.md
 
+# Log files and CI output dumps
+*.log
+clippy_output.txt
+
+# Windows installer binaries
+*.exe
+
 # Generated contract bindings (regenerated from WASM via pnpm generate:bindings)
 frontend/src/lib/contracts/generated/
 
-
 contracts/quest/test_snapshots/test/*
-frontend/.vercel
-
-# Root-level node_modules — never track (#669)
-node_modules/
-
-# Windows installer binaries (#668)
-*.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### ⚠ BREAKING CHANGES
+
+* **contracts:** The `workspace` identifier has been renamed to `quest` across all contracts, frontend code, and URLs. The `/workspace/:id` route now redirects to `/quest/:id` via a compatibility shim (`WorkspaceRedirect`). The shim and all `workspace` aliases will be removed on **2026-09-01**. Integrators must migrate any direct references to `WorkspaceInfo`, `MOCK_WORKSPACES`, or `/workspace/` paths to their `quest`-prefixed equivalents before that date.
+
 ## [0.3.0](https://github.com/lernza/lernza/compare/v0.2.3...v0.3.0) (2026-03-27)
 
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -49,6 +49,24 @@ export default defineConfig([
         'warn',
         { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
       ],
+      // Ban legacy "workspace" identifiers — use "quest" equivalents instead.
+      // The only allowed file is the redirect shim that bridges /workspace/:id → /quest/:id.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Identifier[name=/[Ww]orkspace/]',
+          message:
+            'The "workspace" identifier is deprecated. Use the "quest" equivalent instead. ' +
+            'Only src/components/workspace-redirect.tsx is exempt.',
+        },
+      ],
+    },
+  },
+  // Allow-list: the redirect shim is the sole permitted home for workspace identifiers.
+  {
+    files: ['src/components/workspace-redirect.tsx'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
 ])


### PR DESCRIPTION
## Summary

Four housekeeping issues addressed in one branch.

---

## Changes

### 1. `.gitignore` — cover leaked artifact patterns

Extended `.gitignore` to prevent future commits of build/CI debris:

- `*.log` — covers `readable.log`, `rustfmt_error*.log`
- `*.exe` — Windows binaries
- `*.rs.bk` — rustfmt backup files
- `*.tsbuildinfo` — TypeScript incremental build cache
- `clippy_output.txt` — CI output dump
- Consolidated `node_modules/` and `frontend/.vercel` entries

Untracked the five straggler files already present in the working tree.

### 2. `CHANGELOG.md` — surface the workspace→quest rename as a breaking change

Added an `[Unreleased]` section at the top with a `⚠ BREAKING CHANGES` entry:

- Documents the `workspace` → `quest` rename across contracts, frontend, and URLs
- Notes the `/workspace/:id` redirect shim and its **EOL date: 2026-09-01**
- Lists the specific symbols integrators must migrate (`WorkspaceInfo`, `MOCK_WORKSPACES`, `/workspace/` paths)

### 3. `frontend/eslint.config.js` — ban `workspace` identifiers via `no-restricted-syntax`

Added a lint rule that errors on any `Identifier` matching `/[Ww]orkspace/` in all `.ts`/`.tsx` files:

- Prevents the renamed identifier from drifting back into the codebase
- `src/components/workspace-redirect.tsx` is explicitly allow-listed as the sole compatibility shim

### 4. `README.md` — latest release badge

Already present (`img.shields.io/github/v/release/lernza/lernza`) — no change required.

---

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Future `*.log`, `*.exe`, `*.rs.bk`, `*.tsbuildinfo` files are auto-ignored | ✅ |
| 2 | Breaking rename entry visible at top of unreleased section in CHANGELOG | ✅ |
| 3 | Lint fails on new `workspace` identifiers outside the redirect shim | ✅ |
| 4 | Latest release badge renders current tag in README | ✅ (pre-existing) |

closes #679 
closes #691 
closes #692 
closes #680 