### PR TITLE
fix(frontend): document stable handler pattern in profile

### DIFF
--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -30,6 +30,7 @@ export function Profile() {
   const stats = MOCK_USER_STATS
   const [copied, setCopied] = useState(false)
 
+  // Stable handler — state resets live in event handlers, not effects.
   const handleCopy = () => {
     if (address) {
       navigator.clipboard.writeText(address)


### PR DESCRIPTION
Closes #905

## What changed
- Added comment in `Profile` confirming state resets live in event handlers, not effects

## Why
The `setState-in-effect` reset block in `profile.tsx:181-189` (resetting `activityItems`, `activityError`, `nextActivityCursor`, `activityLoading` on `activeTab` change) was already removed by #1024 when the tab/activity system was stripped out. The current code uses stable handlers called from onClick — the correct pattern.

## How to test
- Lint `profile.tsx` — no `setState-during-render` or `setState-in-effect` warnings