### PR TITLE
fix(a11y): add missing aria labels, fix duplicate h1, improve keyboard support

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -88,7 +88,6 @@ export function AppShell({ children }: AppShellProps) {
       <Navbar />
       <ErrorBoundary>
         <main id="main-content" tabIndex={-1} className="outline-none">
-          <h1 className="sr-only">Lernza Platform</h1>
           <Outlet />
           {children}
         </main>

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -107,8 +107,8 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
                 <div className="bg-success border-border h-2.5 w-2.5 border" />
                 <span className="font-mono text-sm font-bold">{shortAddress}</span>
               </div>
-              <Button variant="ghost" size="icon" onClick={disconnect}>
-                <LogOut className="h-4 w-4" />
+              <Button variant="ghost" size="icon" onClick={disconnect} aria-label="Disconnect wallet">
+                <LogOut className="h-4 w-4" aria-hidden="true" />
               </Button>
             </>
           ) : (
@@ -121,16 +121,19 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
           {/* Mobile hamburger */}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-nav-menu"
             className="border-border bg-background neo-press flex h-9 w-9 cursor-pointer items-center justify-center border-[2px] shadow-[2px_2px_0_var(--color-border)] sm:hidden"
           >
-            {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+            {mobileOpen ? <X className="h-4 w-4" aria-hidden="true" /> : <Menu className="h-4 w-4" aria-hidden="true" />}
           </button>
         </div>
       </div>
 
       {/* Mobile menu dropdown */}
       {mobileOpen && (
-        <div className="border-border bg-background animate-fade-in-down border-t-[3px] transition-colors duration-300 sm:hidden">
+        <div id="mobile-nav-menu" className="border-border bg-background animate-fade-in-down border-t-[3px] transition-colors duration-300 sm:hidden">
           <div className="space-y-1 px-4 py-3">
             {NAV_ITEMS.map(item => (
               <button

--- a/frontend/src/components/swipeable-quest-card.tsx
+++ b/frontend/src/components/swipeable-quest-card.tsx
@@ -98,10 +98,21 @@ export function SwipeableQuestCard({
     }
   }
 
+  const handleKeyDown = async (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !quest.isEnrolled) {
+      if (window.confirm(`Enroll in "${quest.name}"?`)) {
+        await onEnroll(quest.id)
+      }
+    } else if (e.key === "Backspace" || e.key === "Delete") {
+      setIsDismissed(true)
+      setTimeout(() => onDismiss(quest.id), 300)
+    }
+  }
+
   if (isDismissed) return null
 
   return (
-    <div className="relative touch-pan-y overflow-hidden rounded-xl">
+    <div className="relative touch-pan-y overflow-hidden rounded-xl" role="group" aria-label={`Quest: ${quest.name}`}>
       {/* Action Layer (visible during swipe) */}
       <motion.div
         style={{ background, opacity }}
@@ -143,6 +154,27 @@ export function SwipeableQuestCard({
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Keyboard action bar — visible only for keyboard users */}
+      <div className="sr-only focus-within:not-sr-only focus-within:flex gap-2 px-4 py-2 bg-background border-b border-border">
+        <button
+          onKeyDown={handleKeyDown}
+          onClick={() => { setIsDismissed(true); setTimeout(() => onDismiss(quest.id), 300) }}
+          className="border-border border-[2px] px-3 py-1 text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`Dismiss quest: ${quest.name}`}
+        >
+          Dismiss
+        </button>
+        {!quest.isEnrolled && (
+          <button
+            onClick={async () => { if (window.confirm(`Enroll in "${quest.name}"?`)) await onEnroll(quest.id) }}
+            className="bg-primary border-border border-[2px] px-3 py-1 text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Enroll in quest: ${quest.name}`}
+          >
+            Enroll
+          </button>
+        )}
+      </div>
 
       {/* Card Layer */}
       <motion.div

--- a/frontend/src/components/ui/form-field.tsx
+++ b/frontend/src/components/ui/form-field.tsx
@@ -1,10 +1,11 @@
+import React from "react"
 import { AlertCircle } from "lucide-react"
 
-export function FieldError({ message }: { message?: string }) {
+export function FieldError({ id, message }: { id?: string; message?: string }) {
   if (!message) return null
   return (
-    <p role="alert" aria-live="polite" className="text-destructive mt-1 flex items-center gap-1.5 text-xs font-bold">
-      <AlertCircle className="h-3 w-3 flex-shrink-0" />
+    <p id={id} role="alert" aria-live="polite" className="text-destructive mt-1 flex items-center gap-1.5 text-xs font-bold">
+      <AlertCircle className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
       {message}
     </p>
   )
@@ -16,5 +17,24 @@ export function FormLabel({ children, required, htmlFor }: { children: React.Rea
       {children}
       {required && <span className="text-destructive ml-0.5" aria-hidden="true">*</span>}
     </label>
+  )
+}
+
+interface FormFieldProps {
+  id: string
+  label?: string
+  required?: boolean
+  error?: string
+  children: (props: { id: string; "aria-invalid": boolean; "aria-describedby"?: string }) => React.ReactNode
+}
+
+export function FormField({ id, label, required, error, children }: FormFieldProps) {
+  const errorId = error ? `${id}-error` : undefined
+  return (
+    <div>
+      {label && <FormLabel htmlFor={id} required={required}>{label}</FormLabel>}
+      {children({ id, "aria-invalid": !!error, "aria-describedby": errorId })}
+      <FieldError id={errorId} message={error} />
+    </div>
   )
 }

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -178,12 +178,13 @@ export function Profile() {
                   </p>
                   <button
                     onClick={handleCopy}
+                    aria-label={copied ? "Address copied" : "Copy wallet address"}
                     className="border-border bg-card neo-press hover:bg-secondary flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center border-2 shadow-[2px_2px_0_var(--color-border)]"
                   >
                     {copied ? (
-                      <Check className="text-success h-3 w-3" />
+                      <Check className="text-success h-3 w-3" aria-hidden="true" />
                     ) : (
-                      <Copy className="h-3 w-3" />
+                      <Copy className="h-3 w-3" aria-hidden="true" />
                     )}
                   </button>
                 </div>


### PR DESCRIPTION
## Summary

- Removed duplicate sr-only `<h1>` from `app-shell.tsx` that conflicted with each page's own `<h1>`, causing two h1s per page
- Added `aria-label`, `aria-expanded`, and `aria-controls` to navbar disconnect button and hamburger toggle; added `aria-hidden` to icon elements
- Added `aria-label` to profile copy-address icon button
- Added `id` prop to `FieldError` and a new `FormField` wrapper component that wires `aria-invalid` and `aria-describedby` between inputs and their error messages
- Added visible keyboard-accessible Enroll/Dismiss buttons to `SwipeableQuestCard` (shown via `focus-within`) with `role="group"` labelling for screen reader context

## Test plan

- [ ] Verify only one `<h1>` appears per page in the DOM (DevTools or axe)
- [ ] Tab to the disconnect wallet button and confirm screen readers announce "Disconnect wallet"
- [ ] Tab to the hamburger menu and confirm `aria-expanded` changes and the menu id is referenced
- [ ] Tab to the profile copy-address button and confirm announcement changes after copy
- [ ] Use a form field with an error and confirm screen readers announce the error linked via `aria-describedby`
- [ ] Tab to a `SwipeableQuestCard` and confirm Enroll/Dismiss buttons become reachable and operable from keyboard

Closes #943
Closes #944
Closes #945
Closes #946