### PR TITLE
fix: payout-before-transfer, refund counter sync, paginate completion rate, emit distribution-mode event

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -196,6 +196,10 @@ pub const MAX_MILESTONE_TITLE_LEN: u32 = 128;
 pub const MAX_MILESTONE_DESCRIPTION_LEN: u32 = 1000;
 pub const MAX_BATCH_SIZE: u32 = 20;
 pub const MAX_MILESTONES: u32 = 50;
+/// Maximum window size accepted by `get_quest_completion_rate`. Callers must
+/// supply an explicit `limit <= MAX_COMPLETION_RATE_PAGE` so a single call
+/// can never iterate an unbounded enrollee set. See issue #865.
+pub const MAX_COMPLETION_RATE_PAGE: u32 = 100;
 
 // IsDataKey implementation — restricts TTL extension to Milestone DataKey only
 impl common::IsDataKey for DataKey {}
@@ -502,13 +506,32 @@ impl MilestoneContract {
             .persistent()
             .extend_ttl(&mode_key, THRESHOLD, BUMP);
 
-        if matches!(mode, DistributionMode::Flat) {
+        let flat_for_event = if matches!(mode, DistributionMode::Flat) {
             let flat_key = DataKey::FlatReward(quest_id);
             env.storage().persistent().set(&flat_key, &flat_reward);
             env.storage()
                 .persistent()
                 .extend_ttl(&flat_key, THRESHOLD, BUMP);
-        }
+            flat_reward
+        } else {
+            0
+        };
+
+        // Emit a distribution-mode-set event so indexers and frontends can
+        // detect mode changes and warn enrolled learners that the reward
+        // rules have shifted. See issue #868.
+        // Topic: ("distribution_mode_set",)
+        // Data: (quest_id, mode, flat_reward_or_zero, actor, timestamp)
+        env.events().publish(
+            (Symbol::new(&env, "distribution_mode_set"),),
+            (
+                quest_id,
+                mode,
+                flat_for_event,
+                owner,
+                env.ledger().timestamp(),
+            ),
+        );
 
         Ok(())
     }
@@ -1080,42 +1103,62 @@ impl MilestoneContract {
         }
     }
 
-    /// Get quest completion rate (% of enrollees who completed all milestones).
-    pub fn get_quest_completion_rate(env: Env, quest_id: u32, total_enrollees: u32) -> i128 {
-        if total_enrollees == 0 {
-            return 0;
+    /// Paginated quest completion rate (issue #865).
+    ///
+    /// Returns the percentage of enrollees in the window
+    /// `enrollees[offset .. offset + limit]` that have completed every
+    /// milestone for the quest. The previous unbounded version iterated
+    /// every enrollee on every call, which became a DOS vector for quests
+    /// with thousands of enrollees.
+    ///
+    /// Bounded by `MAX_COMPLETION_RATE_PAGE`: callers that pass `limit`
+    /// above that cap are rejected with `Error::InvalidInput`. Pass
+    /// `limit == 0` to also be rejected; callers must opt in to a window.
+    pub fn get_quest_completion_rate(
+        env: Env,
+        quest_id: u32,
+        offset: u32,
+        limit: u32,
+    ) -> Result<i128, Error> {
+        if limit == 0 || limit > MAX_COMPLETION_RATE_PAGE {
+            return Err(Error::InvalidInput);
         }
 
-        let total_milestones = match Self::get_quest_milestone_count(env.clone(), quest_id) {
-            Ok(count) => count,
-            Err(_) => return 0,
-        };
-
+        let total_milestones = Self::get_quest_milestone_count(env.clone(), quest_id)?;
         if total_milestones == 0 {
-            return 0;
+            return Ok(0);
         }
 
-        // Get quest contract address
         let quest_contract_addr: Address = env
             .storage()
             .instance()
             .get(&DataKey::QuestContract)
-            .expect("Quest contract NOT INITIALIZED");
-
-        // Cross-contract call to get enrollees
+            .ok_or(Error::NotInitialized)?;
         let quest_client = QuestClient::new(&env, &quest_contract_addr);
         let enrollees = quest_client.get_enrollees(&quest_id);
 
+        let total = enrollees.len();
+        if offset >= total {
+            return Ok(0);
+        }
+        let end = offset.saturating_add(limit).min(total);
+
+        let mut window_size = 0u32;
         let mut fully_completed = 0u32;
-        for enrollee in enrollees.iter() {
+        for i in offset..end {
+            let enrollee = enrollees.get(i).expect("index in bounds by construction");
             let completions = Self::get_enrollee_completions(env.clone(), quest_id, enrollee);
             if completions >= total_milestones {
                 fully_completed += 1;
             }
+            window_size += 1;
         }
 
-        // Return percentage (0-100)
-        (fully_completed as i128 * 100) / total_enrollees as i128
+        if window_size == 0 {
+            return Ok(0);
+        }
+
+        Ok((fully_completed as i128 * 100) / window_size as i128)
     }
 
     /// Get total earned for an enrollee in a quest.

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -1393,7 +1393,7 @@ fn test_get_quest_completion_rate() {
     quest_client.add_enrollee(&q_id, &e4);
 
     // Initial rate should be 0
-    assert_eq!(client.get_quest_completion_rate(&q_id, &4), 0);
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 0);
 
     // e1 completes both (100%)
     client.verify_completion(&owner, &q_id, &0, &e1);
@@ -1403,27 +1403,27 @@ fn test_get_quest_completion_rate() {
     client.verify_completion(&owner, &q_id, &0, &e2);
 
     // Current rate: 1/4 = 25%
-    assert_eq!(client.get_quest_completion_rate(&q_id, &4), 25);
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 25);
 
     // e3 completes both
     client.verify_completion(&owner, &q_id, &0, &e3);
     client.verify_completion(&owner, &q_id, &1, &e3);
 
     // Current rate: 2/4 = 50%
-    assert_eq!(client.get_quest_completion_rate(&q_id, &4), 50);
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 50);
 
     // e4 completes both
     client.verify_completion(&owner, &q_id, &0, &e4);
     client.verify_completion(&owner, &q_id, &1, &e4);
 
     // Current rate: 3/4 = 75%
-    assert_eq!(client.get_quest_completion_rate(&q_id, &4), 75);
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 75);
 
     // e2 completes the second one
     client.verify_completion(&owner, &q_id, &1, &e2);
 
     // Current rate: 4/4 = 100%
-    assert_eq!(client.get_quest_completion_rate(&q_id, &4), 100);
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 100);
 }
 
 #[test]
@@ -1565,4 +1565,78 @@ fn test_competitive_max_winners_one_does_not_double_pay() {
     // pay again.
     let retry = client.try_verify_completion(&owner, &q_id, &0, &e1);
     assert_eq!(retry, Err(Ok(Error::AlreadyCompleted)));
+}
+
+// --- Paginated quest completion rate (issue #865) ---
+
+#[test]
+fn test_completion_rate_rejects_unbounded_limits() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q_id, "M1", 100);
+
+    // limit == 0 is rejected — callers must opt in to a window.
+    let err = client.try_get_quest_completion_rate(&q_id, &0, &0);
+    assert_eq!(err, Err(Ok(Error::InvalidInput)));
+
+    // limit > MAX_COMPLETION_RATE_PAGE (100) is rejected.
+    let err = client.try_get_quest_completion_rate(&q_id, &0, &101);
+    assert_eq!(err, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_completion_rate_offset_beyond_total_returns_zero() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q_id, "M1", 100);
+
+    let e1 = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &e1);
+
+    // 1 enrollee total; offset=10 is past the end → 0.
+    assert_eq!(client.get_quest_completion_rate(&q_id, &10, &5), 0);
+}
+
+#[test]
+fn test_completion_rate_windowed() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q_id, "M1", 100);
+
+    let e1 = Address::generate(&env);
+    let e2 = Address::generate(&env);
+    let e3 = Address::generate(&env);
+    let e4 = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &e1);
+    quest_client.add_enrollee(&q_id, &e2);
+    quest_client.add_enrollee(&q_id, &e3);
+    quest_client.add_enrollee(&q_id, &e4);
+
+    // e1 and e3 finish the quest.
+    client.verify_completion(&owner, &q_id, &0, &e1);
+    client.verify_completion(&owner, &q_id, &0, &e3);
+
+    // Window over the first two enrollees → 1 of 2 done → 50%.
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &2), 50);
+    // Window over the last two enrollees → 1 of 2 done → 50%.
+    assert_eq!(client.get_quest_completion_rate(&q_id, &2, &2), 50);
+    // Full window of 4 → 2 of 4 done → 50%.
+    assert_eq!(client.get_quest_completion_rate(&q_id, &0, &4), 50);
+}
+
+// --- set_distribution_mode emits event (issue #868) ---
+
+#[test]
+fn test_set_distribution_mode_emits_event() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q_id, "M1", 100);
+
+    let before = env.events().all().len();
+    client.set_distribution_mode(&owner, &q_id, &DistributionMode::Flat, &50);
+    let after = env.events().all().len();
+    assert!(
+        after > before,
+        "set_distribution_mode should publish a distribution_mode_set event"
+    );
 }

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -50,6 +50,10 @@ pub enum DataKey {
     QuestCount,
     // Total tokens distributed per quest
     QuestDistributed(u32),
+    // Total tokens refunded per quest. Authoritative persistent aggregate
+    // kept in sync with refund_pool / refund_unused_pool so the instance
+    // counter `TotalDistributed` stays consistent — issue #864.
+    QuestRefunded(u32),
     // Idempotency: tracks whether a (quest, milestone, enrollee) payout was already made
     PayoutRecord(u32, u32, Address), // (quest_id, milestone_id, enrollee)
     // Configurable refund grace period in seconds — Issue #882
@@ -313,21 +317,26 @@ impl RewardsContract {
             return Err(Error::InsufficientPool);
         }
 
-        // Transfer tokens to enrollee
-        let token_addr = Self::get_token(&env)?;
-        let client = token::Client::new(&env, &token_addr);
-        client.transfer(&env.current_contract_address(), &enrollee, &amount);
+        // Record payout for idempotency BEFORE the token transfer. If the
+        // transfer subsequently panics or reverts, the whole transaction
+        // rolls back together with the PayoutRecord write — so on retry we
+        // see no record and try again. If the transfer succeeds the record
+        // is durable, blocking any duplicate payout. See issue #861.
+        env.storage().persistent().set(&payout_key, &amount);
+        common::extend_persistent_ttl(&env, &payout_key);
 
-        // Update pool balance
+        // Update pool balance to reflect the upcoming transfer.
         let new_pool = pool.checked_sub(amount).ok_or(Error::ArithmeticOverflow)?;
         env.storage().persistent().set(&pool_key, &new_pool);
         env.storage()
             .persistent()
             .extend_ttl(&pool_key, THRESHOLD, BUMP);
 
-        // Record payout for idempotency (prevents duplicate payouts on retry)
-        env.storage().persistent().set(&payout_key, &amount);
-        common::extend_persistent_ttl(&env, &payout_key);
+        // Transfer tokens to enrollee. A panic here reverts the whole tx
+        // including the PayoutRecord + pool writes above.
+        let token_addr = Self::get_token(&env)?;
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&env.current_contract_address(), &enrollee, &amount);
 
         // Track user earnings
         let earn_key = DataKey::UserEarnings(enrollee.clone());
@@ -463,6 +472,14 @@ impl RewardsContract {
             .persistent()
             .extend_ttl(&pool_key, THRESHOLD, BUMP);
 
+        // Keep the aggregate counters in sync with the refund (issue #864).
+        // The instance-storage `TotalDistributed` is a fast read; we
+        // decrement it so reads after a refund don't show stale "money in
+        // user hands" totals. `QuestRefunded(quest_id)` is the persistent
+        // authoritative aggregate that always equals the sum of refunds for
+        // this quest.
+        Self::record_refund(&env, quest_id, amount)?;
+
         // Emit refund event
         // Event topics: (reward_refunded,)
         // Event data: (quest_id, authority, amount)
@@ -471,6 +488,34 @@ impl RewardsContract {
             (quest_id, authority, amount),
         );
 
+        Ok(())
+    }
+
+    /// Decrement the instance-storage `TotalDistributed` counter and bump
+    /// the persistent `QuestRefunded` aggregate by the refunded amount.
+    /// Called from both `refund_pool` and `refund_unused_pool` so the
+    /// counters stay consistent across every refund path. See issue #864.
+    fn record_refund(env: &Env, quest_id: u32, amount: i128) -> Result<(), Error> {
+        let total: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalDistributed)
+            .unwrap_or(0);
+        // Saturate at 0 — the instance counter must never go negative even
+        // if a refund-without-prior-distribute happens (the invariant is
+        // re-established by the persistent QuestRefunded aggregate).
+        let new_total = total.saturating_sub(amount);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDistributed, &new_total);
+
+        let q_refunded_key = DataKey::QuestRefunded(quest_id);
+        let q_refunded: i128 = env.storage().persistent().get(&q_refunded_key).unwrap_or(0);
+        let new_refunded = q_refunded
+            .checked_add(amount)
+            .ok_or(Error::ArithmeticOverflow)?;
+        env.storage().persistent().set(&q_refunded_key, &new_refunded);
+        common::extend_persistent_ttl(env, &q_refunded_key);
         Ok(())
     }
 
@@ -739,6 +784,9 @@ impl RewardsContract {
             .persistent()
             .extend_ttl(&DataKey::QuestPool(quest_id), THRESHOLD, BUMP);
 
+        // Keep aggregate counters in sync — issue #864.
+        Self::record_refund(&env, quest_id, refundable)?;
+
         // Emit event — reuse reward_refunded topic for indexer compatibility
         env.events().publish(
             (Symbol::new(&env, "reward_refunded"),),
@@ -746,6 +794,17 @@ impl RewardsContract {
         );
 
         Ok(refundable)
+    }
+
+    /// Persistent per-quest aggregate of refunded tokens. The instance
+    /// counter `TotalDistributed` is the fast read; this is the
+    /// authoritative source of truth that survives across contract
+    /// upgrades.
+    pub fn get_quest_refunded(env: Env, quest_id: u32) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::QuestRefunded(quest_id))
+            .unwrap_or(0)
     }
 }
 

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -2117,3 +2117,58 @@ fn test_pause_blocks_grace_period_updates() {
     client.set_refund_grace_period(&admin, &259_200);
     assert_eq!(client.get_refund_grace_period(), 259_200);
 }
+// --- TotalDistributed / TotalRefunded sync (issue #864) ---
+
+#[test]
+fn test_refund_pool_decrements_total_distributed() {
+    // Fund a pool, archive the quest, advance time past the grace window,
+    // then refund some of the pool. The instance-storage `TotalDistributed`
+    // counter must decrement by the refunded amount, and the persistent
+    // `get_quest_refunded` aggregate must reflect the refund.
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Refund counter test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+    // No payouts have happened — TotalDistributed is still 0.
+    assert_eq!(client.get_total_distributed(), 0);
+    assert_eq!(client.get_quest_refunded(&q_id), 0);
+
+    quest_client.archive_quest(&q_id);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 604_800 + 1);
+
+    client.refund_pool(&owner, &q_id, &2_000);
+
+    // TotalDistributed saturates at 0 (no prior distribute) and
+    // QuestRefunded reflects the refunded amount.
+    assert_eq!(client.get_total_distributed(), 0);
+    assert_eq!(client.get_quest_refunded(&q_id), 2_000);
+
+    client.refund_pool(&owner, &q_id, &1_500);
+    assert_eq!(client.get_quest_refunded(&q_id), 3_500);
+}


### PR DESCRIPTION
## Summary
One PR for the four assigned issues across `contracts/rewards` and
`contracts/milestone`. Two storage/order corrections and two new
observability/safety surfaces.

closes #861
closes #864
closes #865
closes #868

## Per-issue detail

### closes #861 — write PayoutRecord before token transfer
**File:** `contracts/rewards/src/lib.rs` (`distribute_reward`).

The body of `distribute_reward` previously did:

1. check `PayoutRecord(quest_id, milestone_id, enrollee)` for idempotency,
2. transfer tokens via SAC,
3. write `PayoutRecord` with the amount.

If the host crashed or the token-transfer frame reverted between steps 2
and 3, the replay guard wasn't yet durable and a retry would pay out
again.

This PR reorders the body so `PayoutRecord` is written **before** the
SAC `client.transfer` call (and after the pool-balance update, which is
also pre-transfer). Soroban transactions are atomic per host frame: if
the transfer subsequently panics, the storage writes (including the
PayoutRecord) roll back together; if the transfer succeeds, the record
is already durable and a duplicate `distribute_reward` returns
`AlreadyPaid`.

### closes #864 — keep TotalDistributed and refunds in sync
**File:** `contracts/rewards/src/lib.rs`.

`distribute_reward` updated the instance-storage `TotalDistributed` and
the persistent `QuestDistributed(quest_id)`, but `refund_pool` and
`refund_unused_pool` only touched the pool balance. The instance counter
became stale after any refund.

This PR:

- Adds a new `DataKey::QuestRefunded(quest_id)` — the persistent
  per-quest authoritative refund aggregate.
- Adds a private helper `record_refund(env, quest_id, amount)` that
  decrements the instance `TotalDistributed` (saturating at 0 to handle
  refunds that exceed prior payouts) and bumps `QuestRefunded(quest_id)`.
- Calls `record_refund` from both `refund_pool` and `refund_unused_pool`.
- Exposes `get_quest_refunded(quest_id) -> i128` for indexers and tests.

After this change the instance counter satisfies `TotalDistributed ==
sum(payouts) - sum(refunds)` (saturated at 0), and the persistent
`QuestRefunded` aggregate is independently verifiable.

**Tests added:** `test_refund_pool_decrements_total_distributed` covers the
two-refund path and asserts both the saturated `TotalDistributed` and the
`QuestRefunded` aggregate.

### closes #865 — paginate `get_quest_completion_rate`
**File:** `contracts/milestone/src/lib.rs` (`get_quest_completion_rate`)
plus the existing rate test.

The function fetched the full enrollee list via cross-contract call and
iterated every entry, with no bound. For quests with thousands of
enrollees the call would either run out of budget or wedge the RPC.

This PR replaces the signature with explicit `(offset: u32, limit: u32)`
parameters and a new constant `MAX_COMPLETION_RATE_PAGE = 100`:

- `limit == 0` or `limit > MAX_COMPLETION_RATE_PAGE` ⇒ `InvalidInput`.
- `offset >= enrollees.len()` ⇒ returns `0`.
- Otherwise iterates `enrollees[offset .. min(offset + limit, len)]` and
  returns the percentage fully-completed within that window.

The existing `test_get_quest_completion_rate` is updated to call with
`offset=0, limit=4`. Three new tests cover the unbounded-limit rejection
(both `limit==0` and `limit>cap`), an offset past the end, and partial
windows.

**Breaking ABI change:** the function signature went from
`(quest_id, total_enrollees) -> i128` to
`(quest_id, offset, limit) -> Result<i128, Error>`. Any off-chain caller
that hard-codes the old signature will need to update.

### closes #868 — emit event for `set_distribution_mode`
**File:** `contracts/milestone/src/lib.rs` (`set_distribution_mode`).

The function rewrote distribution rules silently. Indexers and frontends
had no way to warn enrolled learners that their reward structure had
shifted.

This PR publishes a new event at the end of `set_distribution_mode`:

- **Topic:** `(\"distribution_mode_set\",)`
- **Data:** `(quest_id, mode, flat_reward_or_zero, actor, timestamp)`

where `flat_reward_or_zero` is the newly-stored flat reward when the mode
is `Flat`, and 0 otherwise. `test_set_distribution_mode_emits_event`
asserts that the event count increases when the function is called.

## What's covered
- 4 new unit tests across the two contract test files.
- The existing `test_get_quest_completion_rate` is updated to the new
  signature, preserving the prior end-state coverage.

## Honest caveats
- Not built or unit-tested locally — sandboxed environment can't run
  `cargo test --workspace`. Relying on CI.
- The `get_quest_completion_rate` signature change is breaking for the
  Soroban contract ABI (and for any TypeScript binding generated against
  it).
- `EVENT_REFERENCE.md` (referenced in the issue acceptance) was not
  located in the repo; if it exists elsewhere, the new
  `distribution_mode_set` topic should be added to it in a follow-up.