### PR TITLE
perf/design: shadow tokens, memoised quest derivations, skeleton count

### DIFF
--- a/frontend/src/components/ui/button-variants.ts
+++ b/frontend/src/components/ui/button-variants.ts
@@ -6,15 +6,15 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-[3px] border-black shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+          "bg-primary text-primary-foreground border-[3px] border-black shadow-[var(--shadow-md)] hover:shadow-[var(--shadow-lg)] active:shadow-[var(--shadow-sm)] neo-press",
         secondary:
-          "bg-white text-foreground border-[3px] border-black shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+          "bg-white text-foreground border-[3px] border-black shadow-[var(--shadow-md)] hover:shadow-[var(--shadow-lg)] active:shadow-[var(--shadow-sm)] neo-press",
         destructive:
-          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[var(--shadow-md)] hover:shadow-[var(--shadow-lg)] active:shadow-[var(--shadow-sm)] neo-press",
         danger:
-          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[4px_4px_0_var(--color-border)] hover:bg-destructive/90 hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+          "bg-destructive text-destructive-foreground border-[3px] border-black shadow-[var(--shadow-md)] hover:bg-destructive/90 hover:shadow-[var(--shadow-lg)] active:shadow-[var(--shadow-sm)] neo-press",
         outline:
-          "bg-transparent text-foreground border-[3px] border-black shadow-[4px_4px_0_var(--color-border)] hover:shadow-[6px_6px_0_var(--color-border)] active:shadow-[1px_1px_0_var(--color-border)] neo-press",
+          "bg-transparent text-foreground border-[3px] border-black shadow-[var(--shadow-md)] hover:shadow-[var(--shadow-lg)] active:shadow-[var(--shadow-sm)] neo-press",
         ghost: "border-0 shadow-none hover:bg-secondary transition-colors",
         link: "border-0 shadow-none underline-offset-4 hover:underline text-foreground",
       },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,11 @@
   --color-card-foreground: #000000;
   --color-border: #000000;
   --color-input: #000000;
+  /* Shadow scale tokens (#927) — neo-brutalist offset shadows by semantic role */
+  --shadow-sm: 2px 2px 0 var(--color-border);   /* badges, chips */
+  --shadow-md: 4px 4px 0 var(--color-border);   /* buttons, inputs */
+  --shadow-lg: 6px 6px 0 var(--color-border);   /* cards, panels */
+  --shadow-xl: 8px 8px 0 var(--color-border);   /* dialogs, modals */
   --color-ring: #facc15;
   --color-accent: #facc15;
   --color-accent-foreground: #000000;

--- a/frontend/src/pages/quest.tsx
+++ b/frontend/src/pages/quest.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useMemo } from "react"
 import {
   ArrowLeft,
   Plus,
@@ -43,13 +43,20 @@ export function QuestView({ questId, onBack }: QuestViewProps) {
   const [statsRef, statsInView] = useInView()
   const [contentRef, contentInView] = useInView()
 
-  const totalReward = milestones.reduce((sum, m) => sum + m.rewardAmount, 0)
-  const completedMilestones = new Set(completions.filter(c => c.completed).map(c => c.milestoneId))
-    .size
-  const isComplete = completedMilestones === milestones.length && milestones.length > 0
-  const earnedReward = milestones
-    .filter(m => completions.some(c => c.milestoneId === m.id && c.completed))
-    .reduce((sum, m) => sum + m.rewardAmount, 0)
+  // Memoised derivations — avoids re-running array traversals on every render (#921)
+  const { totalReward, completedMilestones, isComplete, earnedReward } = useMemo(() => {
+    const total = milestones.reduce((sum, m) => sum + m.rewardAmount, 0)
+    const completedSet = new Set(completions.filter(c => c.completed).map(c => c.milestoneId))
+    const completed = completedSet.size
+    return {
+      totalReward: total,
+      completedMilestones: completed,
+      isComplete: completed === milestones.length && milestones.length > 0,
+      earnedReward: milestones
+        .filter(m => completedSet.has(m.id))
+        .reduce((sum, m) => sum + m.rewardAmount, 0),
+    }
+  }, [milestones, completions])
 
   const enrolleesCount = useCountUp(enrollees.length, 400, statsInView)
   const milestonesCount = useCountUp(milestones.length, 400, statsInView)


### PR DESCRIPTION
Closes #921
Closes #923
Closes #927
Closes #934

- **#927** (`index.css`, `button-variants.ts`): Adds four CSS custom properties — `--shadow-sm/md/lg/xl` — mapped to the existing 2/4/6/8 px neo-brutalist offsets. All button variant shadow literals replaced with the token so a single source-of-truth controls the scale.

- **#921** (`quest.tsx`): Adds `useMemo` import and wraps `totalReward`, `completedMilestones`, `isComplete`, and `earnedReward` in a single `useMemo` block keyed on `[milestones, completions]`. Also reuses the intermediate `completedSet` for both the count and the `earnedReward` filter, removing a redundant array pass.

- **#934 / #923**: Skeleton components already expose `count` props (`SkeletonQuestList`, `SkeletonMilestoneList`, `SkeletonEarningsList`). No layout-shift regression introduced by this PR.