### PR TITLE
fix: breadcrumb, explicit loading messages, empty-state sizing, inline hero CSS

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,17 @@
 
     <title>Lernza — Learn. Earn. On-chain.</title>
 
+    <!-- Critical hero CSS inlined to unblock first paint (issue #925) -->
+    <style>
+      *,::before,::after{box-sizing:border-box}
+      body{margin:0;background:#fff;color:#0a0a0a;font-family:Inter,system-ui,sans-serif}
+      #root{min-height:100dvh}
+      .hero-section{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:5rem 1.5rem;text-align:center;background:#FACC15}
+      .hero-heading{font-size:clamp(2rem,6vw,4rem);font-weight:900;line-height:1.1;margin:0 0 1rem}
+      .hero-sub{font-size:1.125rem;max-width:42ch;margin:0 auto 2rem}
+      .hero-cta{display:inline-flex;align-items:center;gap:.5rem;padding:.75rem 1.75rem;font-weight:700;border:3px solid #0a0a0a;box-shadow:4px 4px 0 #0a0a0a;background:#0a0a0a;color:#FACC15;cursor:pointer;text-decoration:none}
+    </style>
+
     <!-- Font preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/src/components/ui/async-states.tsx
+++ b/frontend/src/components/ui/async-states.tsx
@@ -5,11 +5,12 @@ import { Button } from "@/components/ui/button"
 // ─── Loading States ─────────────────────────────────────────────────────────────
 
 interface LoadingStateProps {
-  message?: string
+  /** Contextual message — callers must provide one (e.g. "Fetching quests", "Confirming transaction"). */
+  message: string
   variant?: "default" | "compact" | "inline"
 }
 
-export function LoadingState({ message = "Loading...", variant = "default" }: LoadingStateProps) {
+export function LoadingState({ message, variant = "default" }: LoadingStateProps) {
   if (variant === "inline") {
     return (
       <div className="flex items-center gap-2 text-sm font-bold">
@@ -280,7 +281,8 @@ export function EmptyState(props: EmptyStateProps) {
     return (
       <Card className="animate-fade-in-up">
         <CardContent className="flex items-center gap-3 py-4">
-          <div className="bg-primary border-border flex h-8 w-8 items-center justify-center border-[2px] shadow-[2px_2px_0_var(--color-border)]">
+          {/* compact: h-10 w-10 container, icon h-6 w-6 — 1.6× ratio matching standalone */}
+          <div className="bg-primary border-border flex h-10 w-10 shrink-0 items-center justify-center border-[2px] shadow-[2px_2px_0_var(--color-border)]">
             {config.icon}
           </div>
           <div className="flex-1">

--- a/frontend/src/components/ui/breadcrumb.tsx
+++ b/frontend/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,39 @@
+import { ChevronRight } from "lucide-react"
+
+export interface BreadcrumbItem {
+  label: string
+  onClick?: () => void
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+}
+
+/**
+ * Breadcrumb — renders a small "Back to X > Current" trail above PageHeaders.
+ * The last item is the current page (no onClick).
+ */
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-1 text-sm">
+      {items.map((item, i) => {
+        const isLast = i === items.length - 1
+        return (
+          <span key={i} className="flex items-center gap-1">
+            {i > 0 && <ChevronRight className="text-muted-foreground h-3 w-3" aria-hidden />}
+            {isLast || !item.onClick ? (
+              <span className={isLast ? "font-bold" : "text-muted-foreground"}>{item.label}</span>
+            ) : (
+              <button
+                onClick={item.onClick}
+                className="text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+              >
+                {item.label}
+              </button>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/pages/quest.tsx
+++ b/frontend/src/pages/quest.tsx
@@ -22,6 +22,7 @@ import { formatTokens } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast"
 import { ToastContainer } from "@/components/toast"
 import { ShareButton } from "@/components/share-button"
+import { Breadcrumb } from "@/components/ui/breadcrumb"
 
 interface QuestViewProps {
   questId: number
@@ -78,6 +79,8 @@ export function QuestView({ questId, onBack }: QuestViewProps) {
     <div className="relative mx-auto max-w-6xl px-4 py-8 sm:px-6">
       {/* Background */}
       <div className="bg-grid-dots pointer-events-none absolute inset-0 opacity-30" />
+
+      <Breadcrumb items={[{ label: "Quests", onClick: onBack }, { label: ws.title }]} />
 
       {/* Back button */}
       <button


### PR DESCRIPTION
Closes #925
Closes #929
Closes #935
Closes #940

## Changes

**frontend/src/components/ui/breadcrumb.tsx** *(new)*
- `Breadcrumb` component renders a chevron-separated trail; last item is bold, earlier items are clickable buttons (#940)

**frontend/src/pages/quest.tsx**
- Import and render `<Breadcrumb items={[{ label: "Quests", onClick: onBack }, { label: ws.title }]} />` above the back button (#940)

**frontend/src/components/ui/async-states.tsx**
- `LoadingState.message` is now required (no default) — callers must pass a contextual string (#935)
- Compact `EmptyState` container changed from `h-8 w-8` to `h-10 w-10` so the `h-6 w-6` icon sits at the same ~1.6× container ratio as the standalone variant (#929)

**frontend/index.html**
- Inline `<style>` block with critical hero styles (layout, heading, CTA) to unblock first paint before the Tailwind bundle arrives (#925)