### PR TITLE
fix(a11y): touch targets, skip link, live regions, alt text (#951-#954)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -87,7 +87,7 @@ export function AppShell({ children }: AppShellProps) {
     <div className="bg-background text-foreground flex min-h-screen flex-col">
       <a
         href="#main-content"
-        className="bg-background text-foreground focus-visible:ring-ring sr-only absolute top-4 left-4 z-[100] px-4 py-2 font-bold opacity-0 transition-opacity focus-visible:not-sr-only focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none"
+        className="bg-background text-foreground border-border sr-only absolute top-2 left-2 z-[200] border-[3px] px-4 py-2 font-bold shadow-[4px_4px_0_var(--color-border)] focus:not-sr-only focus:outline-2 focus:outline-offset-2 focus:outline-current"
       >
         Skip to main content
       </a>

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -45,7 +45,7 @@ function ThemeToggle() {
       aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
       title={`Switch to ${isDark ? "light" : "dark"} mode`}
       className={cn(
-        "border-border h-9 w-9 border-[2px] shadow-[2px_2px_0_var(--color-border)]",
+        "border-border h-11 w-11 border-[2px] shadow-[2px_2px_0_var(--color-border)] sm:h-9 sm:w-9",
         "neo-press flex cursor-pointer items-center justify-center",
         "transition-colors duration-300",
         isDark
@@ -111,7 +111,13 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
                 <div className="bg-success border-border h-2.5 w-2.5 border" />
                 <span className="font-mono text-sm font-bold">{shortAddress}</span>
               </div>
-              <Button variant="ghost" size="icon" onClick={disconnect} aria-label="Disconnect wallet">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={disconnect}
+                aria-label="Disconnect wallet"
+                className="h-11 w-11 sm:h-9 sm:w-9"
+              >
                 <LogOut className="h-4 w-4" aria-hidden="true" />
               </Button>
             </>
@@ -128,16 +134,24 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
             aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
             aria-expanded={mobileOpen}
             aria-controls="mobile-nav-menu"
-            className="border-border bg-background neo-press flex h-9 w-9 cursor-pointer items-center justify-center border-[2px] shadow-[2px_2px_0_var(--color-border)] sm:hidden"
+            className="border-border bg-background neo-press flex h-11 w-11 cursor-pointer items-center justify-center border-[2px] shadow-[2px_2px_0_var(--color-border)] sm:hidden"
           >
-            {mobileOpen ? <X className="h-4 w-4" aria-hidden="true" /> : <Menu className="h-4 w-4" aria-hidden="true" />}
+            {mobileOpen ? (
+              <X className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Menu className="h-4 w-4" aria-hidden="true" />
+            )}
           </button>
         </div>
       </div>
 
       {/* Mobile menu dropdown */}
       {mobileOpen && (
-        <nav aria-label="Main navigation" id="mobile-nav-menu" className="border-border bg-background animate-fade-in-down border-t-[3px] transition-colors duration-300 sm:hidden">
+        <nav
+          aria-label="Main navigation"
+          id="mobile-nav-menu"
+          className="border-border bg-background animate-fade-in-down border-t-[3px] transition-colors duration-300 sm:hidden"
+        >
           <ul className="space-y-1 px-4 py-3">
             {NAV_ITEMS.map(item => (
               <li key={item.key}>

--- a/frontend/src/components/ui/async-states.tsx
+++ b/frontend/src/components/ui/async-states.tsx
@@ -13,8 +13,13 @@ interface LoadingStateProps {
 export function LoadingState({ message, variant = "default" }: LoadingStateProps) {
   if (variant === "inline") {
     return (
-      <div className="flex items-center gap-2 text-sm font-bold">
-        <Loader2 className="h-4 w-4 animate-spin" />
+      <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        className="flex items-center gap-2 text-sm font-bold"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
         {message}
       </div>
     )
@@ -24,8 +29,15 @@ export function LoadingState({ message, variant = "default" }: LoadingStateProps
     return (
       <Card>
         <CardContent className="flex items-center gap-3 py-4">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm font-bold">{message}</span>
+          <div
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="flex items-center gap-3"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            <span className="text-sm font-bold">{message}</span>
+          </div>
         </CardContent>
       </Card>
     )
@@ -34,11 +46,18 @@ export function LoadingState({ message, variant = "default" }: LoadingStateProps
   return (
     <Card className="animate-fade-in-up">
       <CardContent className="flex flex-col items-center py-12 text-center">
-        <div className="bg-muted border-border mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
-          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="flex flex-col items-center"
+        >
+          <div className="bg-muted border-border mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
+            <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" aria-hidden="true" />
+          </div>
+          <h3 className="mb-2 font-black">{message}</h3>
+          <p className="text-muted-foreground text-sm">Fetching on-chain data, please wait...</p>
         </div>
-        <h3 className="mb-2 font-black">{message}</h3>
-        <p className="text-muted-foreground text-sm">Fetching on-chain data, please wait...</p>
       </CardContent>
     </Card>
   )
@@ -63,8 +82,8 @@ export function ErrorState({
 
   if (variant === "inline") {
     return (
-      <div className="text-destructive flex items-center gap-2 text-sm font-bold">
-        <ErrorIcon className="h-4 w-4" />
+      <div role="alert" className="text-destructive flex items-center gap-2 text-sm font-bold">
+        <ErrorIcon className="h-4 w-4" aria-hidden="true" />
         {message}
       </div>
     )
@@ -74,8 +93,10 @@ export function ErrorState({
     return (
       <Card className="border-destructive">
         <CardContent className="flex items-center gap-3 py-4">
-          <ErrorIcon className="text-destructive h-4 w-4" />
-          <span className="text-destructive text-sm font-bold">{message}</span>
+          <div role="alert" className="flex flex-1 items-center gap-3">
+            <ErrorIcon className="text-destructive h-4 w-4" aria-hidden="true" />
+            <span className="text-destructive text-sm font-bold">{message}</span>
+          </div>
           {onRetry && (
             <Button size="sm" variant="outline" onClick={onRetry}>
               Retry
@@ -89,11 +110,13 @@ export function ErrorState({
   return (
     <Card className="animate-fade-in-up">
       <CardContent className="flex flex-col items-center py-12 text-center">
-        <div className="bg-destructive/10 border-destructive mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
-          <ErrorIcon className="text-destructive h-6 w-6" />
+        <div role="alert" className="flex flex-col items-center">
+          <div className="bg-destructive/10 border-destructive mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
+            <ErrorIcon className="text-destructive h-6 w-6" aria-hidden="true" />
+          </div>
+          <h3 className="mb-2 font-black">Error</h3>
+          <p className="text-muted-foreground mb-4 max-w-md text-sm">{message}</p>
         </div>
-        <h3 className="mb-2 font-black">Error</h3>
-        <p className="text-muted-foreground mb-4 max-w-md text-sm">{message}</p>
         {onRetry && (
           <Button onClick={onRetry} className="shimmer-on-hover">
             Try Again
@@ -301,15 +324,14 @@ export function EmptyState(props: EmptyStateProps) {
 
   return (
     <Card className="animate-fade-in-up">
-      <CardContent className="flex flex-col items-center py-12 text-center">
+      <CardContent
+        role="status"
+        aria-live="polite"
+        className="flex flex-col items-center py-12 text-center"
+      >
         {illustrationSrc ? (
           <div className="mb-6">
-            <img
-              src={illustrationSrc}
-              alt=""
-              className="h-32 w-32 sm:h-40 sm:w-40"
-              aria-hidden="true"
-            />
+            <img src={illustrationSrc} alt={config.title} className="h-32 w-32 sm:h-40 sm:w-40" />
           </div>
         ) : (
           <div className="bg-primary border-border mb-4 flex h-14 w-14 items-center justify-center border-[3px] shadow-[4px_4px_0_var(--color-border)]">
@@ -361,7 +383,7 @@ if (typeof document !== "undefined") {
     "/illustrations/empty-profile.svg",
     "/illustrations/empty-leaderboard.svg",
   ]
-  preloads.forEach((src) => {
+  preloads.forEach(src => {
     const link = document.createElement("link")
     link.rel = "prefetch"
     link.as = "image"

--- a/frontend/src/pages/create-quest/step2.tsx
+++ b/frontend/src/pages/create-quest/step2.tsx
@@ -87,7 +87,8 @@ export function Step2Form({
                       type="button"
                       onClick={() => swap(index, index - 1)}
                       disabled={index === 0}
-                      className="border-border bg-background hover:bg-secondary neo-press flex h-7 w-7 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30"
+                      aria-label={`Move milestone ${index + 1} up`}
+                      className="border-border bg-background hover:bg-secondary neo-press flex h-11 w-11 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30 sm:h-7 sm:w-7"
                     >
                       <ChevronUp className="h-3.5 w-3.5" />
                     </button>
@@ -95,7 +96,8 @@ export function Step2Form({
                       type="button"
                       onClick={() => swap(index, index + 1)}
                       disabled={index === fields.length - 1}
-                      className="border-border bg-background hover:bg-secondary neo-press flex h-7 w-7 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30"
+                      aria-label={`Move milestone ${index + 1} down`}
+                      className="border-border bg-background hover:bg-secondary neo-press flex h-11 w-11 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30 sm:h-7 sm:w-7"
                     >
                       <ChevronDown className="h-3.5 w-3.5" />
                     </button>
@@ -103,7 +105,8 @@ export function Step2Form({
                       type="button"
                       onClick={() => remove(index)}
                       disabled={fields.length === 1}
-                      className="border-border bg-background hover:bg-destructive/10 hover:border-destructive neo-press flex h-7 w-7 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30"
+                      aria-label={`Remove milestone ${index + 1}`}
+                      className="border-border bg-background hover:bg-destructive/10 hover:border-destructive neo-press flex h-11 w-11 cursor-pointer items-center justify-center border-[2px] transition-colors disabled:cursor-not-allowed disabled:opacity-30 sm:h-7 sm:w-7"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>


### PR DESCRIPTION
## Summary

Fixes four accessibility issues in the frontend.

### #951 — 44px touch targets on mobile icon buttons
- **navbar.tsx**: ThemeToggle and disconnect button promoted to `h-11 w-11` on mobile (`sm:h-9 sm:w-9` on desktop). Hamburger promoted to `h-11 w-11`.
- **step2.tsx**: Milestone reorder/delete buttons promoted to `h-11 w-11` on mobile (`sm:h-7 sm:w-7` on desktop). Added `aria-label` to each.

### #952 — Skip-to-content link visible and unobstructed
- **app-shell.tsx**: Raised `z-[200]` (above navbar `z-50`). Switched to `focus:not-sr-only` with `outline-2 outline-offset-2`.

### #953 — Live regions for async state changes
- **async-states.tsx**: `LoadingState` → `role="status" aria-live="polite" aria-busy="true"`. `ErrorState` → `role="alert"`. `EmptyState` → `role="status" aria-live="polite"`.

### #954 — Alt text for empty-state illustrations
- **async-states.tsx**: Illustration `<img>` now uses `alt={config.title}` (variant-specific meaningful text). `error-boundary.tsx` uses Lucide icon components, not `<img>` — no change needed.

## Testing
- Lint and Prettier passed via lint-staged on commit.
- Pre-existing TS errors in `types.ts` and `profile.tsx` are unrelated (present on `main` before this PR).

Closes #951
Closes #952
Closes #953
Closes #954