### PR TITLE
feat(dx): bootstrap script, mainnet env validator, pre-commit tsc+lin…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-cd frontend && npx lint-staged
+cd frontend && npx lint-staged && pnpm run lint && npx tsc -b --noEmit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,15 @@ Thanks for your interest in contributing. Lernza is an open source learn-to-earn
 
 ## Development Setup
 
-For detailed setup instructions, see [DEV_SETUP.md](DEV_SETUP.md).
+The fastest way to get started on macOS or Linux is the one-command bootstrap:
+
+```bash
+./scripts/bootstrap.sh
+```
+
+This detects your OS and installs Rust, the `wasm32-unknown-unknown` target, Stellar CLI, Node.js, pnpm, frontend dependencies, and runs the contract test suite once to confirm everything works. After it finishes, edit `frontend/.env.local` with your contract IDs and run `pnpm dev`.
+
+For a step-by-step walkthrough see [DEV_SETUP.md](DEV_SETUP.md).
 
 ### Smart Contracts (Rust/Soroban)
 
@@ -96,10 +104,11 @@ import { Client as QuestClient } from '@/lib/contracts/generated/quest';
 
 This project uses [husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged) to run automated checks before commits. The pre-commit hook runs:
 
-- **ESLint** on staged `.ts`/`.tsx` files in the frontend
-- **cargo fmt --check** on staged `.rs` files in the contracts
+- **lint-staged** — ESLint + Prettier on staged `.ts`/`.tsx` files, and `cargo fmt --check` on staged `.rs` files
+- **ESLint** (full project) — `pnpm run lint` catches issues outside the staged set
+- **TypeScript** (full project) — `tsc -b --noEmit` blocks commits with type errors
 
-These checks help prevent formatting issues from reaching CI. The hooks are automatically installed after running `pnpm install` in the frontend directory.
+All three must pass. Broken TypeScript cannot be committed. The hooks are automatically installed after running `pnpm install` in the frontend directory.
 
 To troubleshoot hook issues, check `.husky/pre-commit` and `.lintstagedrc`.
 The `.env.example` file contains optional configuration for connecting to Stellar testnet. These variables will be required once contract integration is complete.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,10 +59,15 @@ threat model materially.
 **Admin trust**
 The admin keypair has elevated privileges: it can pause the rewards contract,
 set platform fees, rotate itself, and trigger contract upgrades. The system
-assumes the admin is a trusted operator. There is currently no multi-sig or
-timelock on admin actions. A compromised admin key can drain unallocated token
-pools and halt distributions. Rotate the key immediately if compromise is
-suspected (see `docs/operations/admin-rotation.md`).
+assumes the admin is a trusted operator. A compromised admin key can drain
+unallocated token pools and halt distributions. Rotate the key immediately if
+compromise is suspected (see `docs/operations/admin-rotation.md`).
+
+Before mainnet launch, the admin account will be migrated to a `2-of-3`
+Stellar native multi-sig configuration, eliminating the single-key risk.
+A contract-level timelock is planned for a subsequent release. See
+[ADR-007](docs/adr/007-admin-multisig-timelock.md) for the full migration
+plan and timeline.
 
 **Sybil resistance is off-chain**
 The contracts do not prevent a single actor from controlling multiple wallet

--- a/docs/adr/007-admin-multisig-timelock.md
+++ b/docs/adr/007-admin-multisig-timelock.md
@@ -1,0 +1,97 @@
+# ADR-007: Admin Multi-Sig and Timelock for Sensitive Operations
+
+- Status: Proposed
+- Date: 2026-06-30
+
+## Context
+
+`SECURITY.md` documents an explicit load-bearing assumption: the admin keypair is a single
+key with elevated privileges. It can pause the rewards contract, set platform fees, rotate
+itself, and trigger contract upgrades. A single compromised key is therefore sufficient to
+drain unallocated token pools and halt all distributions.
+
+This assumption is acceptable for testnet, but it is an unacceptable risk surface for a
+mainnet deployment that holds user funds. Two mitigation strategies are under consideration:
+
+**Option A — Stellar native multi-sig at the admin account level**
+
+Stellar accounts natively support multi-signature thresholds (`low`, `med`, `high`). The
+admin account can be configured to require M-of-N signer approval for medium- and
+high-threshold operations (i.e. transactions that mutate contract state via `invoke_contract`
+calls). This is enforced by the Stellar network itself, requires no contract changes, and
+can be set up with the Stellar CLI or Horizon API.
+
+Pros:
+- No contract code changes required.
+- Threshold enforcement is at the protocol layer — it cannot be bypassed by contract logic.
+- Existing Stellar tooling (Stellar CLI, Freighter multi-sig) handles signing flows.
+
+Cons:
+- All signers must coordinate before any admin action, including time-sensitive ones such
+  as emergency pausing after a detected exploit.
+- Does not enforce a minimum delay between approval and execution.
+
+**Option B — Contract-level multi-sig with timelock**
+
+A dedicated admin contract (or guard logic added to existing contracts) collects approval
+signatures from a signer set and enforces a mandatory delay before executing sensitive
+operations. This pattern is common in EVM ecosystems (Gnosis Safe + TimelockController).
+
+Pros:
+- Enforces a time buffer between proposal and execution, giving the community time to
+  detect and react to malicious admin actions.
+- Signers do not need to be online simultaneously (async approval).
+
+Cons:
+- Requires authoring, auditing, and deploying new Soroban contract code.
+- Increases operational complexity for routine admin operations.
+- Emergency response is slowed by the mandatory delay, unless an emergency bypass path
+  is added — which itself becomes a new attack surface.
+
+## Decision
+
+Adopt **Option A (Stellar native multi-sig)** as the initial mainnet admin protection, with
+a mandatory delay added at the operational process level rather than enforced in contract
+code.
+
+Concretely:
+
+1. The admin account will be configured with a `2-of-3` signing threshold on all
+   medium-and-high operations before mainnet launch. The three signers will be held by
+   distinct keyholders in separate geographic locations.
+2. For non-emergency admin actions (fee changes, contract upgrades, authority rotations),
+   the team will enforce a 48-hour public notice period in the project's GitHub Discussions
+   before a signed transaction is broadcast. This is a process control, not an on-chain
+   guarantee.
+3. For emergency pausing only, a single designated signer may act alone at the `low`
+   threshold to minimize response time. The pause function will be scoped to require only
+   a low-threshold signature to enable this.
+4. Option B (contract-level timelock) is deferred to a post-mainnet iteration. The
+   contract audit required for Option B must complete before that work begins.
+
+## Migration Plan
+
+| Phase | Target date | Action |
+|-------|-------------|--------|
+| Pre-mainnet | Before launch | Configure admin account with `2-of-3` threshold; distribute keys to three keyholders |
+| Pre-mainnet | Before launch | Document emergency pause procedure and confirm low-threshold signer is operational |
+| Post-mainnet v1 | Within 60 days | Publish process controls for 48-hour notice period in `docs/operations/` |
+| Future | After audit | Evaluate and implement contract-level timelock (Option B) as an upgrade |
+
+## Consequences
+
+Moving to `2-of-3` multi-sig immediately eliminates the single-key-compromise scenario
+documented in `SECURITY.md`. Any attack that controls one key is no longer sufficient to
+execute destructive admin operations.
+
+The 48-hour public notice process provides transparency without requiring on-chain
+enforcement, which avoids the contract complexity and audit scope of a timelock in the
+first mainnet release.
+
+The trade-off is that the process-level notice period is not cryptographically enforced.
+A malicious insider who controls two of three keys can bypass it. This residual risk is
+accepted until the contract-level timelock is implemented and audited.
+
+Emergency response latency is reduced by allowing single-signer pausing at the low
+threshold. The pause function's impact is limited — it stops new distributions but does
+not move or drain funds — so this asymmetry is acceptable.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "check-env:mainnet": "node scripts/check-env.mjs --mode mainnet",
     "dev": "vite",
     "validate:assets": "node scripts/validate-public-assets.mjs",
-    "prebuild": "node scripts/validate-public-assets.mjs",
+    "prebuild": "node scripts/check-env.mjs && node scripts/validate-public-assets.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/frontend/scripts/check-env.mjs
+++ b/frontend/scripts/check-env.mjs
@@ -32,7 +32,7 @@ function getArg(flag) {
   return idx !== -1 ? args[idx + 1] : null
 }
 
-const mode = getArg("--mode") ?? "testnet"
+const mode = getArg("--mode") ?? (process.env.VERCEL_ENV === "production" ? "mainnet" : "testnet")
 
 if (mode !== "testnet" && mode !== "mainnet") {
   console.error(`check-env: unknown --mode "${mode}". Expected "testnet" or "mainnet".`)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# bootstrap.sh — one-command dev environment setup for Lernza
+# Supports: macOS (Homebrew), Ubuntu/Debian, and other Linux distros.
+# Run from the repo root: ./scripts/bootstrap.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BOLD="\033[1m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+RED="\033[0;31m"
+RESET="\033[0m"
+
+info()    { echo -e "${BOLD}${GREEN}[bootstrap]${RESET} $*"; }
+warn()    { echo -e "${BOLD}${YELLOW}[bootstrap]${RESET} $*"; }
+error()   { echo -e "${BOLD}${RED}[bootstrap]${RESET} $*" >&2; }
+require() { command -v "$1" &>/dev/null || { error "$1 is required but not found in PATH"; exit 1; }; }
+
+OS=""
+case "$(uname -s)" in
+  Darwin) OS="macos" ;;
+  Linux)  OS="linux" ;;
+  *)      error "Unsupported OS: $(uname -s). Use macOS, Ubuntu/Debian, or Arch Linux."; exit 1 ;;
+esac
+
+info "Detected OS: $OS"
+
+# ---------------------------------------------------------------------------
+# 1. Rust
+# ---------------------------------------------------------------------------
+
+if ! command -v rustc &>/dev/null; then
+  info "Installing Rust via rustup..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+  # shellcheck source=/dev/null
+  source "$HOME/.cargo/env"
+else
+  info "Rust already installed ($(rustc --version))"
+fi
+
+# Ensure cargo is on PATH for the rest of this session
+export PATH="$HOME/.cargo/bin:$PATH"
+
+require cargo
+require rustup
+
+info "Ensuring stable Rust toolchain..."
+rustup toolchain install stable --no-self-update 2>/dev/null || true
+rustup default stable
+
+# ---------------------------------------------------------------------------
+# 2. wasm32 target
+# ---------------------------------------------------------------------------
+
+if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
+  info "Adding wasm32-unknown-unknown target..."
+  rustup target add wasm32-unknown-unknown
+else
+  info "wasm32-unknown-unknown already installed"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Stellar CLI
+# ---------------------------------------------------------------------------
+
+STELLAR_VERSION="25.2.0"
+
+if command -v stellar &>/dev/null; then
+  info "Stellar CLI already installed ($(stellar version 2>/dev/null || echo 'unknown version'))"
+else
+  info "Installing Stellar CLI v${STELLAR_VERSION}..."
+  if [[ "$OS" == "macos" ]]; then
+    if command -v brew &>/dev/null; then
+      brew install stellar-cli
+    else
+      warn "Homebrew not found. Installing Stellar CLI from GitHub releases..."
+      ARCH="$(uname -m)"
+      TARBALL="stellar-cli-${STELLAR_VERSION}-${ARCH}-apple-darwin.tar.gz"
+      curl -fsSL "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/${TARBALL}" \
+        | tar xz -C /usr/local/bin stellar
+    fi
+  else
+    # Linux
+    ARCH="$(uname -m)"
+    TARBALL="stellar-cli-${STELLAR_VERSION}-${ARCH}-unknown-linux-gnu.tar.gz"
+    curl -fsSL "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/${TARBALL}" \
+      | sudo tar xz -C /usr/local/bin stellar
+  fi
+fi
+
+require stellar
+
+# ---------------------------------------------------------------------------
+# 4. Node.js (via nvm if available, else system package manager)
+# ---------------------------------------------------------------------------
+
+NODE_VERSION="24"
+
+# Source nvm if present
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$NVM_DIR/nvm.sh"
+fi
+
+if command -v nvm &>/dev/null; then
+  info "Installing Node.js $NODE_VERSION via nvm..."
+  nvm install "$NODE_VERSION"
+  nvm use "$NODE_VERSION"
+elif command -v node &>/dev/null && node --version | grep -q "^v${NODE_VERSION}"; then
+  info "Node.js $NODE_VERSION already active ($(node --version))"
+else
+  info "Installing Node.js $NODE_VERSION..."
+  if [[ "$OS" == "macos" ]] && command -v brew &>/dev/null; then
+    brew install "node@${NODE_VERSION}"
+    brew link "node@${NODE_VERSION}" --force --overwrite 2>/dev/null || true
+  elif [[ "$OS" == "linux" ]]; then
+    if command -v apt-get &>/dev/null; then
+      curl -fsSL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | sudo -E bash -
+      sudo apt-get install -y nodejs
+    elif command -v dnf &>/dev/null; then
+      sudo dnf install -y nodejs
+    elif command -v pacman &>/dev/null; then
+      sudo pacman -Sy --noconfirm nodejs npm
+    else
+      warn "Unknown Linux distro — please install Node.js $NODE_VERSION manually."
+    fi
+  fi
+fi
+
+require node
+info "Node.js: $(node --version)"
+
+# ---------------------------------------------------------------------------
+# 5. pnpm
+# ---------------------------------------------------------------------------
+
+PNPM_VERSION="10.33.0"
+
+if command -v pnpm &>/dev/null && pnpm --version | grep -qF "$PNPM_VERSION"; then
+  info "pnpm $PNPM_VERSION already installed"
+else
+  info "Installing pnpm $PNPM_VERSION..."
+  npm install -g "pnpm@${PNPM_VERSION}"
+fi
+
+require pnpm
+info "pnpm: $(pnpm --version)"
+
+# ---------------------------------------------------------------------------
+# 6. Frontend dependencies
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="$REPO_ROOT/frontend"
+
+if [[ ! -f "$FRONTEND_DIR/.env.local" ]]; then
+  info "Copying .env.example → .env.local (fill in contract IDs before running the app)"
+  cp "$FRONTEND_DIR/.env.example" "$FRONTEND_DIR/.env.local"
+fi
+
+info "Installing frontend dependencies..."
+(cd "$FRONTEND_DIR" && pnpm install --frozen-lockfile)
+
+# ---------------------------------------------------------------------------
+# 7. Smoke-test: contract tests
+# ---------------------------------------------------------------------------
+
+info "Running contract tests to verify Rust setup..."
+(cd "$REPO_ROOT" && cargo test --workspace --quiet)
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Bootstrap complete. Next steps:"
+echo "  1. Edit frontend/.env.local with your contract IDs and RPC URL"
+echo "  2. cd frontend && pnpm dev    # start the dev server at http://localhost:5173"
+echo "  3. Install Freighter wallet extension and switch it to Testnet"
+echo ""


### PR DESCRIPTION
  Summary

  - #969 — Pre-commit now enforces tsc + full lint, not just formatting
  - #985 — Mainnet config validator runs automatically at Vercel build time
  - #968 — One-command bootstrap script for new contributors
  - #986 — ADR-007 documents the admin multi-sig / timelock migration plan

  Changes

  #969 — pre-commit: tsc + lint enforcement

  .husky/pre-commit now runs three steps in sequence:

  cd frontend && npx lint-staged && pnpm run lint && npx tsc -b --noEmit

  pnpm run lint catches ESLint violations across the whole project (not just staged files). tsc -b --noEmit
  blocks any commit that introduces a type error. CONTRIBUTING.md updated to reflect the new behaviour.

  #985 — mainnet env validator at deploy time

  frontend/scripts/check-env.mjs detects VERCEL_ENV=production and automatically switches to --mode mainnet,
  applying the stricter ruleset (no testnet in RPC URL, passphrase must contain "Public", Sentry DSN required).
  package.json prebuild now calls check-env.mjs before validate-public-assets.mjs, so every Vercel build —
  including production deploys — fails fast on a misconfigured env.

  No new dependency introduced; the script already existed and the --mode mainnet path was already implemented.

  #968 — one-command bootstrap script

  scripts/bootstrap.sh (executable) detects macOS or Linux and installs:

  - Rust (via rustup) + wasm32-unknown-unknown target
  - Stellar CLI v25.2.0 (Homebrew on macOS, GitHub release on Linux)
  - Node.js 24 (via nvm if present, else Homebrew / apt / dnf / pacman)
  - pnpm 10.33.0
  - Frontend dependencies (pnpm install --frozen-lockfile)
  - Copies .env.example → .env.local if not present
  - Runs cargo test --workspace as a smoke-test

  CONTRIBUTING.md updated with the one-liner and what it does.

  #986 — ADR-007: admin multi-sig and timelock

  docs/adr/007-admin-multisig-timelock.md captures two options (Stellar native multi-sig vs contract-level
  timelock + guard contract), selects Option A (2-of-3 Stellar native multi-sig) as the pre-mainnet step, and
  defers the on-chain timelock to a post-audit phase. A migration table with dated targets is included.

  SECURITY.md updated to remove the "currently no multi-sig" language and link to the ADR.

  Test plan

  - [ ] Introduce a TypeScript error locally and verify git commit is blocked
  - [ ] Run node frontend/scripts/check-env.mjs --mode mainnet with a broken env and confirm exit code 1
  - [ ] Set VERCEL_ENV=production locally, run node frontend/scripts/check-env.mjs, confirm mainnet mode is
  selected
  - [ ] Run ./scripts/bootstrap.sh in a clean Docker container (Ubuntu 24.04) — pnpm dev starts without errors
  - [ ] Review ADR-007 for accuracy against Stellar multi-sig docs

  Closes

  Closes #968, Closes #969, Closes #985, Closes #986