### PR TITLE
fix(contracts): extend TTL for TotalReservedReward key

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -640,6 +640,9 @@ impl MilestoneContract {
         env.storage()
             .persistent()
             .extend_ttl(&comp_key, THRESHOLD, BUMP);
+        env.storage()
+            .persistent()
+            .extend_ttl(&reserved_key, THRESHOLD, BUMP);
 
         // Determine reward based on distribution mode. The Competitive
         // counter bump happens AFTER the comp_key tombstone is in place.
@@ -786,6 +789,9 @@ impl MilestoneContract {
         env.storage()
             .persistent()
             .set(&reserved_key, &(current_reserved + milestone.reward_amount));
+        env.storage()
+            .persistent()
+            .extend_ttl(&reserved_key, THRESHOLD, BUMP);
         env.storage()
             .persistent()
             .extend_ttl(&submit_key, THRESHOLD, BUMP);


### PR DESCRIPTION
 
## What does this PR do?

The TotalReservedReward(quest_id) persistent key is updated in verify_completion and submit_for_review but its TTL was never extended. This allowed the entry to expire (archive). Upon expiry, reads in get_total_reserved_reward fall back to 0, hiding outstanding reserved rewards from the rewards contract's refund_pool / refund_unused_pool functions. A quest authority could then refund the entire pool even while enrollees have verified-but-unpaid milestones, effectively stealing from them. Fix by adding .extend_ttl(THRESHOLD, BUMP) after every .set() on this key, consistent with all other persistent writes in the contract. 

## Related Issue

Closes #<!--issue number-->
[1103](https://github.com/lernza/lernza/issues/1103)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
