### PR TITLE
fix(a11y): add visible skip-to-content link above sticky navbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -144,9 +144,16 @@ function App() {
   return (
     <ErrorBoundary githubRepo="https://github.com/lernza/lernza">
       <div className="bg-background text-foreground min-h-screen">
+        {/* Skip-to-content link: sr-only until focused, z-index above sticky navbar */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[9999] focus:rounded focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-current"
+        >
+          Skip to main content
+        </a>
         <Navbar activePage={state.page} onNavigate={handleNavigate} />
         <ErrorBoundary key={`${state.page}-${state.questId ?? state.creatorAddress ?? ""}`}>
-          <main>{renderPage()}</main>
+          <main id="main-content">{renderPage()}</main>
         </ErrorBoundary>
         <Analytics />
         <SpeedInsights />

--- a/frontend/src/test/skip-link.test.tsx
+++ b/frontend/src/test/skip-link.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests that the skip-to-content link is present, reachable by keyboard,
+ * and points to the main content landmark.
+ * Issue: #952
+ */
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import React from "react"
+
+// ── Minimal stubs ──────────────────────────────────────────────────────────
+
+vi.mock("@vercel/analytics/react", () => ({ Analytics: () => null }))
+vi.mock("@vercel/speed-insights/react", () => ({ SpeedInsights: () => null }))
+vi.mock("@/components/navbar", () => ({
+  Navbar: () => React.createElement("nav", { "aria-label": "main" }),
+}))
+vi.mock("@/components/toast", () => ({
+  ToastContainer: () => null,
+}))
+vi.mock("@/components/error-boundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}))
+vi.mock("@/pages/landing", () => ({ Landing: () => React.createElement("div", null, "Landing") }))
+vi.mock("@/pages/dashboard", () => ({ Dashboard: () => null }))
+vi.mock("@/pages/quest", () => ({ QuestView: () => null }))
+vi.mock("@/pages/profile", () => ({ Profile: () => null }))
+vi.mock("@/pages/not-found", () => ({ NotFound: () => null }))
+vi.mock("@/pages/create-quest", () => ({ CreateQuest: () => null }))
+vi.mock("@/pages/terms", () => ({ TermsOfService: () => null }))
+vi.mock("@/pages/privacy", () => ({ PrivacyPolicy: () => null }))
+vi.mock("@/pages/leaderboard", () => ({ Leaderboard: () => null }))
+vi.mock("@/pages/creator", () => ({ CreatorProfile: () => null }))
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toasts: [], addToast: vi.fn(), removeToast: vi.fn() }),
+}))
+vi.mock("@/lib/notifications", () => ({ subscribeToasts: vi.fn(() => () => {}) }))
+
+import App from "../App"
+
+describe("skip-to-content link (issue #952)", () => {
+  it("renders a skip link with the correct href", () => {
+    render(<App />)
+    const link = screen.getByRole("link", { name: /skip to main content/i })
+    expect(link.getAttribute("href")).toBe("#main-content")
+  })
+
+  it("skip link appears before the navbar in the DOM", () => {
+    const { container } = render(<App />)
+    const all = Array.from(container.querySelectorAll("a[href='#main-content'], nav"))
+    expect(all[0].tagName.toLowerCase()).toBe("a")
+  })
+
+  it("main landmark has id='main-content' for the skip link target", () => {
+    render(<App />)
+    const main = screen.getByRole("main")
+    expect(main.getAttribute("id")).toBe("main-content")
+  })
+
+  it("skip link has z-index utility class above the navbar when focused", () => {
+    render(<App />)
+    const link = screen.getByRole("link", { name: /skip to main content/i })
+    // The Tailwind utility focus:z-[9999] is in the class list
+    expect(link.className).toContain("z-[9999]")
+  })
+
+  it("skip link is sr-only by default (not visually obtrusive)", () => {
+    render(<App />)
+    const link = screen.getByRole("link", { name: /skip to main content/i })
+    expect(link.className).toContain("sr-only")
+  })
+})


### PR DESCRIPTION
## Summary

- **#952**: The skip-to-content link was missing entirely from `App.tsx`. Added it as the very first element inside the root div, before the `<Navbar>`:
  - `sr-only` by default — invisible and out of flow until focused
  - `focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999]` — snaps into view at the top-left on Tab press, with `z-[9999]` well above the sticky navbar
  - `focus:outline focus:outline-2 focus:outline-offset-2` — visible focus ring for keyboard users
  - `href="#main-content"` — targets the `<main id="main-content">` element so Tab reach is one keystroke
  - Added `id="main-content"` to the existing `<main>` element

Also added `src/test/skip-link.test.tsx` with 5 unit tests verifying: correct href, DOM order before navbar, `main` landmark id, z-index class, and default `sr-only` visibility.

## Test plan
- [ ] `pnpm test` passes with 5 new skip-link tests green
- [ ] Manual: Tab key on landing page — skip link appears at top-left, above navbar, with visible outline
- [ ] Manual: Activate skip link — focus jumps to `<main>` bypassing navbar links
- [ ] Manual: Mobile widths (320px, 375px) — link not obscured by anything

Closes #952