### PR TITLE
fix(certificate): add pause/unpause functions to enable emergency stop

### DIFF
--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -314,6 +314,33 @@ impl CertificateContract {
             .has(&DataKey::RevokedCertificate(token_id))
     }
 
+    // ─── Pause / Unpause (emergency stop) ────────────────────────────────────
+
+    /// Pause certificate minting – only callable by the contract owner.
+    /// Once paused, `mint_quest_certificate` will fail with `Error::Paused`.
+    #[only_owner]
+    pub fn pause(env: Env) -> Result<(), Error> {
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "paused"), &true);
+        env.storage().instance().extend_ttl(THRESHOLD, BUMP);
+        env.events().publish((Symbol::new(&env, "paused"),), ());
+        Ok(())
+    }
+
+    /// Unpause certificate minting – only callable by the contract owner.
+    #[only_owner]
+    pub fn unpause(env: Env) -> Result<(), Error> {
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "paused"), &false);
+        env.storage().instance().extend_ttl(THRESHOLD, BUMP);
+        env.events().publish((Symbol::new(&env, "unpaused"),), ());
+        Ok(())
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────────────
+
     fn require_not_paused(env: &Env) -> Result<(), Error> {
         if env
             .storage()


### PR DESCRIPTION

## What does this PR do?

- The certificate contract included a require_not_paused check in mint_quest_certificate but had no functions to set the "paused" flag, making the check dead code. This left no way to halt certificate minting in case of an incident.

- Add pause() and unpause() functions, both protected by #[only_owner], that set the flag in instance storage. This brings the certificate contract in line with the quest, milestone, and rewards contracts, which already expose similar admin controls.

- Events are emitted for transparency, and TTL is extended on storage updates.


## Related Issue

Closes # https://github.com/lernza/lernza/issues/1105

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
