### PR TITLE
Fix (useTypewriter): remove redundant reset causing double render

### DIFF
--- a/frontend/src/hooks/use-animations.ts
+++ b/frontend/src/hooks/use-animations.ts
@@ -1,68 +1,68 @@
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef } from "react";
 
 export function useInView<T extends HTMLElement = HTMLDivElement>(
   options?: IntersectionObserverInit
 ) {
-  const ref = useRef<T>(null)
-  const [inView, setInView] = useState(false)
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
 
   // Stabilize options to avoid re-running the effect
-  const threshold = options?.threshold ?? 0.15
-  const rootMargin = options?.rootMargin
+  const threshold = options?.threshold ?? 0.15;
+  const rootMargin = options?.rootMargin;
 
   useEffect(() => {
-    const el = ref.current
-    if (!el) return
+    const el = ref.current;
+    if (!el) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
-        setInView(entry.isIntersecting)
+        setInView(entry.isIntersecting);
       },
       { threshold, rootMargin }
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [threshold, rootMargin])
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold, rootMargin]);
 
-  return [ref, inView] as const
+  return [ref, inView] as const;
 }
 
 export function useCountUp(target: number, duration = 1200, active = true) {
-  const [value, setValue] = useState(0)
+  const [value, setValue] = useState(0);
 
   useEffect(() => {
-    if (!active) return
-    let raf: number
-    const start = performance.now()
+    if (!active) return;
+    let raf: number;
+    const start = performance.now();
     const tick = (now: number) => {
-      const progress = Math.min((now - start) / duration, 1)
-      const eased = 1 - Math.pow(1 - progress, 3)
-      setValue(Math.round(eased * target))
-      if (progress < 1) raf = requestAnimationFrame(tick)
-    }
-    raf = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(raf)
-  }, [target, duration, active])
+      const progress = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setValue(Math.round(eased * target));
+      if (progress < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, duration, active]);
 
-  return active ? value : 0
+  return active ? value : 0;
 }
 
 export function useTypewriter(text: string, speed = 35, active = true) {
-  const [displayed, setDisplayed] = useState("")
+  const [displayed, setDisplayed] = useState("");
 
   useEffect(() => {
-    if (!active) return
-    setDisplayed("")
-    let i = 0
+    if (!active) return;
+    //  Removed: setDisplayed("") – was causing an extra render cycle
+    let i = 0;
     const interval = setInterval(() => {
       if (i < text.length) {
-        setDisplayed(text.slice(0, i + 1))
-        i++
+        setDisplayed(text.slice(0, i + 1));
+        i++;
       } else {
-        clearInterval(interval)
+        clearInterval(interval);
       }
-    }, speed)
-    return () => clearInterval(interval)
-  }, [text, speed, active])
+    }, speed);
+    return () => clearInterval(interval);
+  }, [text, speed, active]);
 
-  return active ? displayed : ""
+  return active ? displayed : "";
 }


### PR DESCRIPTION


## What does this PR do?

- Removed setDisplayed("") from the useEffect dependency chain to avoid an extra render cycle when text or active changes.
- The hook now relies on the caller to pass a key prop (e.g., key={text}) to force a remount and cleanly reset the state.
- Resolves lint warning about unnecessary state updates.

## Related Issue

Closes # https://github.com/lernza/lernza/issues/906

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
