### PR TITLE
refactor(quest): enhance QuestStats with count-up animations

### DIFF
--- a/frontend/src/components/quest-detail/quest-stats.tsx
+++ b/frontend/src/components/quest-detail/quest-stats.tsx
@@ -1,83 +1,74 @@
-import { Users, Target, Coins, Clock, Layout, TrendingUp } from "lucide-react"
+ 
+import { Users, Target, Coins } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
+import { useInView, useCountUp } from "@/hooks/use-animations"
 import { formatTokens } from "@/lib/utils"
 
 interface QuestStatsProps {
-  enrollees: number
-  milestones: number
-  poolBalance: bigint
-  totalReward: bigint
-  deadlineDays: number
-  statsInView: boolean
+  enrolleesCount: number
+  milestonesCount: number
+  poolBalance: number
+  totalReward: number
 }
 
 export function QuestStats({
-  enrollees,
-  milestones,
+  enrolleesCount,
+  milestonesCount,
   poolBalance,
   totalReward,
-  deadlineDays,
-  statsInView,
 }: QuestStatsProps) {
+  const [statsRef, statsInView] = useInView()
+
+  const animatedEnrollees = useCountUp(enrolleesCount, 400, statsInView)
+  const animatedMilestones = useCountUp(milestonesCount, 400, statsInView)
+  const animatedPoolBalance = useCountUp(poolBalance, 800, statsInView)
+  const animatedTotalReward = useCountUp(totalReward, 800, statsInView)
+
+  const stats = [
+    {
+      icon: Users,
+      label: "Enrollees",
+      value: animatedEnrollees,
+      bg: "bg-accent",
+    },
+    {
+      icon: Target,
+      label: "Milestones",
+      value: animatedMilestones,
+      bg: "bg-accent",
+    },
+    {
+      icon: Coins,
+      label: "Pool Balance",
+      value: formatTokens(animatedPoolBalance),
+      bg: "bg-accent",
+    },
+    {
+      icon: Coins,
+      label: "Total Rewards",
+      value: formatTokens(animatedTotalReward),
+      bg: "bg-success",
+    },
+  ]
+
   return (
-    <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
-      {[
-        {
-          icon: Users,
-          label: "Enrolled",
-          value: enrollees,
-          bg: "bg-accent",
-        },
-        {
-          icon: Target,
-          label: "Milestones",
-          value: milestones,
-          bg: "bg-success",
-        },
-        {
-          icon: Coins,
-          label: "Available Pool",
-          value: formatTokens(Number(poolBalance)),
-          bg: "bg-warning",
-        },
-        {
-          icon: TrendingUp,
-          label: "Reward/User",
-          value: formatTokens(Number(totalReward)),
-          bg: "bg-info",
-        },
-        {
-          icon: Clock,
-          label: "Deadline",
-          value: `${deadlineDays} Days left`,
-          bg: "bg-destructive",
-        },
-        {
-          icon: Layout,
-          label: "Category",
-          value: "Developer",
-          bg: "bg-secondary",
-        },
-      ].map((stat, i) => (
+    <div ref={statsRef} className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+      {stats.map((stat, i) => (
         <div
           key={stat.label}
           className={`reveal-up ${statsInView ? "in-view" : ""}`}
           style={{ transitionDelay: `${i * 100}ms` }}
         >
-          <Card className="neo-lift border-border border-2 bg-white transition-all hover:shadow-lg active:shadow-sm">
-            <CardContent className="flex flex-col items-center gap-3 p-4 sm:flex-row sm:items-start">
+          <Card className="neo-lift hover:shadow-lg active:shadow-sm">
+            <CardContent className="flex items-center gap-3 p-4">
               <div
-                className={`h-10 w-10 ${stat.bg} border-border animate-scale-in flex flex-shrink-0 items-center justify-center border shadow-sm`}
+                className={`h-10 w-10 ${stat.bg} border-border flex flex-shrink-0 items-center justify-center border shadow-sm`}
               >
                 <stat.icon className="h-4 w-4" />
               </div>
-              <div className="text-center sm:text-left">
-                <p className="text-muted-foreground text-[10px] font-semibold tracking-widest uppercase">
-                  {stat.label}
-                </p>
-                <p className="text-base font-semibold whitespace-nowrap tabular-nums">
-                  {stat.value}
-                </p>
+              <div>
+                <p className="text-muted-foreground text-xs font-bold">{stat.label}</p>
+                <p className="text-lg font-semibold tabular-nums">{stat.value}</p>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION


## What does this PR do?

- Move stats cards from quest.tsx
- Preserve useCountUp animations
- Include enrollees, milestones, pool balance, and total rewards

## Related Issue

Closes # https://github.com/lernza/lernza/issues/997

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
