### PR TITLE
feat(create-quest): extract schemas, types, and helper components

### DIFF
--- a/frontend/src/pages/create-quest/types.tsx
+++ b/frontend/src/pages/create-quest/types.tsx
@@ -3,8 +3,7 @@ import { Check, AlertCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import React from "react"
 
-// ─── Zod schemas ─────────────────────────────────────────────────────────────
-
+// Zod schemas
 export const step1Schema = z.object({
   name: z.string().min(1, "Quest name is required").max(64, "Max 64 characters"),
   description: z.string().min(1, "Description is required").max(2000, "Max 2000 characters"),
@@ -22,13 +21,10 @@ export const step2Schema = z.object({
 })
 export type Step2Values = z.infer<typeof step2Schema>
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export type FormStep = 1 | 2 | 3
 export type TxPhase = "idle" | "funding" | "funded" | "creating" | "done"
 
-// ─── Helper components ────────────────────────────────────────────────────────
-
+// Helper components
 export function FieldError({ message }: { message?: string }) {
   if (!message) return null
   return (
@@ -39,13 +35,7 @@ export function FieldError({ message }: { message?: string }) {
   )
 }
 
-export function FormLabel({
-  children,
-  required,
-}: {
-  children: React.ReactNode
-  required?: boolean
-}) {
+export function FormLabel({ children, required }: { children: React.ReactNode; required?: boolean }) {
   return (
     <label className="mb-1.5 block text-sm font-semibold">
       {children}


### PR DESCRIPTION


## What does this PR do?

- Move Zod schemas (step1Schema, step2Schema, milestoneSchema) to types.ts
- Add FormStep, TxPhase types
- Extract FieldError, FormLabel, StepIndicator as reusable UI components

## Related Issue

Closes # https://github.com/lernza/lernza/issues/998

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
