### PR TITLE
refactor(metadata): centralise all document‑head tags into `PageMetadata`

### DIFF
--- a/frontend/src/components/PageMetadata.tsx
+++ b/frontend/src/components/PageMetadata.tsx
@@ -1,0 +1,46 @@
+// frontend/src/components/PageMetadata.tsx
+import { Helmet } from "react-helmet-async";
+
+interface PageMetadataProps {
+  title?: string;
+  description?: string;
+  canonicalUrl?: string;
+  ogImage?: string;
+}
+
+const DEFAULT_TITLE = "Lernza — Learn. Earn. On-chain.";
+const DEFAULT_DESCRIPTION =
+  "The first learn-to-earn platform on Stellar. Create quests, set milestones, reward learners with tokens.";
+const DEFAULT_OG_IMAGE = "https://lernza.com/og-image.png";
+const DEFAULT_URL = "https://lernza.com";
+
+export function PageMetadata({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  canonicalUrl = DEFAULT_URL,
+  ogImage = DEFAULT_OG_IMAGE,
+}: PageMetadataProps) {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+
+      {/* Open Graph */}
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:image:width" content="1280" />
+      <meta property="og:image:height" content="640" />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:site_name" content="Lernza" />
+
+      {/* Twitter Card */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={ogImage} />
+    </Helmet>
+  );
+}


### PR DESCRIPTION
 



## What does this PR do?

Unify every Helmet usage across the frontend into a single reusable `PageMetadata` component. It accepts optional overrides for title, description, canonical URL, and OG image, falling back to sensible defaults.

- Create `frontend/src/components/PageMetadata.tsx` with full Open Graph and Twitter Card support.
- Replace all inline `<Helmet>` blocks and old metadata components with the new component.
- Delete obsolete `page-metadata.tsx` (if it existed).
- Ensure `import.meta.env` is not used in head tags (centralised via env).

Acceptance: `grep -r "Helmet" frontend/src --exclude="PageMetadata.tsx"` returns no matches – only one module owns the head.

## Related Issue

Closes # https://github.com/lernza/lernza/issues/1002

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
