### PR TITLE
test(frontend): add FormLabel accessibility regression tests

### DIFF
--- a/frontend/src/pages/create-quest/types.test.tsx
+++ b/frontend/src/pages/create-quest/types.test.tsx
@@ -1,0 +1,45 @@
+import React from "react"  
+import { describe, it, expect } from "vitest"  
+import { render } from "@testing-library/react"  
+import { axe } from "vitest-axe"  
+import { FormLabel } from "./types"  // CHANGED from "@/components/ui/form-field"  
+  
+describe("Form Accessibility Regression Tests", () => {  
+  it("detects missing label-input association", async () => {  
+    const { container } = render(  
+      <form>  
+        <FormLabel>Name</FormLabel>  
+        <input type="text" />  
+      </form>  
+    )  
+  
+    const results = await axe(container)  
+  
+    // Should have violations related to labels  
+    const labelViolations = results.violations.filter(v => v.id === "label")  
+    expect(labelViolations.length).toBeGreaterThan(0)  
+  })  
+  
+  it("passes when label and input are correctly associated", async () => {  
+    const { container } = render(  
+      <form>  
+        <FormLabel htmlFor="name-input">Name</FormLabel>  
+        <input id="name-input" type="text" />  
+      </form>  
+    )  
+  
+    const results = await axe(container)  
+    expect(results).toHaveNoViolations()  
+  })  
+  
+  it("detects missing aria-label or label for buttons with only icons", async () => {  
+    const { container } = render(  
+      <button type="button">  
+        <svg aria-hidden="true" />  
+      </button>  
+    )  
+  
+    const results = await axe(container)  
+    expect(results.violations.some(v => v.id === "button-name")).toBe(true)  
+  })  
+})


### PR DESCRIPTION

## What does this PR do?

Add vitest-axe tests for FormLabel component in types.test.tsx.   Tests label-input association and button accessibility compliance.


## Related Issue

Closes # https://github.com/lernza/lernza/issues/1005

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
