### PR TITLE
fix: add pause checks and validation improvements

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -762,6 +762,9 @@ impl MilestoneContract {
             return Err(Error::NotEnrolled);
         }
 
+        // Verify prerequisite milestone is completed if required
+        Self::ensure_previous_completed(&env, quest_id, milestone_id, &enrollee, &milestone)?;
+
         // Snapshot the distribution-mode parameters at submission time so
         // the approval flow is paid under the rules the enrollee signed up
         // for. See issue #863.
@@ -1074,9 +1077,9 @@ impl MilestoneContract {
         enrollee: Address,
         offset: u32,
         limit: u32,
-    ) -> EnrolleeProgress {
+    ) -> Result<EnrolleeProgress, Error> {
         if limit == 0 || limit > 100 {
-            panic!("unbounded range");
+            return Err(Error::InvalidInput);
         }
 
         let completions: u32 = env
@@ -1118,14 +1121,14 @@ impl MilestoneContract {
             }
         }
 
-        EnrolleeProgress {
+        Ok(EnrolleeProgress {
             quest_id,
             enrollee,
             completions,
             total_milestones,
             total_earned,
             completion_details,
-        }
+        })
     }
 
     /// Paginated quest completion rate (issue #865).

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -143,6 +143,10 @@ impl RewardsContract {
     pub fn fund_quest(env: Env, funder: Address, quest_id: u32, amount: i128) -> Result<(), Error> {
         funder.require_auth();
 
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::Paused);
+        }
+
         if amount <= 0 || amount > MAX_REWARD_AMOUNT {
             return Err(Error::InvalidAmount);
         }
@@ -264,6 +268,10 @@ impl RewardsContract {
         amount: i128,
     ) -> Result<(), Error> {
         authority.require_auth();
+
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::Paused);
+        }
 
         if amount <= 0 || amount > MAX_REWARD_AMOUNT {
             return Err(Error::InvalidAmount);
@@ -389,6 +397,10 @@ impl RewardsContract {
         amount: i128,
     ) -> Result<(), Error> {
         authority.require_auth();
+
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::Paused);
+        }
 
         if amount <= 0 || amount > MAX_REWARD_AMOUNT {
             return Err(Error::InvalidAmount);
@@ -706,6 +718,10 @@ impl RewardsContract {
     ///   - There is actually something to refund
     pub fn refund_unused_pool(env: Env, authority: Address, quest_id: u32) -> Result<i128, Error> {
         authority.require_auth();
+
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::Paused);
+        }
 
         // Verify authority
         let auth_key = DataKey::QuestAuthority(quest_id);

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -5,11 +5,19 @@ export interface Quest {
   owner: string
   name: string
   description: string
+  category: string
+  tags: string[]
   tokenAddr: string
-  enrolleeCount: number
-  milestoneCount: number
-  poolBalance: number
   createdAt: number
+  visibility: 'Public' | 'Private'
+  status: 'Active' | 'Archived'
+  deadline: number
+  archivedAt: number
+  maxEnrollees: number | null
+  verified: boolean
+  enrolleeCount?: number
+  milestoneCount?: number
+  poolBalance?: number
 }
 
 export interface Milestone {
@@ -40,11 +48,19 @@ export const MOCK_QUESTS: Quest[] = [
     name: "Learn to Code with Alex",
     description:
       "Teaching my brother the fundamentals of programming. From basic syntax to deploying a real application.",
+    category: "Programming",
+    tags: ["javascript", "web-dev", "beginner"],
     tokenAddr: "USDC...STELLAR",
+    createdAt: 1710000000,
+    visibility: "Public",
+    status: "Active",
+    deadline: 0,
+    archivedAt: 0,
+    maxEnrollees: null,
+    verified: true,
     enrolleeCount: 3,
     milestoneCount: 5,
     poolBalance: 2500,
-    createdAt: 1710000000,
   },
   {
     id: 1,
@@ -52,22 +68,38 @@ export const MOCK_QUESTS: Quest[] = [
     name: "Stellar Development Bootcamp",
     description:
       "A structured path to becoming a Stellar developer. Smart contracts, Soroban, DeFi.",
+    category: "Blockchain",
+    tags: ["stellar", "soroban", "smart-contracts", "rust"],
     tokenAddr: "USDC...STELLAR",
+    createdAt: 1709500000,
+    visibility: "Public",
+    status: "Active",
+    deadline: 0,
+    archivedAt: 0,
+    maxEnrollees: null,
+    verified: true,
     enrolleeCount: 8,
     milestoneCount: 10,
     poolBalance: 10000,
-    createdAt: 1709500000,
   },
   {
     id: 2,
     owner: "GCMN...P8TL",
     name: "Design Fundamentals",
     description: "Learn UI/UX design principles. From Figma basics to shipping a design system.",
+    category: "Design",
+    tags: ["ui/ux", "figma", "design-systems"],
     tokenAddr: "USDC...STELLAR",
+    createdAt: 1709800000,
+    visibility: "Public",
+    status: "Active",
+    deadline: 0,
+    archivedAt: 0,
+    maxEnrollees: null,
+    verified: true,
     enrolleeCount: 5,
     milestoneCount: 4,
     poolBalance: 1200,
-    createdAt: 1709800000,
   },
 ]
 


### PR DESCRIPTION
## What

This PR fixes four issues affecting contract pause enforcement, validation, and frontend type definitions.

## Issues Resolved

Closes #1160
Closes #1161
Closes #1162
Closes #1163

## Changes

### #1160 - rewards pause() is a no-op

Added pause flag checks to fund_quest, distribute_reward, refund_pool, and refund_unused_pool functions so the pause flag actually blocks these operations. Matches the pattern in milestone and quest contracts.

### #1161 - submit_for_review allows locked milestones

Added ensure_previous_completed check to submit_for_review before accepting a submission, matching the check in verify_completion and approve_completion flows.

### #1162 - get_enrollee_progress panics instead of returning Result

Changed get_enrollee_progress signature from returning EnrolleeProgress to Result<EnrolleeProgress, Error> and returns InvalidInput error instead of panicking on invalid limit, consistent with get_quest_completion_rate.

### #1163 - mock-data.ts Quest interface missing on-chain QuestInfo fields

Updated the Quest interface to include all fields from the on-chain QuestInfo struct: status, visibility, category, tags, deadline, max_enrollees, archived_at, and verified. Made derived fields (enrolleeCount, milestoneCount, poolBalance) optional. Updated MOCK_QUESTS data accordingly.