### PR TITLE
fix(contracts): add pause checks to transfer_admin and mint_certificate, remove duplicate list_milestones

### DIFF
--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -27,6 +27,7 @@ pub enum DataKey {
     UserCertificates(Address),
     MetadataBase,
     RevokedCertificate(u32),
+    Paused,
 }
 
 // -- add IsDataKey implementation --
@@ -75,6 +76,7 @@ impl CertificateContract {
         recipient: Address,
         issuer: Address,
     ) -> Result<u32, Error> {
+        Self::require_not_paused(&env)?;
         let cert_key = DataKey::QuestCertificate(quest_id, recipient.clone());
         if env.storage().persistent().has(&cert_key) {
             return Err(Error::AlreadyIssued);
@@ -264,9 +266,7 @@ impl CertificateContract {
 
     #[only_owner]
     pub fn pause(env: Env) -> Result<(), Error> {
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, "paused"), &true);
+        env.storage().instance().set(&DataKey::Paused, &true);
         extend_instance_ttl(&env);
         env.events().publish((Symbol::new(&env, "paused"),), ());
         Ok(())
@@ -274,9 +274,7 @@ impl CertificateContract {
 
     #[only_owner]
     pub fn unpause(env: Env) -> Result<(), Error> {
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, "paused"), &false);
+        env.storage().instance().set(&DataKey::Paused, &false);
         extend_instance_ttl(&env);
         env.events().publish((Symbol::new(&env, "unpaused"),), ());
         Ok(())
@@ -286,7 +284,7 @@ impl CertificateContract {
         if env
             .storage()
             .instance()
-            .get(&Symbol::new(env, "paused"))
+            .get(&DataKey::Paused)
             .unwrap_or(false)
         {
             return Err(Error::Paused);

--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -1042,11 +1042,6 @@ impl MilestoneContract {
         result
     }
 
-    /// List all milestones for a quest.
-    pub fn list_milestones(env: Env, quest_id: u32) -> Vec<MilestoneInfo> {
-        Self::get_milestones(env, quest_id)
-    }
-
     /// Get milestone count for a quest.
     pub fn get_milestone_count(env: Env, quest_id: u32) -> u32 {
         env.storage()

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -170,11 +170,11 @@ fn test_get_milestones() {
 }
 
 #[test]
-fn test_list_milestones_empty() {
+fn test_get_milestones_empty() {
     let (env, client, quest_client, owner) = setup();
     let q_id = create_quest(&env, &quest_client, &owner);
 
-    let milestones = client.list_milestones(&q_id);
+    let milestones = client.get_milestones(&q_id);
     assert_eq!(milestones.len(), 0);
     assert_eq!(client.get_milestone_count(&q_id), 0);
 
@@ -182,13 +182,13 @@ fn test_list_milestones_empty() {
 }
 
 #[test]
-fn test_list_milestones_with_milestones() {
+fn test_get_milestones_with_milestones() {
     let (env, client, quest_client, owner) = setup();
     let q_id = create_quest(&env, &quest_client, &owner);
     create_ms(&env, &client, &owner, q_id, "A", 10);
     create_ms(&env, &client, &owner, q_id, "B", 20);
 
-    let milestones = client.list_milestones(&q_id);
+    let milestones = client.get_milestones(&q_id);
     assert_eq!(milestones.len(), 2);
     assert_eq!(
         milestones.get(0).unwrap().title,

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -227,6 +227,7 @@ impl QuestContract {
         new_admin: Address,
     ) -> Result<(), Error> {
         Self::require_admin(&env, &current_admin)?;
+        Self::require_not_paused(&env)?;
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         extend_instance_ttl(&env);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,7 +46,7 @@ Returned by `get_quest`, `list_public_quests`, `list_quests_by_owner`, `list_que
 
 ### `MilestoneInfo`
 
-Returned by `get_milestone`, `get_milestones`, `list_milestones`.
+Returned by `get_milestone`, `get_milestones`.
 
 | Field | Type | Description |
 |:------|:-----|:------------|
@@ -620,13 +620,12 @@ get_milestone(env: Env, quest_id: u32, milestone_id: u32) -> Result<MilestoneInf
 
 ---
 
-### `get_milestones` / `list_milestones`
+### `get_milestones`
 
-All milestones for a quest (both functions are equivalent).
+All milestones for a quest.
 
 ```rust
 get_milestones(env: Env, quest_id: u32) -> Vec<MilestoneInfo>
-list_milestones(env: Env, quest_id: u32) -> Vec<MilestoneInfo>
 ```
 
 ---

--- a/frontend/src/lib/contracts/milestone-client.ts
+++ b/frontend/src/lib/contracts/milestone-client.ts
@@ -95,7 +95,7 @@ export class MilestoneClient {
   }
 
   async listMilestones(questId: number): Promise<MilestoneInfo[]> {
-    const result = await this.invokeRead("list_milestones", [
+    const result = await this.invokeRead("get_milestones", [
       nativeToScVal(questId, { type: "u32" }),
     ])
     if (!Array.isArray(result)) return []


### PR DESCRIPTION
## Summary
- Added require_not_paused check to transfer_admin in the quest contract (#1167)
- Added require_not_paused check to mint_certificate in the certificate contract (#1166)
- Replaced raw Symbol pause key with DataKey::Paused enum variant for type safety (#1165)
- Removed duplicate list_milestones function from milestone contract, frontend, tests, and docs (#1168)
## Changes
contracts/certificate/src/lib.rs
- Added Paused variant to DataKey enum
- Replaced Symbol::new(&env, "paused") with DataKey::Paused in pause(), unpause(), and require_not_paused()
- Added Self::require_not_paused(&env)?; at start of mint_certificate
contracts/quest/src/lib.rs
- Added Self::require_not_paused(&env)?; after require_admin in transfer_admin
contracts/milestone/src/lib.rs
- Removed list_milestones function (was just Self::get_milestones(env, quest_id))
contracts/milestone/src/test.rs
- Renamed tests from test_list_milestones_* to test_get_milestones_*
- Updated calls to use get_milestones
frontend/src/lib/contracts/milestone-client.ts
- Changed invokeRead("list_milestones", ...) to invokeRead("get_milestones", ...)
docs/api-reference.md
- Removed list_milestones from function listings and MilestoneInfo description

## Issues Resolved 
closes #1165 
closes #1166 
closes #1167 
closes #1168 