### PR TITLE
fix(contracts): restore corrupted quest crate and emit detailed quest_updated event

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -360,17 +360,17 @@ impl QuestContract {
         }
 
         // Input validation & update
-        if let Some(n) = name {
+        if let Some(n) = name.clone() {
             validate_name(&n)?;
             quest.name = n;
         }
 
-        if let Some(d) = description {
+        if let Some(d) = description.clone() {
             validate_description(&d)?;
             quest.description = d;
         }
 
-        if let Some(c) = category {
+        if let Some(c) = category.clone() {
             if is_blank_ascii(&c) {
                 return Err(Error::InvalidInput);
             }
@@ -391,7 +391,7 @@ impl QuestContract {
             }
         }
 
-        if let Some(t) = tags {
+        if let Some(t) = tags.clone() {
             Self::validate_tags(&t)?;
             quest.tags = t;
         }
@@ -408,11 +408,13 @@ impl QuestContract {
             .persistent()
             .set(&DataKey::Quest(quest_id), &quest);
 
-        // Emit quest updated event
+        // Emit quest updated event with the fields that were actually changed
         // Event topics: (quest_updated,)
-        // Event data: (quest_id)
-        env.events()
-            .publish((Symbol::new(&env, "quest_updated"),), quest_id);
+        // Event data: (quest_id, name, description, category, tags, max_enrollees)
+        env.events().publish(
+            (Symbol::new(&env, "quest_updated"),),
+            (quest_id, name, description, category, tags, max_enrollees),
+        );
 
         Self::bump(&env, quest_id);
         Ok(())
@@ -490,53 +492,54 @@ impl QuestContract {
     }
 
     /// Allow a learner to enroll themselves in a public quest.
-    E
-        /// Allow a learner to enroll themselves in a public quest.
-pub fn join_quest(env: Env, enrollee: Address, quest_id: u32) -> Result<(), Error> {
-    enrollee.require_auth();
-    Self::require_not_paused(&env)?;
+    pub fn join_quest(env: Env, enrollee: Address, quest_id: u32) -> Result<(), Error> {
+        enrollee.require_auth();
+        Self::require_not_paused(&env)?;
 
-    let quest = Self::load_quest(&env, quest_id)?;
-    if quest.status == QuestStatus::Archived {
-        return Err(Error::EnrollmentClosed);
-    }
-    if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
-        return Err(Error::DeadlineExpired);
-    }
-    if quest.visibility == Visibility::Private {
-        return Err(Error::InviteOnly);
-    }
-
-    let enrollees = Self::load_enrollees(&env, quest_id);
-
-    if let Some(max) = quest.max_enrollees {
-        if enrollees.len() >= max {
-            return Err(Error::QuestFull);
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.status == QuestStatus::Archived {
+            return Err(Error::EnrollmentClosed);
         }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
+        }
+        if quest.visibility == Visibility::Private {
+            return Err(Error::InviteOnly);
+        }
+
+        let enrollees = Self::load_enrollees(&env, quest_id);
+
+        if let Some(max) = quest.max_enrollees {
+            if enrollees.len() >= max {
+                return Err(Error::QuestFull);
+            }
+        }
+
+        if enrollees.contains(&enrollee) {
+            return Err(Error::AlreadyEnrolled);
+        }
+
+        let mut new_enrollees = enrollees;
+        new_enrollees.push_back(enrollee.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Enrollees(quest_id), &new_enrollees);
+        Self::add_id_to_index(&env, DataKey::EnrolleeQuests(enrollee.clone()), quest_id);
+
+        // Emit enrollment event with distinct join_mode for self-enrollment
+        // Event topics: (enrollee_added,)
+        // Event data: (quest_id, enrollee, actor, timestamp, join_mode)
+        let timestamp = env.ledger().timestamp();
+        let join_mode = Symbol::new(&env, "self");
+        env.events().publish(
+            (Symbol::new(&env, "enrollee_added"),),
+            (quest_id, enrollee.clone(), quest.owner.clone(), timestamp, join_mode),
+        );
+
+        Self::bump(&env, quest_id);
+        Ok(())
     }
 
-    if enrollees.contains(&enrollee) {
-        return Err(Error::AlreadyEnrolled);
-    }
-
-    let mut new_enrollees = enrollees;
-    new_enrollees.push_back(enrollee.clone());
-    env.storage()
-        .persistent()
-        .set(&DataKey::Enrollees(quest_id), &new_enrollees);
-    Self::add_id_to_index(&env, DataKey::EnrolleeQuests(enrollee.clone()), quest_id);
-
-    // Emit enrollment event with distinct join_mode for self-enrollment
-    let timestamp = env.ledger().timestamp();
-    let join_mode = Symbol::new(&env, "self");  // <-- CHANGED HERE
-    env.events().publish(
-        (Symbol::new(&env, "enrollee_added"),),
-        (quest_id, enrollee.clone(), quest.owner.clone(), timestamp, join_mode),
-    );
-
-    Self::bump(&env, quest_id);
-    Ok(())
-}
     /// Register an invite commitment for a private quest. Owner only.
     ///
     /// The owner generates a random secret off-chain, computes
@@ -608,6 +611,535 @@ pub fn join_quest(env: Env, enrollee: Address, quest_id: u32) -> Result<(), Erro
     }
 
     /// Allow a learner to self-enroll in a private quest using an invite code.
-    // (The rest of the contract including invite redemption and other helpers
-    //  would follow here, but they are not shown in the provided snippet.)
+    ///
+    /// The enrollee submits the raw `preimage` bytes. The contract hashes them
+    /// with SHA-256 and checks that the resulting commitment was registered by
+    /// the owner and has not been consumed yet. On success the commitment is
+    /// marked as used (preventing replay) and the enrollee is added.
+    ///
+    /// This method also works for public quests — the invite path is simply an
+    /// alternative to `join_quest` when the owner wants single-use codes.
+    pub fn join_quest_with_invite(
+        env: Env,
+        enrollee: Address,
+        quest_id: u32,
+        preimage: Bytes,
+    ) -> Result<(), Error> {
+        enrollee.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.status == QuestStatus::Archived {
+            return Err(Error::EnrollmentClosed);
+        }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
+        }
+
+        // Derive commitment from the submitted preimage.
+        let commitment: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+        let commitment_key = DataKey::InviteCommitment(quest_id, commitment.clone());
+        let used_key = DataKey::InviteUsed(quest_id, commitment.clone());
+
+        // Commitment must be registered.
+        if !env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&commitment_key)
+            .unwrap_or(false)
+        {
+            return Err(Error::InvalidInvite);
+        }
+
+        // Commitment must not have been consumed already.
+        if env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&used_key)
+            .unwrap_or(false)
+        {
+            return Err(Error::InviteAlreadyUsed);
+        }
+
+        let enrollees = Self::load_enrollees(&env, quest_id);
+
+        if let Some(max) = quest.max_enrollees {
+            if enrollees.len() >= max {
+                return Err(Error::QuestFull);
+            }
+        }
+
+        if enrollees.contains(&enrollee) {
+            return Err(Error::AlreadyEnrolled);
+        }
+
+        // Mark invite as consumed before mutating enrollment state.
+        env.storage().persistent().set(&used_key, &true);
+        common::extend_persistent_ttl(&env, &used_key);
+
+        let mut new_enrollees = enrollees;
+        new_enrollees.push_back(enrollee.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Enrollees(quest_id), &new_enrollees);
+        Self::add_id_to_index(&env, DataKey::EnrolleeQuests(enrollee.clone()), quest_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "enrollee_added"),),
+            (quest_id, enrollee.clone()),
+        );
+
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Remove an enrollee from a quest. Owner only.
+    pub fn remove_enrollee(env: Env, quest_id: u32, enrollee: Address) -> Result<(), Error> {
+        Self::require_not_paused(&env)?;
+        let quest = Self::load_quest(&env, quest_id)?;
+        quest.owner.require_auth();
+
+        Self::internal_remove_enrollee(&env, quest_id, enrollee.clone())?;
+
+        // Emit enrollee removed event
+        // Event topics: (enrollee_removed,)
+        // Event data: (quest_id, enrollee_address)
+        env.events().publish(
+            (Symbol::new(&env, "enrollee_removed"),),
+            (quest_id, &enrollee),
+        );
+
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Allow an enrollee to unenroll themselves from a quest. Enrollee only.
+    ///
+    /// Rejects with `LeaveBlockedByPendingApproval` if the quest owner has
+    /// placed a peer-review hold on the enrollee (see `place_leave_hold`).
+    /// The hold exists so completion submissions awaiting peer approval
+    /// cannot reference a non-enrollee.
+    pub fn leave_quest(env: Env, enrollee: Address, quest_id: u32) -> Result<(), Error> {
+        enrollee.require_auth();
+        Self::require_not_paused(&env)?;
+        Self::load_quest(&env, quest_id)?;
+
+        let hold_key = DataKey::LeaveHold(quest_id, enrollee.clone());
+        if env.storage().persistent().has(&hold_key) {
+            return Err(Error::LeaveBlockedByPendingApproval);
+        }
+
+        Self::internal_remove_enrollee(&env, quest_id, enrollee)
+    }
+
+    /// Place a peer-review hold on an enrollee. Owner only.
+    /// While the hold is in place, `leave_quest` is rejected for that
+    /// enrollee. The owner is expected to call this whenever the enrollee
+    /// has a peer-review submission in flight or a recently verified
+    /// completion awaiting reward settlement.
+    pub fn place_leave_hold(
+        env: Env,
+        quest_id: u32,
+        owner: Address,
+        enrollee: Address,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        Self::require_not_paused(&env)?;
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        if !Self::load_enrollees(&env, quest_id).contains(&enrollee) {
+            return Err(Error::NotEnrolled);
+        }
+
+        let hold_key = DataKey::LeaveHold(quest_id, enrollee);
+        env.storage().persistent().set(&hold_key, &true);
+        common::extend_persistent_ttl(&env, &hold_key);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Lift a peer-review hold so the enrollee can `leave_quest` again.
+    /// Owner only. No-op if no hold was set.
+    pub fn lift_leave_hold(
+        env: Env,
+        quest_id: u32,
+        owner: Address,
+        enrollee: Address,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        Self::require_not_paused(&env)?;
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+
+        let hold_key = DataKey::LeaveHold(quest_id, enrollee);
+        env.storage().persistent().remove(&hold_key);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Read whether a peer-review hold is currently in place.
+    pub fn has_leave_hold(env: Env, quest_id: u32, enrollee: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::LeaveHold(quest_id, enrollee))
+    }
+
+    /// Get quest info by ID.
+    ///
+    /// Visibility does not gate direct reads. Even quests marked `Private`
+    /// remain queryable by id; the flag only affects discovery helpers such as
+    /// `list_public_quests` and `get_quests_by_category`.
+    pub fn get_quest(env: Env, quest_id: u32) -> Result<QuestInfo, Error> {
+        let quest = Self::load_quest(&env, quest_id)?;
+        Self::bump(&env, quest_id);
+        Ok(quest)
+    }
+
+    /// Get all enrollees for a quest.
+    ///
+    /// Like `get_quest`, this is readable for any existing quest id regardless
+    /// of visibility. `Private` means unlisted, not confidential.
+    pub fn get_enrollees(env: Env, quest_id: u32) -> Result<Vec<Address>, Error> {
+        Self::load_quest(&env, quest_id)?; // verify exists
+        let enrollees = Self::load_enrollees(&env, quest_id);
+        Self::bump(&env, quest_id);
+        Ok(enrollees)
+    }
+
+    /// Check if a user is enrolled in a quest.
+    ///
+    /// Visibility does not restrict this check; callers that know the quest id
+    /// can query enrollment state directly.
+    pub fn is_enrollee(env: Env, quest_id: u32, user: Address) -> Result<bool, Error> {
+        Self::load_quest(&env, quest_id)?;
+        let enrollees = Self::load_enrollees(&env, quest_id);
+        Ok(enrollees.contains(&user))
+    }
+
+    /// Update or clear the deadline for a quest. Owner only.
+    /// Pass 0 to remove the deadline.
+    pub fn set_deadline(env: Env, quest_id: u32, deadline: u64) -> Result<(), Error> {
+        Self::require_not_paused(&env)?;
+        let mut quest = Self::load_quest(&env, quest_id)?;
+        quest.owner.require_auth();
+        quest.deadline = deadline;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Quest(quest_id), &quest);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Returns true if the quest has a non-zero deadline that has passed.
+    pub fn is_expired(env: Env, quest_id: u32) -> Result<bool, Error> {
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.deadline == 0 {
+            return Ok(false);
+        }
+        Ok(env.ledger().timestamp() > quest.deadline)
+    }
+
+    /// Get total quest count.
+    pub fn get_quest_count(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::NextId).unwrap_or(0)
+    }
+
+    /// Set visibility of a quest. Owner only.
+    ///
+    /// This only controls whether the quest appears in public discovery lists.
+    /// It does not provide on-chain confidentiality.
+    pub fn set_visibility(env: Env, quest_id: u32, visibility: Visibility) -> Result<(), Error> {
+        Self::require_not_paused(&env)?;
+        let mut quest = Self::load_quest(&env, quest_id)?;
+        quest.owner.require_auth();
+
+        Self::internal_set_visibility(&env, quest_id, &mut quest, visibility);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Quest(quest_id), &quest);
+        Self::bump(&env, quest_id);
+        Ok(())
+    }
+
+    /// Get all public quests (paginated).
+    pub fn list_public_quests(env: Env, start: u32, limit: u32) -> Vec<QuestInfo> {
+        let public_ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PublicQuests)
+            .unwrap_or(Vec::new(&env));
+        let mut public_quests = Vec::new(&env);
+        let total = public_ids.len();
+
+        if start < total {
+            let end = core::cmp::min(start + limit, total);
+            for i in start..end {
+                if let Some(id) = public_ids.get(i) {
+                    if let Ok(quest) = Self::load_quest(&env, id) {
+                        public_quests.push_back(quest);
+                    }
+                }
+            }
+        }
+
+        if env.storage().persistent().has(&DataKey::PublicQuests) {
+            common::extend_persistent_ttl(&env, &DataKey::PublicQuests);
+        }
+        public_quests
+    }
+
+    /// Get all public quests within a category.
+    pub fn get_quests_by_category(env: Env, category: String) -> Vec<QuestInfo> {
+        let category_ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PublicCategoryQuests(category.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut matches = Vec::new(&env);
+
+        for i in 0..category_ids.len() {
+            if let Some(id) = category_ids.get(i) {
+                if let Ok(quest) = Self::load_quest(&env, id) {
+                    matches.push_back(quest);
+                }
+            }
+        }
+
+        let category_key = DataKey::PublicCategoryQuests(category);
+        if env.storage().persistent().has(&category_key) {
+            common::extend_persistent_ttl(&env, &category_key);
+        }
+        matches
+    }
+
+    /// Get all quests owned by an address.
+    pub fn list_quests_by_owner(env: Env, owner: Address) -> Vec<QuestInfo> {
+        let owner_key = DataKey::OwnerQuests(owner);
+        let owner_ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&owner_key)
+            .unwrap_or(Vec::new(&env));
+        let mut matches = Vec::new(&env);
+
+        for i in 0..owner_ids.len() {
+            if let Some(id) = owner_ids.get(i) {
+                if let Ok(quest) = Self::load_quest(&env, id) {
+                    matches.push_back(quest);
+                }
+            }
+        }
+
+        if env.storage().persistent().has(&owner_key) {
+            common::extend_persistent_ttl(&env, &owner_key);
+        }
+        env.storage().instance().extend_ttl(THRESHOLD, BUMP);
+        matches
+    }
+
+    /// Get all quests an address is enrolled in.
+    pub fn list_quests_by_enrollee(env: Env, enrollee: Address) -> Vec<QuestInfo> {
+        let enrollee_key = DataKey::EnrolleeQuests(enrollee);
+        let enrollee_ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&enrollee_key)
+            .unwrap_or(Vec::new(&env));
+        let mut matches = Vec::new(&env);
+
+        for i in 0..enrollee_ids.len() {
+            if let Some(id) = enrollee_ids.get(i) {
+                if let Ok(quest) = Self::load_quest(&env, id) {
+                    matches.push_back(quest);
+                }
+            }
+        }
+
+        if env.storage().persistent().has(&enrollee_key) {
+            common::extend_persistent_ttl(&env, &enrollee_key);
+        }
+        env.storage().instance().extend_ttl(THRESHOLD, BUMP);
+        matches
+    }
+
+    /// Get enrollment cap for a quest.
+    pub fn get_enrollment_cap(env: Env, quest_id: u32) -> Option<u32> {
+        let quest = Self::load_quest(&env, quest_id).ok()?;
+        quest.max_enrollees
+    }
+
+    // --- internals ---
+
+    fn load_quest(env: &Env, id: u32) -> Result<QuestInfo, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Quest(id))
+            .ok_or(Error::NotFound)
+    }
+
+    fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        if *admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(())
+    }
+
+    fn require_not_paused(env: &Env) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            Err(Error::Paused)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn load_enrollees(env: &Env, id: u32) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Enrollees(id))
+            .unwrap_or(Vec::new(env))
+    }
+
+    fn internal_set_visibility(
+        env: &Env,
+        quest_id: u32,
+        quest: &mut QuestInfo,
+        visibility: Visibility,
+    ) {
+        if quest.visibility != visibility {
+            if quest.visibility == Visibility::Public {
+                Self::remove_id_from_index(
+                    env,
+                    DataKey::PublicCategoryQuests(quest.category.clone()),
+                    quest_id,
+                );
+            }
+
+            let mut public_ids: Vec<u32> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PublicQuests)
+                .unwrap_or(Vec::new(env));
+
+            if visibility == Visibility::Public {
+                public_ids.push_back(quest_id);
+            } else if let Some(index) = public_ids.first_index_of(quest_id) {
+                public_ids.remove(index);
+            }
+            env.storage()
+                .persistent()
+                .set(&DataKey::PublicQuests, &public_ids);
+
+            if visibility == Visibility::Public {
+                Self::add_id_to_index(
+                    env,
+                    DataKey::PublicCategoryQuests(quest.category.clone()),
+                    quest_id,
+                );
+            }
+        }
+        quest.visibility = visibility;
+    }
+
+    fn internal_remove_enrollee(env: &Env, quest_id: u32, enrollee: Address) -> Result<(), Error> {
+        let enrollees = Self::load_enrollees(env, quest_id);
+        let mut found = false;
+        let mut new_list = Vec::new(env);
+
+        for i in 0..enrollees.len() {
+            let addr = enrollees.get(i).unwrap();
+            if addr == enrollee {
+                found = true;
+            } else {
+                new_list.push_back(addr);
+            }
+        }
+
+        if !found {
+            return Err(Error::NotEnrolled);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Enrollees(quest_id), &new_list);
+        if found {
+            Self::remove_id_from_index(env, DataKey::EnrolleeQuests(enrollee), quest_id);
+        }
+        Ok(())
+    }
+
+    fn add_id_to_index(env: &Env, key: DataKey, id: u32) {
+        let mut ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env));
+        if !ids.contains(id) {
+            ids.push_back(id);
+            env.storage().persistent().set(&key, &ids);
+        }
+        common::extend_persistent_ttl(env, &key);
+    }
+
+    fn remove_id_from_index(env: &Env, key: DataKey, id: u32) {
+        let ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env));
+        let mut updated = Vec::new(env);
+
+        for i in 0..ids.len() {
+            if let Some(existing_id) = ids.get(i) {
+                if existing_id != id {
+                    updated.push_back(existing_id);
+                }
+            }
+        }
+
+        env.storage().persistent().set(&key, &updated);
+        common::extend_persistent_ttl(env, &key);
+    }
+
+    fn validate_tags(tags: &Vec<String>) -> Result<(), Error> {
+        if tags.len() > MAX_TAGS {
+            return Err(Error::InvalidInput);
+        }
+
+        for i in 0..tags.len() {
+            let tag = tags.get(i).ok_or(Error::InvalidInput)?;
+            if tag.is_empty() || tag.len() > MAX_TAG_LEN {
+                return Err(Error::InvalidInput);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn bump(env: &Env, quest_id: u32) {
+        extend_instance_ttl(env);
+        common::extend_persistent_ttl(env, &DataKey::Quest(quest_id));
+        common::extend_persistent_ttl(env, &DataKey::Enrollees(quest_id));
+    }
 }
+
+#[cfg(test)]
+mod test;


### PR DESCRIPTION
## Summary

Fixes **#1173** — `update_quest` only published `(quest_id)` on its `quest_updated` event, so indexers/frontends couldn't tell which fields actually changed. It now publishes `(quest_id, name, description, category, tags, max_enrollees)`, matching the detail level `create_quest` already provides.

## The bigger issue this PR fixes first

While implementing #1173 (split out of #1181, which covered my other 3 assigned issues), I found `contracts/quest/src/lib.rs` on `main` doesn't compile at all: `update_quest` calls `Self::internal_set_visibility(...)`, which doesn't exist anywhere in the file.

Tracing it back: commit `a7a3ecc` ("Fix: emit distinct join_mode for self-enrollment in join_quest") accidentally **deleted 571 lines** from that file — 18 public functions gone (`get_quest`, `set_visibility`, `leave_quest`, `remove_enrollee`, `list_public_quests`, `get_quests_by_category`, `join_quest_with_invite`, the leave-hold functions, etc.) plus every private helper (`add_id_to_index`, `internal_set_visibility`, `load_quest`, `bump`, ...), replaced with a comment admitting *"the rest of the contract... would follow here, but they are not shown in the provided snippet."* This has been live on `main` and is why `ci.yml` has been failing.

I restored the file from commit `56d3f61` (the last known-good version — 1142 lines, all 34 public functions) and reapplied every legitimate fix that landed on `main` after that commit but before the corruption/since, so nothing is regressed:

- `join_quest` now emits `join_mode="self"` instead of `"owner"` so indexers can distinguish self-enrollment from owner-added enrollment (the actual intended fix of `a7a3ecc`, for issue #1104).
- `transfer_admin` now checks `require_not_paused` before transferring admin control (from commit `53cdc67`, issue #1167), which the restored base predates.

The #1173 event-detail fix is implemented on top of this restored, working file.

## Verification

This environment's pinned toolchain (1.80.0) can't resolve dependencies at all (an `edition2024`-requiring transitive dep breaks `cargo check` outright), so I used a newer local toolchain (1.89.0) as a workaround.

- `cargo check -p quest` — clean.
- `cargo clippy -p quest` (lib target) — no new warnings (one pre-existing `too_many_arguments` warning on `update_quest`, unrelated — it already had 8 params before this PR).
- `cargo test -p quest` — **could not be run to completion**: `quest`'s dev-dependencies pull in `testutils`, which pulls in `certificate`, which independently fails to compile in this environment (`stellar_macros::default_impl` not found — confirmed this isn't a stale-lockfile issue; neither `stellar-macros` 0.6.0 nor 0.7.2 export `default_impl`). That's a separate, pre-existing bug unrelated to this PR that I have not touched. I manually checked `contracts/quest/src/test.rs` and confirmed no existing test asserts on the exact event payload of `quest_updated` or `enrollee_added`, so this change shouldn't break any existing test — but please rely on CI rather than my local run for this crate.
- Diffed against `main` to confirm the only changes are the three reapplied fixes plus the #1173 event detail — no unintended regressions.

## Test plan

- [x] `cargo check -p quest` — clean
- [x] `cargo clippy -p quest` — no new warnings
- [ ] `cargo test -p quest` — not run to completion locally (unrelated `certificate` crate breakage blocks the `testutils` dev-dependency); please rely on CI
- [x] Manually confirmed no existing quest test asserts on `quest_updated`/`enrollee_added` event payloads
- [ ] CI (should go green on the `quest` crate for the first time since `a7a3ecc`)