### PR TITLE
docs(frontend): clarify useAsyncData's stale-closure safety, confirm contract fixes already shipped

### DIFF
--- a/frontend/src/hooks/use-async-data.ts
+++ b/frontend/src/hooks/use-async-data.ts
@@ -17,9 +17,12 @@ export function useAsyncData<T>(
   queryFn: () => Promise<T>,  
   options: UseAsyncDataOptions<T>  
 ): AsyncDataState<T> & { refetch: () => Promise<void> } {  
-  const { initialData = null, queryKey, enabled = true } = options  
-  
-  const query = useQuery({  
+  const { initialData = null, queryKey, enabled = true } = options
+
+  // queryFn re-runs whenever queryKey changes, so callers don't need to
+  // memoize it — unlike the old useCallback + manual-dependencies version,
+  // there's no suppressed lint rule for a stale closure to hide behind.
+  const query = useQuery({
     queryKey,  
     queryFn,  
     enabled,  


### PR DESCRIPTION
closes #1106 - useAsyncData's stableFetcher/eslint-disable pattern no longer exists (fixed in 0517044). Added a comment explaining why the TanStack Query design structurally avoids the stale-closure class of bug.

closes #1104 - join_quest already emits join_mode = "self" for self-enrollment, distinct from add_enrollee's "owner" (fixed in a7a3ecc). Verified in code, no diff needed.

closes #1103 - TotalReservedReward's TTL is already extended via extend_ttl(THRESHOLD, BUMP) at both write sites in verify_completion and submit_for_review (fixed in 7ffcbf5). Verified in code, no diff needed.

closes #1007 - Mainnet deploy is not yet done: environments.toml's [mainnet] section has no contract IDs or WASM hashes pinned, and docs/operations/contracts-mainnet.md doesn't exist. Closing per your call, but flagging that the acceptance checklist isn't actually satisfied yet.
