### PR TITLE
fix: implement logging, state store, form builder, and mock data generator (#1251, #1252, #1253, #1254)

### DIFF
--- a/frontend/src/hooks/useFormBuilder.ts
+++ b/frontend/src/hooks/useFormBuilder.ts
@@ -1,0 +1,75 @@
+import { useState, useCallback, ChangeEvent } from 'react'
+
+export type Validator<T> = (values: T) => Partial<Record<keyof T, string>>
+
+export interface UseFormBuilderOptions<T extends Record<string, unknown>> {
+  initialValues: T
+  validate?: Validator<T>
+  onSubmit: (values: T) => void | Promise<void>
+}
+
+export function useFormBuilder<T extends Record<string, unknown>>({
+  initialValues,
+  validate,
+  onSubmit,
+}: UseFormBuilderOptions<T>) {
+  const [values, setValues] = useState<T>(initialValues)
+  const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({})
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+
+  const handleChange = useCallback(
+    (name: keyof T) => (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const val = e.target.value
+      setValues((prev) => ({ ...prev, [name]: val }))
+      if (errors[name]) {
+        setErrors((prev) => ({ ...prev, [name]: undefined }))
+      }
+    },
+    [errors]
+  )
+
+  const setValue = useCallback((name: keyof T, value: unknown) => {
+    setValues((prev) => ({ ...prev, [name]: value }))
+  }, [])
+
+  const resetForm = useCallback(() => {
+    setValues(initialValues)
+    setErrors({})
+    setIsSubmitting(false)
+  }, [initialValues])
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      if (e && e.preventDefault) {
+        e.preventDefault()
+      }
+
+      if (validate) {
+        const validationErrors = validate(values)
+        if (Object.keys(validationErrors).length > 0) {
+          setErrors(validationErrors)
+          return
+        }
+      }
+
+      setIsSubmitting(true)
+      try {
+        await onSubmit(values)
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [values, validate, onSubmit]
+  )
+
+  return {
+    values,
+    errors,
+    isSubmitting,
+    handleChange,
+    setValue,
+    resetForm,
+    handleSubmit,
+    setValues,
+  }
+}

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,61 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+export interface LogEntry {
+  level: LogLevel
+  message: string
+  timestamp: string
+  context?: Record<string, unknown>
+}
+
+class Logger {
+  private level: LogLevel = 'info'
+  private levels: Record<LogLevel, number> = {
+    debug: 0,
+    info: 1,
+    warn: 2,
+    error: 3,
+  }
+
+  public setLevel(level: LogLevel): void {
+    this.level = level
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return this.levels[level] >= this.levels[this.level]
+  }
+
+  private format(level: LogLevel, message: string, context?: Record<string, unknown>): LogEntry {
+    return {
+      level,
+      message,
+      timestamp: new Date().toISOString(),
+      ...(context && { context }),
+    }
+  }
+
+  public debug(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('debug')) {
+      console.debug('[DEBUG]', this.format('debug', message, context))
+    }
+  }
+
+  public info(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('info')) {
+      console.info('[INFO]', this.format('info', message, context))
+    }
+  }
+
+  public warn(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('warn')) {
+      console.warn('[WARN]', this.format('warn', message, context))
+    }
+  }
+
+  public error(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('error')) {
+      console.error('[ERROR]', this.format('error', message, context))
+    }
+  }
+}
+
+export const logger = new Logger()

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -237,3 +237,31 @@ export const MOCK_EARNINGS_HISTORY: EarningsDataPoint[] = [
   { date: "Mar", amount: 400 },
   { date: "Apr", amount: 750 },
 ]
+
+export function generateMockQuest(id: number, overrides?: Partial<Quest>): Quest {
+  return {
+    id,
+    owner: `G${Math.random().toString(36).substring(2, 6).toUpperCase()}...MOCK`,
+    name: `Generated Quest #${id}`,
+    description: `Auto-generated mock quest description for quest #${id}`,
+    category: "General",
+    tags: ["mock", "test"],
+    tokenAddr: "USDC...STELLAR",
+    createdAt: Math.floor(Date.now() / 1000),
+    visibility: "Public",
+    status: "Active",
+    deadline: 0,
+    archivedAt: 0,
+    maxEnrollees: null,
+    verified: true,
+    enrolleeCount: Math.floor(Math.random() * 10),
+    milestoneCount: 3,
+    poolBalance: 1000,
+    ...overrides,
+  }
+}
+
+export function generateMockDataset(count: number = 5): Quest[] {
+  return Array.from({ length: count }, (_, i) => generateMockQuest(i + 100))
+}
+

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -1,0 +1,35 @@
+type Listener<T> = (state: T) => void
+
+export class Store<T extends object> {
+  private state: T
+  private listeners: Set<Listener<T>> = new Set()
+
+  constructor(initialState: T) {
+    this.state = initialState
+  }
+
+  public getState(): T {
+    return this.state
+  }
+
+  public setState(partialState: Partial<T> | ((prevState: T) => Partial<T>)): void {
+    const nextPartial = typeof partialState === 'function' ? partialState(this.state) : partialState
+    this.state = { ...this.state, ...nextPartial }
+    this.notify()
+  }
+
+  public subscribe(listener: Listener<T>): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener(this.state))
+  }
+}
+
+export function createStore<T extends object>(initialState: T): Store<T> {
+  return new Store<T>(initialState)
+}


### PR DESCRIPTION
Closes #1251
Closes #1252
Closes #1253
Closes #1254

## Summary
This pull request resolves four assigned issues for edehvictor:

- **Closes #1251**: Implemented a structured logging framework (\rontend/src/lib/logger.ts\) supporting log levels (\debug\, \info\, \warn\, \error\) and formatted log metadata for observability.
- **Closes #1252**: Added a lightweight state store pattern (\rontend/src/lib/store.ts\) for scalable state management refactoring.
- **Closes #1253**: Implemented a reusable form builder hook (\rontend/src/hooks/useFormBuilder.ts\) to handle state, validation, and submit flows across forms.
- **Closes #1254**: Implemented dynamic mock data generators (\generateMockQuest\ and \generateMockDataset\ in \rontend/src/lib/mock-data.ts\) for frontend testing without contract calls.