### PR TITLE
fix: centralize env reads, bump Node to 24, add contract doc comments

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -3,7 +3,7 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "22"
+  NODE_VERSION = "24"
   PNPM_VERSION = "10"
 
 [[redirects]]

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,3 +1,4 @@
+import { isDev } from "@/lib/env"
 import {
   Component,
   createContext,
@@ -138,7 +139,7 @@ const ERROR_COPY: Record<
 }
 
 function devLog(error: Error, info: ErrorInfo | null) {
-  if (import.meta.env.DEV) {
+  if (isDev) {
     console.group("%c[ErrorBoundary]", "color:#e11d48;font-weight:bold;font-size:14px")
     console.error("Error:", error)
     console.error("Message:", error.message)
@@ -261,7 +262,7 @@ function ErrorFallbackUI({
         </div>
 
         {/* Dev-only stack trace panel */}
-        {import.meta.env.DEV && (
+        {isDev && (
           <details className="border-border mt-4 border bg-black shadow-lg">
             <summary className="text-accent flex cursor-pointer items-center gap-2 px-4 py-2.5 text-xs font-semibold tracking-[2px] uppercase select-none">
               <Zap size={12} /> DEV — STACK TRACE

--- a/frontend/src/hooks/use-transaction-queue.ts
+++ b/frontend/src/hooks/use-transaction-queue.ts
@@ -1,3 +1,4 @@
+import { isDev } from "@/lib/env"
 import { useCallback, useRef, useState, useEffect } from "react"
 
 export type TransactionQueuePhase = "signing" | "confirming"
@@ -66,7 +67,7 @@ function saveTransactionsToStorage<TType extends string, TMeta>(
     localStorage.setItem(TRANSACTION_QUEUE_STORAGE_KEY, serializeTransactions(transactions))
   } catch {
     // Storage unavailable — fail silently
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.warn("Failed to persist transaction queue to localStorage")
     }
   }

--- a/frontend/src/lib/app-url.ts
+++ b/frontend/src/lib/app-url.ts
@@ -1,9 +1,11 @@
+import { env } from "@/lib/env"
+
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value
 }
 
 export function getCanonicalAppUrl(): string {
-  const configured = import.meta.env.VITE_APP_URL?.trim()
+  const configured = env.VITE_APP_URL?.trim()
   if (configured) {
     return trimTrailingSlash(configured)
   }

--- a/frontend/src/lib/contracts/client.ts
+++ b/frontend/src/lib/contracts/client.ts
@@ -1,3 +1,5 @@
+/** Core Soroban RPC client — connection, signing, submission, and rate limiting. */
+import { isDev } from "@/lib/env"
 import * as rpc from "@stellar/stellar-sdk/rpc"
 import { Transaction } from "@stellar/stellar-sdk"
 import { signTransaction, getNetworkDetails, getAddress } from "@stellar/freighter-api"
@@ -7,10 +9,8 @@ import { logContractCall } from "./logger"
 import { trackTransaction, type HorizonTransactionMeta } from "./tx-tracker"
 import { RpcHealthManager, parseRpcUrls } from "./rpc-health"
 
-export const SOROBAN_RPC_URL =
-  import.meta.env.VITE_SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org"
-export const NETWORK_PASSPHRASE =
-  import.meta.env.VITE_SOROBAN_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015"
+export const SOROBAN_RPC_URL = env.VITE_SOROBAN_RPC_URL
+export const NETWORK_PASSPHRASE = env.VITE_SOROBAN_NETWORK_PASSPHRASE
 
 // Determine timeout based on network (testnet: 15s, mainnet: 8s)
 const isMainnet = SOROBAN_RPC_URL.includes("mainnet")
@@ -418,7 +418,7 @@ export async function signAndSubmit(
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unknown error during signing/submission"
     logTx("sign_and_submit", "error", { error: message })
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.error("Transaction submission error:", err)
     }
     return { status: "FAILED", txHash: "", error: message }

--- a/frontend/src/lib/contracts/logger.ts
+++ b/frontend/src/lib/contracts/logger.ts
@@ -1,3 +1,4 @@
+import { isDev } from "@/lib/env"
 /**
  * Structured logger for contract call lifecycles.
  *
@@ -38,7 +39,7 @@ function addSentryBreadcrumb(entry: ContractLogEntry) {
 export function logContractCall(entry: ContractLogEntry) {
   addSentryBreadcrumb(entry)
 
-  if (import.meta.env.DEV) {
+  if (isDev) {
     const prefix = `[contract:${entry.contract}] ${entry.fn}`
     if (entry.result === "success") {
       console.info(prefix, { ...entry })

--- a/frontend/src/lib/contracts/milestone-client.ts
+++ b/frontend/src/lib/contracts/milestone-client.ts
@@ -1,3 +1,5 @@
+/** Soroban contract client for quest milestones (create, verify completion, claim rewards). */
+import { isDev, env } from "@/lib/env"
 import {
   Address,
   Contract,
@@ -19,7 +21,7 @@ import {
 } from "./client"
 import { withContractLogging } from "./logger"
 
-const CONTRACT_ID = import.meta.env.VITE_MILESTONE_CONTRACT_ID || ""
+const CONTRACT_ID = env.VITE_MILESTONE_CONTRACT_ID
 
 const MILESTONE_ERROR_MESSAGES: Record<number, string> = {
   1: "Milestone not found.",
@@ -71,7 +73,7 @@ export class MilestoneClient {
         this.contract = new Contract(CONTRACT_ID)
       } catch {
         this.contract = null
-        if (import.meta.env.DEV) {
+        if (isDev) {
           console.error(`[MilestoneClient] Invalid VITE_MILESTONE_CONTRACT_ID: "${CONTRACT_ID}"`)
         }
       }
@@ -230,7 +232,7 @@ export class MilestoneClient {
       }
       return null
     }).catch((e: unknown) => {
-      if (import.meta.env.DEV) {
+      if (isDev) {
         console.error(`Read error ${method}:`, e)
       }
       return null

--- a/frontend/src/lib/contracts/quest.ts
+++ b/frontend/src/lib/contracts/quest.ts
@@ -1,3 +1,5 @@
+/** Soroban contract client for Lernza quests (create, enroll, complete, verify). */
+import { isDev, env } from "@/lib/env"
 import {
   Address,
   Contract,
@@ -20,7 +22,7 @@ import {
 import { safeContractCall } from "../error-utils"
 import { withContractLogging } from "./logger"
 
-const CONTRACT_ID = import.meta.env.VITE_QUEST_CONTRACT_ID || ""
+const CONTRACT_ID = env.VITE_QUEST_CONTRACT_ID
 
 // Re-export so consumers can import the canonical contract types from either
 // `@/lib/contracts/quest` or `@/lib/contract-types`. Keeping both import paths
@@ -37,7 +39,7 @@ export class QuestClient {
         this.contract = new Contract(CONTRACT_ID)
       } catch {
         this.contract = null
-        if (import.meta.env.DEV) {
+        if (isDev) {
           console.error(`[QuestClient] Invalid VITE_QUEST_CONTRACT_ID: "${CONTRACT_ID}"`)
         }
       }
@@ -406,7 +408,7 @@ export class QuestClient {
       }
       return null
     }).catch((e: unknown) => {
-      if (import.meta.env.DEV) {
+      if (isDev) {
         console.error(`Read error ${method}:`, e)
       }
       return null

--- a/frontend/src/lib/contracts/rewards.ts
+++ b/frontend/src/lib/contracts/rewards.ts
@@ -1,3 +1,5 @@
+/** Soroban contract client for the Lernza rewards system (claim, distribute, track). */
+import { isDev, env } from "@/lib/env"
 import {
   Address,
   Contract,
@@ -21,7 +23,7 @@ import type { PoolBalance, UserEarnings, TotalDistributed } from "../contract-ty
 import { safeContractCall } from "../error-utils"
 import { withContractLogging } from "./logger"
 
-const CONTRACT_ID = import.meta.env.VITE_REWARDS_CONTRACT_ID || ""
+const CONTRACT_ID = env.VITE_REWARDS_CONTRACT_ID
 
 export class RewardsClient {
   private contract: Contract | null
@@ -32,7 +34,7 @@ export class RewardsClient {
         this.contract = new Contract(CONTRACT_ID)
       } catch {
         this.contract = null
-        if (import.meta.env.DEV) {
+        if (isDev) {
           console.error(`[RewardsClient] Invalid VITE_REWARDS_CONTRACT_ID: "${CONTRACT_ID}"`)
         }
       }
@@ -160,7 +162,7 @@ export class RewardsClient {
       }
       return null
     }).catch((e: unknown) => {
-      if (import.meta.env.DEV) {
+      if (isDev) {
         console.error(`Read error ${method}:`, e)
       }
       return null

--- a/frontend/src/lib/contracts/rpc-health.ts
+++ b/frontend/src/lib/contracts/rpc-health.ts
@@ -1,3 +1,4 @@
+/** Health-aware Soroban RPC endpoint manager with automatic failover. */
 import * as rpc from "@stellar/stellar-sdk/rpc"
 
 // `getHealth` exists on the runtime Server but isn't part of the SDK's public

--- a/frontend/src/lib/contracts/token.ts
+++ b/frontend/src/lib/contracts/token.ts
@@ -1,3 +1,5 @@
+/** SEP-41 token contract client for balance queries, transfers, and metadata. */
+import { isDev, env } from "@/lib/env"
 import { Contract, scValToNative, Keypair, Account, TransactionBuilder } from "@stellar/stellar-sdk"
 import { server, NETWORK_PASSPHRASE, RPC_TIMEOUT_MS, withTimeout, withRpcReadThrottle } from "./client"
 
@@ -19,7 +21,7 @@ export class TokenClient {
         this.contract = new Contract(tokenAddress)
       } catch {
         this.contract = null
-        if (import.meta.env.DEV) {
+        if (isDev) {
           console.error(`[TokenClient] Invalid token address: "${tokenAddress}"`)
         }
       }
@@ -114,7 +116,7 @@ export class TokenClient {
 
       return metadata
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (isDev) {
         console.error("Failed to fetch token metadata:", error)
       }
       // Return fallback metadata
@@ -133,8 +135,8 @@ export class TokenClient {
   private getContractAddress(): string {
     const addr =
       this.tokenAddress ||
-      import.meta.env.VITE_REWARDS_TOKEN_CONTRACT_ID ||
-      import.meta.env.VITE_USDC_TOKEN_ADDRESS
+      env.VITE_REWARDS_TOKEN_CONTRACT_ID ||
+      env.VITE_USDC_TOKEN_ADDRESS
 
     if (!addr) {
       throw new Error(

--- a/frontend/src/lib/contracts/tx-tracker.ts
+++ b/frontend/src/lib/contracts/tx-tracker.ts
@@ -1,3 +1,5 @@
+/** Tracks Soroban transactions on Horizon and fetches operation details. */
+import { isDev, env } from "@/lib/env"
 const HORIZON_MAINNET = "https://horizon.stellar.org"
 const HORIZON_TESTNET = "https://horizon-testnet.stellar.org"
 
@@ -23,7 +25,7 @@ export interface HorizonTransactionMeta {
 }
 
 function horizonUrl(): string {
-  const rpcUrl = import.meta.env.VITE_SOROBAN_RPC_URL ?? ""
+  const rpcUrl = env.VITE_SOROBAN_RPC_URL ?? ""
   return rpcUrl.includes("mainnet") ? HORIZON_MAINNET : HORIZON_TESTNET
 }
 
@@ -40,7 +42,7 @@ export async function trackTransaction(txHash: string): Promise<HorizonTransacti
     ])
 
     if (!txRes.ok) {
-      if (import.meta.env.DEV) {
+      if (isDev) {
         console.warn(`[TxTracker] Horizon returned ${txRes.status} for ${txHash}`)
       }
       return null
@@ -66,7 +68,7 @@ export async function trackTransaction(txHash: string): Promise<HorizonTransacti
       operations,
     }
 
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.group(`[TxTracker] On-chain meta — ${txHash.slice(0, 8)}…`)
       console.log("ledger:", meta.ledger, "| created_at:", meta.created_at)
       console.log("fee_charged:", meta.fee_charged, "| successful:", meta.successful)
@@ -77,7 +79,7 @@ export async function trackTransaction(txHash: string): Promise<HorizonTransacti
 
     return meta
   } catch (err) {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.warn("[TxTracker] Horizon lookup failed:", err)
     }
     return null

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -62,6 +62,10 @@ const schema = z.object({
   VITE_ENVIRONMENT: z
     .preprocess(emptyToUndefined, z.enum(["development", "staging", "production"]).optional())
     .default("development"),
+
+  VITE_APP_URL: z
+    .preprocess(emptyToUndefined, z.string().url().optional())
+    .default(""),
 });
 
 export const env = schema.parse({
@@ -78,6 +82,13 @@ export const env = schema.parse({
   VITE_REWARDS_TOKEN_CONTRACT_ID: import.meta.env.VITE_REWARDS_TOKEN_CONTRACT_ID,
   VITE_USDC_TOKEN_ADDRESS: import.meta.env.VITE_USDC_TOKEN_ADDRESS,
   VITE_ENVIRONMENT: import.meta.env.VITE_ENVIRONMENT,
+  VITE_APP_URL: import.meta.env.VITE_APP_URL,
 });
 
 export type Env = z.infer<typeof schema>;
+
+/** True when running in Vite dev server (replaces scattered import.meta.env.DEV reads). */
+export const isDev: boolean = import.meta.env.DEV;
+
+/** True when running a production build (replaces scattered import.meta.env.PROD reads). */
+export const isProd: boolean = import.meta.env.PROD;

--- a/frontend/src/lib/error-utils.ts
+++ b/frontend/src/lib/error-utils.ts
@@ -1,3 +1,4 @@
+import { isDev } from "@/lib/env"
 import * as Sentry from "@sentry/react"
 import { env } from "./env"
 
@@ -8,7 +9,7 @@ export function setupGlobalErrorHandlers() {
     const reason = event.reason
     const error = reason instanceof Error ? reason : new Error(String(reason))
 
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.group(
         "%c[GlobalErrorHandler] Unhandled Promise Rejection",
         "color:#e11d48;font-weight:bold"
@@ -25,7 +26,7 @@ export function setupGlobalErrorHandlers() {
   })
 
   window.addEventListener("error", event => {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.group("%c[GlobalErrorHandler] Uncaught Error", "color:#e11d48;font-weight:bold")
       console.error(event.error ?? event.message)
       console.groupEnd()

--- a/frontend/src/lib/transaction-queue-storage.ts
+++ b/frontend/src/lib/transaction-queue-storage.ts
@@ -1,3 +1,4 @@
+import { isDev } from "@/lib/env"
 /**
  * Transaction Queue Storage Utilities
  * Handles persistence and retrieval of pending transactions from localStorage
@@ -34,7 +35,7 @@ export function getStoredTransactionQueue(): QueuedTransaction[] {
     const now = Date.now()
     return data.transactions.filter(tx => !tx.expiresAt || tx.expiresAt > now)
   } catch (error) {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.error("Failed to retrieve transaction queue from storage:", error)
     }
     return []
@@ -54,7 +55,7 @@ export function storeTransactionQueue(transactions: QueuedTransaction[]): boolea
     localStorage.setItem(TRANSACTION_QUEUE_STORAGE_KEY, JSON.stringify(data))
     return true
   } catch (error) {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.error("Failed to store transaction queue:", error)
     }
     return false
@@ -69,7 +70,7 @@ export function clearStoredTransactionQueue(): boolean {
     localStorage.removeItem(TRANSACTION_QUEUE_STORAGE_KEY)
     return true
   } catch (error) {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.error("Failed to clear transaction queue:", error)
     }
     return false
@@ -150,7 +151,7 @@ export function importTransactionQueue(data: string): boolean {
     
     return storeTransactionQueue(transactions)
   } catch (error) {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.error("Failed to import transaction queue:", error)
     }
     return false

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query"
 import { HelmetProvider } from "react-helmet-async"
 import { queryClient } from "@/lib/query-client"
 import * as Sentry from "@sentry/react"
-import { env } from "@/lib/env"
+import { env, isDev, isProd } from "@/lib/env"
 import { setupGlobalErrorHandlers } from "@/lib/error-utils"
 import { reportWebVitals } from "@/lib/analytics"
 import { ThemeProvider } from "@/contexts/theme-context"
@@ -31,7 +31,7 @@ if (env.VITE_SENTRY_DSN) {
 // unhandled promise rejections are forwarded with correct Sentry context.
 setupGlobalErrorHandlers()
 
-if (import.meta.env.DEV) {
+if (isDev) {
   Promise.all([import("@axe-core/react"), import("react"), import("react-dom")]).then(
     ([axe, React, ReactDOM]) => {
       axe.default(React.default, ReactDOM.default, 1000)
@@ -44,10 +44,10 @@ if (import.meta.env.DEV) {
     registerSW({
       // Silently pre-cache the new SW; next reload will pick up the update.
       onRegisteredSW(swUrl, r) {
-        if (import.meta.env.DEV) console.info("[SW] registered at", swUrl, r)
+        if (isDev) console.info("[SW] registered at", swUrl, r)
       },
       onOfflineReady() {
-        if (import.meta.env.DEV) console.info("[SW] app ready to work offline")
+        if (isDev) console.info("[SW] app ready to work offline")
       },
     })
   })
@@ -64,7 +64,7 @@ if (import.meta.env.DEV) {
 //
 // Note: we only call inject() in production — analytics in dev creates noise.
 
-if (import.meta.env.PROD) {
+if (isProd) {
   const scheduleAnalytics = () => {
     import("@vercel/analytics").then(({ inject }) => inject())
   }

--- a/frontend/src/pages/dashboard/trending-quests.tsx
+++ b/frontend/src/pages/dashboard/trending-quests.tsx
@@ -2,6 +2,7 @@ import { Check, Sparkles, Users, Coins } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { formatTokens } from "@/lib/utils"
+import { env } from "@/lib/env"
 import { useTokenMetadata } from "@/hooks/use-token-metadata"
 import type { QuestInfo } from "@/lib/contracts/quest"
 import type { Quest } from "@/lib/mock-data"
@@ -15,7 +16,7 @@ interface TrendingQuestsProps {
 
 export function TrendingQuests({ quests, statsByQuest, onSelectQuest }: TrendingQuestsProps) {
   const tokenAddress =
-    import.meta.env.VITE_REWARDS_TOKEN_CONTRACT_ID || import.meta.env.VITE_USDC_TOKEN_ADDRESS || ""
+    env.VITE_REWARDS_TOKEN_CONTRACT_ID || env.VITE_USDC_TOKEN_ADDRESS || ""
   const { metadata: tokenMetadata } = useTokenMetadata(tokenAddress)
 
   const formatRewardAmount = (amount: number) => {


### PR DESCRIPTION
Fixes #967, Fixes #1000, Fixes #1006, Fixes #1239

## What changed
- **#967**: Bump NODE_VERSION from 22 to 24 in netlify.toml
- **#1000**: Add / exports to env.ts, replace scattered / reads across 12+ files, centralize  env reads through validated env object
- **#1006**:  already wraps  — no migration needed (confirmed)
- **#1239**: Add module-level JSDoc comments to all contract client files

## Why
- Scattered  reads bypass Zod validation and make env config fragile
- Node 22 is outdated for Netlify builds
- Contract files lacked module-level documentation

## How to test
-  should pass
- Verify env vars still resolve correctly in dev and production builds