### PR TITLE
feat: expired-quest refunds, wallet-connect loading states, quest contract docs, and test coverage

### DIFF
--- a/contracts/certificate/src/test.rs
+++ b/contracts/certificate/src/test.rs
@@ -78,7 +78,7 @@ fn test_certificate_revocation() {
         &owner,
     );
 
-    client.revoke_certificate(&owner, &token_id);
+    client.revoke_certificate(&token_id);
 
     // Metadata is gone
     let result = client.try_get_certificate_metadata(&token_id);
@@ -92,7 +92,7 @@ fn test_certificate_revocation() {
     assert!(client.is_revoked(&token_id));
 
     // Double-revoke returns AlreadyRevoked
-    let double = client.try_revoke_certificate(&owner, &token_id);
+    let double = client.try_revoke_certificate(&token_id);
     assert_eq!(double, Err(Ok(Error::AlreadyRevoked)));
 }
 
@@ -146,4 +146,224 @@ fn test_get_metadata_base_not_set_returns_error() {
     let (_env, client, _owner) = setup();
     let result = client.try_get_metadata_base();
     assert_eq!(result, Err(Ok(Error::MetadataBaseNotSet)));
+}
+
+// --- Additional edge-case coverage — issue #1184 ---
+
+#[test]
+fn test_mint_quest_certificate_uses_contract_owner_as_issuer() {
+    // mint_quest_certificate is the owner-only convenience wrapper that
+    // fills in `issuer` from the stored contract owner rather than taking
+    // it as a caller-supplied argument.
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+    let quest_id = 7u32;
+
+    let token_id = client.mint_quest_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest Seven"),
+        &String::from_str(&env, "Design"),
+        &recipient,
+    );
+
+    let metadata = client.get_certificate_metadata(&token_id);
+    assert_eq!(metadata.issuer, owner);
+    assert_eq!(metadata.recipient, recipient);
+    assert_eq!(metadata.quest_id, quest_id);
+}
+
+#[test]
+fn test_mint_quest_certificate_duplicate_prevention() {
+    let (env, client, _owner) = setup();
+    let recipient = Address::generate(&env);
+    let quest_id = 3u32;
+
+    client.mint_quest_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+    );
+
+    let result = client.try_mint_quest_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadyIssued)));
+}
+
+#[test]
+fn test_pause_blocks_minting() {
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+
+    client.pause();
+
+    let result = client.try_mint_certificate(
+        &1u32,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+    assert_eq!(result, Err(Ok(Error::Paused)));
+
+    let result = client.try_mint_quest_certificate(
+        &1u32,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+    );
+    assert_eq!(result, Err(Ok(Error::Paused)));
+}
+
+#[test]
+fn test_unpause_allows_minting_again() {
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+
+    client.pause();
+    client.unpause();
+
+    let token_id = client.mint_certificate(
+        &1u32,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+    let metadata = client.get_certificate_metadata(&token_id);
+    assert_eq!(metadata.quest_id, 1u32);
+}
+
+#[test]
+fn test_get_certificate_metadata_not_found() {
+    let (_env, client, _owner) = setup();
+    let result = client.try_get_certificate_metadata(&999u32);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+#[test]
+fn test_get_quest_certificate_not_found() {
+    let (env, client, _owner) = setup();
+    let stranger = Address::generate(&env);
+    let result = client.try_get_quest_certificate(&999u32, &stranger);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+#[test]
+fn test_has_quest_certificate() {
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+    let quest_id = 42u32;
+
+    assert!(!client.has_quest_certificate(&quest_id, &recipient));
+
+    client.mint_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+
+    assert!(client.has_quest_certificate(&quest_id, &recipient));
+}
+
+#[test]
+fn test_get_certificate_details_returns_metadata_and_owner() {
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+    let quest_id = 5u32;
+
+    let token_id = client.mint_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+
+    let (metadata, token_owner) = client.get_certificate_details(&token_id);
+    assert_eq!(metadata.quest_id, quest_id);
+    assert_eq!(token_owner, recipient);
+}
+
+#[test]
+fn test_revoke_nonexistent_certificate_returns_not_found() {
+    let (_env, client, _owner) = setup();
+    let result = client.try_revoke_certificate(&999u32);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+#[test]
+fn test_revoked_certificate_slot_can_be_reissued() {
+    // After revocation the (quest_id, recipient) slot is cleared entirely,
+    // so a fresh certificate can be minted for the same pair — e.g. if a
+    // learner's original certificate was revoked for a data error and the
+    // owner wants to reissue a corrected one.
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+    let quest_id = 9u32;
+
+    let first_id = client.mint_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+    client.revoke_certificate(&first_id);
+
+    let second_id = client.mint_certificate(
+        &quest_id,
+        &String::from_str(&env, "Quest v2"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+
+    assert_ne!(first_id, second_id);
+    assert!(client.has_quest_certificate(&quest_id, &recipient));
+    assert_eq!(
+        client.get_quest_certificate(&quest_id, &recipient),
+        second_id
+    );
+
+    let user_certs = client.get_user_certificates(&recipient);
+    assert_eq!(user_certs.len(), 1);
+    assert_eq!(user_certs.get(0).unwrap(), second_id);
+}
+
+#[test]
+fn test_revoke_only_removes_target_certificate_from_user_list() {
+    // A user with multiple certificates who has one revoked should keep the
+    // others intact in their UserCertificates index.
+    let (env, client, owner) = setup();
+    let recipient = Address::generate(&env);
+
+    let cert1 = client.mint_certificate(
+        &1u32,
+        &String::from_str(&env, "Quest 1"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+    let cert2 = client.mint_certificate(
+        &2u32,
+        &String::from_str(&env, "Quest 2"),
+        &String::from_str(&env, "Cat"),
+        &recipient,
+        &owner,
+    );
+
+    client.revoke_certificate(&cert1);
+
+    let user_certs = client.get_user_certificates(&recipient);
+    assert_eq!(user_certs.len(), 1);
+    assert_eq!(user_certs.get(0).unwrap(), cert2);
+    assert!(client.is_revoked(&cert1));
+    assert!(!client.is_revoked(&cert2));
 }

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -86,6 +86,8 @@ pub enum Error {
     RewardAmountMismatch = 13,
     QuestNotArchived = 14,
     RefundWindowNotOpen = 15,
+    /// Quest has no deadline, or its deadline has not yet passed — issue #1187.
+    QuestNotExpired = 16,
     AlreadyInitialized = 99, // moved away from standard range
     NotInitialized = 100,    // moved away from standard range
     /// Contract is administratively paused (shared code 400).
@@ -850,6 +852,128 @@ impl RewardsContract {
             .extend_ttl(&DataKey::QuestPool(quest_id), THRESHOLD, BUMP);
 
         // Keep aggregate counters in sync — issue #864.
+        Self::record_refund(&env, quest_id, refundable)?;
+
+        // Emit event — reuse reward_refunded topic for indexer compatibility
+        env.events().publish(
+            (Symbol::new(&env, "reward_refunded"),),
+            (quest_id, authority, refundable),
+        );
+
+        Ok(refundable)
+    }
+
+    /// Reclaim unused pool tokens once a quest's deadline has passed,
+    /// even if the owner never explicitly archived it — issue #1187.
+    ///
+    /// `refund_unused_pool` and `refund_pool` both require `QuestStatus::Archived`,
+    /// which only the quest owner can set via `archive_quest`. If a creator funds a
+    /// quest, sets a deadline, and then goes silent — never completing enough
+    /// milestones to spend the pool and never archiving — those tokens were
+    /// previously stuck with no recovery path. This entry point only requires
+    /// that the quest defines a deadline which has passed (plus the same
+    /// configurable grace period used for archived refunds), so the funding
+    /// authority can always reclaim leftover tokens from an abandoned quest.
+    ///
+    /// Refunds the same "pool minus reserved-but-unpaid obligations" amount as
+    /// `refund_unused_pool`, so milestones an enrollee already qualified for
+    /// remain payable after the refund.
+    pub fn refund_expired_pool(env: Env, authority: Address, quest_id: u32) -> Result<i128, Error> {
+        authority.require_auth();
+
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            return Err(Error::Paused);
+        }
+
+        // Verify authority
+        let auth_key = DataKey::QuestAuthority(quest_id);
+        let stored: Address = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&auth_key)
+            .ok_or(Error::QuestNotFunded)?;
+        if stored != authority {
+            return Err(Error::Unauthorized);
+        }
+
+        // Verify the quest has a deadline that has passed the grace period —
+        // deliberately independent of QuestStatus so an un-archived, abandoned
+        // quest is still recoverable.
+        let quest_contract_addr = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::QuestContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client = QuestClient::new(&env, &quest_contract_addr);
+        let quest_info = match quest_client.try_get_quest(&quest_id) {
+            Ok(Ok(q)) => q,
+            Ok(Err(_)) | Err(_) => return Err(Error::QuestLookupFailed),
+        };
+
+        if quest_info.deadline == 0 {
+            return Err(Error::QuestNotExpired);
+        }
+
+        let grace_period = Self::get_refund_grace_period(env.clone());
+        let now = env.ledger().timestamp();
+        if now <= quest_info.deadline {
+            return Err(Error::QuestNotExpired);
+        }
+        if now < quest_info.deadline + grace_period {
+            return Err(Error::RefundWindowNotOpen);
+        }
+
+        // Calculate refundable amount
+        let milestone_contract_addr = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::MilestoneContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let milestone_client = MilestoneClient::new(&env, &milestone_contract_addr);
+        let total_reserved = milestone_client.get_total_reserved_reward(&quest_id);
+        let distributed = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuestDistributed(quest_id))
+            .unwrap_or(0_i128);
+        let obligations = total_reserved
+            .checked_sub(distributed)
+            .ok_or(Error::ArithmeticOverflow)?;
+        let pool: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuestPool(quest_id))
+            .unwrap_or(0);
+        let refundable = pool
+            .checked_sub(obligations)
+            .ok_or(Error::ArithmeticOverflow)?;
+
+        if refundable <= 0 {
+            return Ok(0);
+        }
+
+        // Transfer unused tokens back to authority
+        let token_addr = Self::get_token(&env)?;
+        let token_client = token::Client::new(&env, &token_addr);
+        token_client.transfer(&env.current_contract_address(), &authority, &refundable);
+
+        // Zero out the refunded portion of the pool
+        let new_pool = pool
+            .checked_sub(refundable)
+            .ok_or(Error::ArithmeticOverflow)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::QuestPool(quest_id), &new_pool);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::QuestPool(quest_id), THRESHOLD, BUMP);
+
+        // Keep aggregate counters in sync — see record_refund doc comment.
         Self::record_refund(&env, quest_id, refundable)?;
 
         // Emit event — reuse reward_refunded topic for indexer compatibility

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -2285,3 +2285,324 @@ fn test_refund_pool_decrements_total_funded() {
     client.refund_pool(&owner, &q_id, &1_500);
     assert_eq!(client.get_quest_refunded(&q_id), 3_500);
 }
+
+// --- refund_expired_pool: issue #1187 — recover funds from an abandoned,
+// never-archived quest once its deadline has passed. ---
+
+#[test]
+fn test_refund_expired_pool_success_without_archiving() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    // Creator funds the pool but the quest is never completed or archived.
+    client.fund_quest(&owner, &q_id, &5_000);
+
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+
+    // Deadline hasn't passed yet — no recovery available.
+    let result = client.try_refund_expired_pool(&owner, &q_id);
+    assert_eq!(result, Err(Ok(Error::QuestNotExpired)));
+
+    // Advance past the deadline plus the default 7-day grace period.
+    env.ledger().set_timestamp(deadline + 604_800 + 1);
+
+    let token_client = TokenClient::new(&env, &token_addr);
+    let balance_before = token_client.balance(&owner);
+
+    let refunded = client.refund_expired_pool(&owner, &q_id);
+
+    assert_eq!(refunded, 5_000);
+    assert_eq!(client.get_pool_balance(&q_id), 0);
+    assert_eq!(token_client.balance(&owner), balance_before + 5_000);
+    assert_eq!(client.get_quest_refunded(&q_id), 5_000);
+}
+
+#[test]
+fn test_refund_expired_pool_no_deadline() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+
+    // No deadline was ever set — expiry-based refund is not available.
+    let result = client.try_refund_expired_pool(&owner, &q_id);
+    assert_eq!(result, Err(Ok(Error::QuestNotExpired)));
+}
+
+#[test]
+fn test_refund_expired_pool_grace_period_enforced() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+
+    // Deadline just passed, but the grace period has not elapsed yet.
+    env.ledger().set_timestamp(deadline + 1);
+    let result = client.try_refund_expired_pool(&owner, &q_id);
+    assert_eq!(result, Err(Ok(Error::RefundWindowNotOpen)));
+}
+
+#[test]
+fn test_refund_expired_pool_unauthorized() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+    env.ledger().set_timestamp(deadline + 604_800 + 1);
+
+    let result = client.try_refund_expired_pool(&attacker, &q_id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_refund_expired_pool_not_funded() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+    env.ledger().set_timestamp(deadline + 604_800 + 1);
+
+    // Quest was never funded — no authority stored.
+    let result = client.try_refund_expired_pool(&owner, &q_id);
+    assert_eq!(result, Err(Ok(Error::QuestNotFunded)));
+}
+
+#[test]
+fn test_refund_expired_pool_respects_reserved_obligations() {
+    // A milestone was verified as completed (reserving its reward) but not
+    // yet paid out. The expired-quest refund path must not let the owner
+    // reclaim tokens still owed to an enrollee for qualifying work.
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        _admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+    let enrollee = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+
+    let m_id = milestone_client.create_milestone(
+        &owner,
+        &q_id,
+        &String::from_str(&env, "Milestone"),
+        &String::from_str(&env, "Desc"),
+        &2_000,
+        &false,
+    );
+
+    quest_client.add_enrollee(&q_id, &enrollee);
+    milestone_client.verify_completion(&owner, &q_id, &m_id, &enrollee);
+
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+    env.ledger().set_timestamp(deadline + 604_800 + 1);
+
+    // Only the unreserved 3_000 should be refundable; the 2_000 reserved for
+    // the verified-but-unpaid milestone must stay in the pool.
+    let refunded = client.refund_expired_pool(&owner, &q_id);
+    assert_eq!(refunded, 3_000);
+    assert_eq!(client.get_pool_balance(&q_id), 2_000);
+
+    // The enrollee can still be paid out of what remains.
+    client.distribute_reward(&owner, &q_id, &m_id, &enrollee, &2_000);
+    assert_eq!(client.get_pool_balance(&q_id), 0);
+}
+
+#[test]
+fn test_refund_expired_pool_paused() {
+    let (
+        env,
+        client,
+        _cid,
+        token_addr,
+        quest_client,
+        _quest_id,
+        _milestone_client,
+        _milestone_id,
+        _certificate_client,
+        _certificate_id,
+        admin,
+    ) = setup();
+    let owner = Address::generate(&env);
+
+    let sac = StellarAssetClient::new(&env, &token_addr);
+    sac.mint(&owner, &10_000);
+
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Test"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &soroban_sdk::Vec::<String>::new(&env),
+        &token_addr,
+        &Visibility::Public,
+        &None,
+    );
+
+    client.fund_quest(&owner, &q_id, &5_000);
+    let deadline = env.ledger().timestamp() + 1_000;
+    quest_client.set_deadline(&q_id, &deadline);
+    env.ledger().set_timestamp(deadline + 604_800 + 1);
+
+    client.pause(&admin);
+
+    let result = client.try_refund_expired_pool(&owner, &q_id);
+    assert_eq!(result, Err(Ok(Error::Paused)));
+}

--- a/docs/contracts/ERROR_CONVENTIONS.md
+++ b/docs/contracts/ERROR_CONVENTIONS.md
@@ -91,6 +91,7 @@ which contract raised the error.
 | 13 | `RewardAmountMismatch` |
 | 14 | `QuestNotArchived` |
 | 15 | `RefundWindowNotOpen` |
+| 16 | `QuestNotExpired` |
 
 ## Adding new errors
 

--- a/docs/contracts/QUEST_CONTRACT.md
+++ b/docs/contracts/QUEST_CONTRACT.md
@@ -1,0 +1,239 @@
+# Quest Contract Architecture
+
+The `quest` crate (`contracts/quest/`) is Lernza's entry-point contract — the
+factory and system of record for the `Quest` entity. This document is a
+deep-dive on its design, storage layout, and interaction patterns, one level
+below the platform-wide summary in [`CONTRACTS_OVERVIEW.md`](../CONTRACTS_OVERVIEW.md)
+and the cross-contract sequence diagrams in [`ARCHITECTURE.md`](../ARCHITECTURE.md).
+
+> Historical note: earlier drafts of this contract and some still-migrating
+> identifiers refer to the same concept as "workspace" (see
+> [ADR-001](../adr/001-quest-entity-model-and-naming.md)). There is no
+> separate "QuestFactory" contract — `quest` *is* the factory: every other
+> contract (`milestone`, `rewards`, `certificate`) treats a `quest_id` minted
+> here as the root of truth and reads `QuestInfo` back from this contract to
+> authorize its own calls.
+
+## Role in the system
+
+`quest` owns three responsibilities and nothing else:
+
+1. **Identity** — mint quest IDs and store `QuestInfo` (name, description,
+   category, tags, token, deadline, status, versioning).
+2. **Access lists** — track who owns a quest and who is enrolled in it, plus
+   the indexes needed to query both directions and to browse public quests.
+3. **Enrollment policy** — decide who may join (open, owner-added, or
+   invite-gated) and enforce it independent of any reward logic.
+
+It deliberately does **not** know about milestones or tokens. `milestone`
+and `rewards` both hold a `QuestClient` (a `#[contractclient]` view of this
+contract's `get_quest`) and call it read-only to verify ownership, status,
+and deadlines before they act — see
+[ADR-002: Three-Contract Architecture](../adr/002-three-contract-architecture.md)
+for why that split exists. `quest` never calls out to the other contracts —
+it is the one dependency-free contract among the four, which means it can be
+deployed and upgraded independently of `milestone`/`rewards`/`certificate`.
+
+## Data model
+
+### `QuestInfo` (shared in `common`, persistent storage)
+
+```rust
+pub struct QuestInfo {
+    pub id: u32,
+    pub owner: Address,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+    pub tags: Vec<String>,
+    pub token_addr: Address,      // reward token, validated as a contract address
+    pub created_at: u64,
+    pub visibility: Visibility,   // Public | Private
+    pub status: QuestStatus,      // Active | Archived
+    pub deadline: u64,            // 0 = no deadline
+    pub archived_at: u64,         // 0 until archive_quest() is called
+    pub max_enrollees: Option<u32>,
+    pub verified: bool,           // snapshotted from is_creator_verified() at creation
+    pub version: u32,             // starts at 1, incremented by update_quest()
+}
+```
+
+`QuestInfo`, `QuestStatus`, and `Visibility` live in the `common` crate (not
+`quest`) so `milestone` and `rewards` can decode the same struct from a
+cross-contract call without depending on the `quest` crate itself.
+
+`verified` is a **snapshot**, not a live lookup: it is copied from
+`is_creator_verified(owner)` at `create_quest` time. Verifying or revoking a
+creator's status afterwards does not retroactively change the `verified` flag
+on quests they already created — this is intentional so a quest's displayed
+trust signal doesn't change out from under enrollees mid-quest.
+
+### `DataKey` (persistent storage keys)
+
+| Key | Value | Purpose |
+|---|---|---|
+| `NextId` (instance) | `u32` | Auto-incrementing quest ID counter |
+| `Quest(u32)` | `QuestInfo` | The quest record itself |
+| `Enrollees(u32)` | `Vec<Address>` | Enrollee list for a quest, insertion order |
+| `PublicQuests` | `Vec<u32>` | IDs of every `Visibility::Public` quest, for `list_public_quests` |
+| `PublicCategoryQuests(String)` | `Vec<u32>` | Public quest IDs bucketed by category |
+| `OwnerQuests(Address)` | `Vec<u32>` | Reverse index: quests an address owns |
+| `EnrolleeQuests(Address)` | `Vec<u32>` | Reverse index: quests an address is enrolled in |
+| `QuestVersionHistory(u32)` | `Vec<QuestVersion>` | Snapshots of prior field values, appended by `update_quest` |
+| `InviteCommitment(u32, BytesN<32>)` | `bool` | Registered invite hash for a quest, keyed by `(quest_id, sha256(preimage))` |
+| `InviteUsed(u32, BytesN<32>)` | `bool` | Marks a commitment as redeemed, prevents replay |
+| `LeaveHold(u32, Address)` | `bool` | Owner-placed hold blocking `leave_quest` for an enrollee mid peer-review |
+| `VerifiedCreator(Address)` | `bool` | Admin-managed allowlist consulted at `create_quest` time |
+| `Admin` / `Paused` (instance) | `Address` / `bool` | Contract-wide admin and kill-switch |
+
+**Storage tier choice**: `Admin`, `Paused`, and `NextId` live in *instance*
+storage (cheap, always resident, but shared TTL across the whole contract).
+Everything keyed by quest ID or address lives in *persistent* storage so each
+quest's cost and TTL are independent — a quest nobody reads can be left to
+expire without affecting others. See
+[ADR-005](../adr/005-storage-patterns-and-ttl-strategy.md) for the general
+policy this follows.
+
+### Versioning
+
+`update_quest` never mutates `QuestInfo` in place without a trail: before
+writing the new field values it pushes the *previous* values (as a
+`QuestVersion` snapshot) onto `QuestVersionHistory(quest_id)`, then
+increments `quest.version`. `get_quest_version_history` returns the list
+oldest-first. There is no cap on history length today — every update adds one
+entry — so integrators building on top of a very long-lived, frequently
+edited quest should be aware the history vector grows unbounded.
+
+## Interaction patterns
+
+### Auth model
+
+Every mutating function follows the same shape: resolve the acting
+`Address` from an explicit parameter (never `env.invoker()`), then call
+`.require_auth()` on it before touching storage. Two authorization roles
+exist:
+
+- **Owner-only**: `update_quest`, `archive_quest`, `add_enrollee`,
+  `remove_enrollee`, `register_invite`, `revoke_invite`, `set_deadline`,
+  `set_visibility`, `place_leave_hold`, `lift_leave_hold`. These load the
+  quest first, then check `quest.owner == caller` (or rely on `require_auth`
+  on the field read directly off the loaded quest — see `archive_quest` and
+  `set_deadline`, which call `quest.owner.require_auth()` instead of taking a
+  separate `owner` parameter, so there is no way to pass a mismatched
+  address).
+- **Self-service**: `join_quest`, `join_quest_with_invite`, and `leave_quest`
+  authenticate the enrollee themselves, not the owner.
+- **Admin-only**: `verify_creator`, `revoke_creator_verification`, `pause`,
+  `unpause`, `transfer_admin` — gated by `require_admin`, which compares
+  against the single `Admin` instance-storage address (no multisig/timelock
+  at this layer; see [ADR-007](../adr/007-admin-multisig-timelock.md) for
+  the platform-wide admin-key posture).
+
+### Pause switch
+
+`require_not_paused` is checked at the top of every mutating entry point
+(creation, updates, enrollment, invites, holds). Pure reads (`get_quest`,
+`list_public_quests`, `is_expired`, …) intentionally skip the check — the
+contract can be frozen for writes without also blocking the frontend's
+ability to display existing quests.
+
+### Enrollment: three paths, one invariant
+
+`quest` supports three ways to add an enrollee, all converging on the same
+`Enrollees(quest_id)` list and the same guard rails (not archived, deadline
+not passed, under `max_enrollees`, not already enrolled):
+
+1. **`add_enrollee`** — owner adds someone directly. Emits
+   `enrollee_added` with `join_mode = "owner"`.
+2. **`join_quest`** — self-serve join, only allowed when
+   `visibility == Public`. Emits `enrollee_added` with `join_mode = "self"`.
+3. **`join_quest_with_invite`** — commit-reveal flow for `Private` quests
+   (and optionally public ones that want single-use codes): the owner calls
+   `register_invite` with `sha256(secret)` computed off-chain, hands the raw
+   `secret` to the intended learner out of band, and the learner calls this
+   function with the preimage. The contract hashes it, checks the commitment
+   is registered and unused, marks it used, then enrolls. The secret itself
+   never touches the chain until redemption, so it can't be front-run by
+   watching pending transactions.
+
+`leave_quest` is the inverse of `add_enrollee`/`join_quest`, but it is
+enrollee-authenticated and can be blocked: if the owner has called
+`place_leave_hold` for that `(quest_id, enrollee)` pair — used while a
+peer-review submission from that enrollee is in flight in the `milestone`
+contract — `leave_quest` returns `LeaveBlockedByPendingApproval` until the
+owner calls `lift_leave_hold`. This exists purely so `milestone`'s
+peer-review bookkeeping never ends up pointing at an address that quietly
+un-enrolled mid-review.
+
+### Reads are visibility-blind
+
+`Visibility::Private` only removes a quest from the *discovery* indexes
+(`PublicQuests`, `PublicCategoryQuests`). It is not access control:
+`get_quest`, `get_enrollees`, `is_enrollee`, and `get_quest_version_history`
+all work on any quest ID regardless of visibility, as documented inline in
+the source. Anyone who already has the ID (e.g., from an invite link) can
+read it directly; "Private" only means "not on the public list."
+
+### Query/index maintenance
+
+Four `Vec<u32>`-based indexes (`PublicQuests`, `PublicCategoryQuests`,
+`OwnerQuests`, `EnrolleeQuests`) back the `list_*` query functions. They are
+maintained by two small helpers, `add_id_to_index` / `remove_id_from_index`,
+called from `create_quest`, `update_quest` (on category or visibility
+change), and enrollment/removal. There is no secondary index by name or
+deadline — category and owner/enrollee are the only supported filters at the
+contract level; anything else (search, sort) is expected to happen in the
+frontend once it has paginated through `list_public_quests` /
+`get_quests_by_category`.
+
+### TTL bumping
+
+Every mutating call ends by calling `Self::bump(&env, quest_id)`, which
+extends the TTL (see [`BUMP`/`THRESHOLD`](../adr/008-bump-threshold-rationale.md))
+on the instance storage plus the quest's own `Quest`, `Enrollees`, and
+`QuestVersionHistory` entries. Reads that touch persistent keys (`get_quest`,
+`get_enrollees`, `is_creator_verified`, the `list_*` functions) also extend
+TTL on the keys they read, so an actively-queried quest never silently
+expires even without writes.
+
+## Error surface
+
+`quest::Error` uses the shared low-numbered codes from `common`
+(`NotFound = 1`, `Unauthorized = 2`, `InvalidInput = 3`) plus contract-local
+codes for domain-specific rejections: `AlreadyEnrolled`, `NotEnrolled`,
+`QuestFull`, `QuestArchived`, `NameTooLong`, `DescriptionTooLong`,
+`InviteOnly`, `LeaveBlockedByPendingApproval`, `EnrollmentClosed`,
+`DeadlineExpired`, `InvalidInvite`, `InviteAlreadyUsed`, and the shared
+`Paused = 400`. Note `EnrollmentClosed` (archived) and `QuestArchived`
+(same underlying condition, different call sites) are distinct variants kept
+for stable ABI reasons — error codes are wire-format and must stay stable
+across upgrades, so existing codes are never renumbered or reused. See
+[`docs/contracts/ERROR_CONVENTIONS.md`](ERROR_CONVENTIONS.md) for the
+project-wide numbering rules and the full per-contract error tables.
+
+## What other contracts read from here
+
+| Caller | Function called | Why |
+|---|---|---|
+| `rewards::fund_quest` | `get_quest` | Confirms the funder is the quest owner and the quest's configured token matches the rewards pool's token |
+| `rewards::refund_pool` / `refund_unused_pool` | `get_quest` | Confirms `status == Archived` and reads `archived_at` for the grace-period check |
+| `rewards::refund_expired_pool` | `get_quest` | Reads `deadline` directly — this path deliberately does **not** require `Archived`, so an abandoned quest is still recoverable (issue #1187) |
+| `milestone::verify_completion` | `get_quest`, `is_enrollee` | Confirms the caller is the quest owner and the enrollee is actually enrolled before recording a completion |
+| `milestone::approve_completion` | `is_enrollee` | Confirms the approving peer is themselves enrolled in the quest (no owner check — peer review doesn't require the owner) |
+
+Both go through `milestone`'s private `is_enrolled` helper, which cross-calls
+`quest::is_enrollee` rather than trusting a client-supplied flag — see
+`contracts/milestone/src/lib.rs`.
+
+Because these calls are read-only (`get_quest`, `is_enrollee`, `is_expired`),
+`quest` never needs to grant or check auth for cross-contract callers — it
+answers the same way for any caller, contract or account.
+
+## Related documents
+
+- [`CONTRACTS_OVERVIEW.md`](../CONTRACTS_OVERVIEW.md) — one-page summary of all five contracts
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — end-to-end sequence diagrams (creation, enrollment, funding, verification, refunds)
+- [ADR-001](../adr/001-quest-entity-model-and-naming.md) — why "Quest" and the workspace-naming transition
+- [ADR-002](../adr/002-three-contract-architecture.md) — why `quest`/`milestone`/`rewards` are separate contracts with no cross-contract writes
+- [ADR-005](../adr/005-storage-patterns-and-ttl-strategy.md) / [ADR-006](../adr/006-storage-tier-optimization-and-caching.md) — storage tier and TTL policy this contract follows
+- [`docs/contracts/ERROR_CONVENTIONS.md`](ERROR_CONVENTIONS.md) — shared error-code numbering rules

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   Wallet,
   Sparkles,
   LayoutDashboard,
+  Loader2,
   Search,
   X,
 } from "lucide-react"
@@ -46,7 +47,7 @@ interface DashboardProps {
 }
 
 export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} as DashboardProps) {
-  const { connected, connect, shortAddress, address } = useWallet()
+  const { connected, connect, shortAddress, address, loading: walletConnecting } = useWallet()
   const [filter, setFilter] = useState<"all" | "owned" | "enrolled">("all")
   const [preset, setPreset] = useState<
     "none" | "ending-soon" | "recently-funded" | "recently-verified"
@@ -300,10 +301,20 @@ export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} 
               <Button
                 size="lg"
                 onClick={connect}
+                disabled={walletConnecting}
                 className="shimmer-on-hover animate-fade-in-up stagger-3"
               >
-                <Wallet className="h-4 w-4" />
-                Connect Wallet
+                {walletConnecting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  <>
+                    <Wallet className="h-4 w-4" />
+                    Connect Wallet
+                  </>
+                )}
               </Button>
 
               {/* Mini feature list */}

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -81,7 +81,7 @@ function WalletAvatar({ address }: { address: string }) {
 }
 
 export function Profile() {
-  const { connected, connect, address } = useWallet()
+  const { connected, connect, address, loading: walletConnecting } = useWallet()
   const [copied, setCopied] = useState(false)
   const [activeTab, setActiveTab] = useState<ProfileTab>("overview")
   const [activityItems, setActivityItems] = useState<WalletActivityItem[]>([])
@@ -301,10 +301,20 @@ export function Profile() {
               <Button
                 size="lg"
                 onClick={connect}
+                disabled={walletConnecting}
                 className="shimmer-on-hover animate-fade-in-up stagger-3"
               >
-                <Wallet className="h-4 w-4" />
-                Connect Wallet
+                {walletConnecting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  <>
+                    <Wallet className="h-4 w-4" />
+                    Connect Wallet
+                  </>
+                )}
               </Button>
 
               <div className="border-border animate-fade-in-up stagger-4 mt-8 border-t-2 pt-6">


### PR DESCRIPTION
## Summary

Resolves four assigned Stellar Wave issues:

- **#1187 — Add refund mechanism for unfunded quests.** The `rewards` contract's existing refund paths (`refund_pool`, `refund_unused_pool`) both require `QuestStatus::Archived`, which only the quest owner can set. If an owner funds a quest, sets a deadline, and then goes silent — never completing enough milestones to spend the pool and never archiving — those tokens had no recovery path. Added `refund_expired_pool()`, which lets the funding authority reclaim unused pool tokens once the quest's deadline has passed (plus the existing configurable grace period), independent of archival status. It reuses the same "pool minus reserved-but-unpaid obligations" accounting as `refund_unused_pool` so milestones an enrollee already qualified for remain payable after the refund. New error `Error::QuestNotExpired` added and documented in `docs/contracts/ERROR_CONVENTIONS.md`.
- **#1206 — Implement proper loading states.** The dashboard and profile pages' "Connect Wallet" buttons didn't reflect `useWallet()`'s `loading` state (a real network round-trip to the Freighter extension, up to a 10s timeout) — unlike the navbar, which already did. Both now show a spinner + "Connecting..." and disable the button while a connection attempt is in flight.
- **#1185 — Document QuestFactory (quest) contract architecture.** Added `docs/contracts/QUEST_CONTRACT.md`: a deep-dive on the `quest` contract's data model, storage layout, auth model, the three enrollment paths (owner-add / self-join / invite commit-reveal), versioning, TTL bumping, and what other contracts read from it. (There's no contract literally named "QuestFactory" in this codebase — `quest` is the factory/entry-point contract; the doc calls this out explicitly.)
- **#1184 — Create comprehensive contract unit tests.** Added edge-case coverage for the new `refund_expired_pool` path (no deadline, grace period, unauthorized, not funded, reserved-obligations, paused) and for the `certificate` contract, which had noticeably thinner coverage than `quest`/`milestone`/`rewards`: pause gating on both mint entry points, not-found lookups, `mint_quest_certificate`'s owner-as-issuer behavior, `get_certificate_details`, and two behavioral edge cases around revocation (a revoked cert's `(quest_id, recipient)` slot can be re-minted; revoking one of a user's certs doesn't touch their others).

## Incidental fix

While adding certificate tests I found `test_certificate_revocation` calling `revoke_certificate(&owner, &token_id)` — a stale two-arg call left over from a prior refactor that dropped the explicit `caller` parameter in favor of the `#[only_owner]` macro (current signature is `revoke_certificate(env, token_id)`). This meant `contracts/certificate/src/test.rs` didn't compile on `main`. Fixed both call sites.

## Test plan

- [x] `cargo build -p rewards` — new `refund_expired_pool` compiles cleanly
- [x] `cargo fmt` on all touched Rust files — clean (pre-existing formatting drift in untouched files left alone)
- [x] New test code manually cross-checked line-by-line against actual contract signatures (`create_quest`, `set_deadline`, `add_enrollee`, `verify_completion`, `distribute_reward`, `mint_certificate`, `revoke_certificate`, `pause`/`unpause`, etc.)
- [x] Frontend: `pnpm exec tsc -b`, `pnpm lint`, and `vitest run` on the touched pages (dashboard, profile) — clean, no new errors
- [ ] `cargo test --workspace` — **could not be executed in the sandboxed dev environment**: the pinned `rust-toolchain.toml` (1.80.0) cannot parse `Cargo.lock`'s `time-core` dependency, which requires edition2024 (stabilized in rustc 1.85+); newer local toolchains (1.85–1.91) hit either a `darling` MSRV floor or a `#[contractimpl]`/rustc-trait-solver incompatibility with the pinned `soroban-sdk` version. This reproduces identically on unmodified `main` (confirmed), and matches this repo's last ~15 CI runs, all of which are currently failing on `main` for unrelated reasons (e.g. a `react`/`react-dom` version mismatch from a recent dependabot bump). Please rely on CI/your local environment to run the full contract test suite.

Closes #1206
Closes #1187
Closes #1185
Closes #1184