### PR TITLE
fix: secure quest upgrades and frontend sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The blockchain IS the backend. All state lives on Stellar's ledger. Zero infrast
 - **TTL:** Bump 518,400 ledgers (~30 days), Threshold 120,960 (~7 days)
 - **No cross-contract calls** — frontend orchestrates the flow
 - **Gas & Resource Costs:** Detailed execution costs in [docs/GAS_COSTS.md](docs/GAS_COSTS.md)
+- **Gas Optimization Report:** [docs/GAS_OPTIMIZATION_REPORT.md](docs/GAS_OPTIMIZATION_REPORT.md)
 
 </details>
 

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -2,7 +2,8 @@
 
 use common::{extend_instance_ttl, extend_persistent_ttl, BUMP, THRESHOLD};
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String, Symbol,
+    Vec,
 };
 use stellar_access::ownable::{self as ownable, Ownable};
 use stellar_macros::{default_impl, only_owner};
@@ -69,6 +70,19 @@ impl CertificateContract {
         ownable::set_owner(&env, &owner);
         // before: env.storage().instance().extend_ttl(THRESHOLD, BUMP);
         extend_instance_ttl(&env);
+    }
+
+    /// Returns the owner, which is this contract's administrator role.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        ownable::get_owner(&env).ok_or(Error::NotOwner)
+    }
+
+    /// Upgrade this contract's WASM. The `only_owner` guard enforces the
+    /// administrator role before Soroban replaces the current code.
+    #[only_owner]
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
     #[only_owner]

--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 use common::{extend_instance_ttl, QuestInfo, BUMP, MAX_REWARD_AMOUNT, THRESHOLD};
 use soroban_sdk::{
-    contract, contractclient, contracterror, contractimpl, contracttype, Address, Env, String,
-    Symbol, Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, Address, BytesN, Env,
+    String, Symbol, Vec,
 };
 
 // Quest contract error type (must match the quest contract)
@@ -239,6 +239,21 @@ impl MilestoneContract {
             .instance()
             .set(&DataKey::CertificateContract, &certificate_contract);
         extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Returns the address that holds the contract-administrator role.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)
+    }
+
+    /// Upgrade this contract's WASM. Only the stored administrator can invoke it.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
 

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -42,6 +42,9 @@ pub enum DataKey {
     LeaveHold(u32, Address),
     /// Version history for a quest. Stores a Vec of QuestVersion snapshots.
     QuestVersionHistory(u32),
+    /// Schema version recorded after an administrator migrates a quest.
+    /// Appended so existing DataKey encodings remain stable across upgrades.
+    QuestSchemaVersion(u32),
 }
 
 // QuestInfo moved to common.
@@ -86,6 +89,10 @@ pub enum Error {
 // TTL constants and address validation moved to common.
 const MAX_TAGS: u32 = 5;
 const MAX_TAG_LEN: u32 = 32;
+/// Current on-chain layout of QuestInfo. Bump only alongside a migration.
+const QUEST_DATA_SCHEMA_VERSION: u32 = 1;
+/// Bound migration work so an administrator cannot exceed transaction limits.
+const MAX_MIGRATION_BATCH: u32 = 25;
 
 fn is_blank_ascii(s: &String) -> bool {
     let len = s.len() as usize;
@@ -139,6 +146,7 @@ pub struct QuestContract;
 impl QuestContract {
     /// Initialize the quest contract with an admin.
     pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::Unauthorized);
         }
@@ -146,6 +154,74 @@ impl QuestContract {
         env.storage().instance().set(&DataKey::Paused, &false);
         extend_instance_ttl(&env);
         Ok(())
+    }
+
+    /// Returns the address that holds the contract-administrator role.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotFound)
+    }
+
+    /// Upgrade this contract's WASM. Only the stored administrator can invoke it.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
+    }
+
+    /// Mark a bounded set of quests as migrated to the current schema.
+    ///
+    /// The current v1 migration is a validated re-serialization pass. Future
+    /// schema revisions must update this function with their explicit
+    /// transformation before increasing `QUEST_DATA_SCHEMA_VERSION`.
+    pub fn migrate_quest_data(
+        env: Env,
+        admin: Address,
+        quest_ids: Vec<u32>,
+        target_schema_version: u32,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        Self::require_not_paused(&env)?;
+        if quest_ids.len() == 0
+            || quest_ids.len() > MAX_MIGRATION_BATCH
+            || target_schema_version != QUEST_DATA_SCHEMA_VERSION
+        {
+            return Err(Error::InvalidInput);
+        }
+
+        // Validate all IDs before writing so an invalid batch has no effects.
+        for quest_id in quest_ids.iter() {
+            Self::load_quest(&env, quest_id)?;
+        }
+        for quest_id in quest_ids.iter() {
+            let quest = Self::load_quest(&env, quest_id)?;
+            let quest_key = DataKey::Quest(quest_id);
+            let version_key = DataKey::QuestSchemaVersion(quest_id);
+            env.storage().persistent().set(&quest_key, &quest);
+            env.storage()
+                .persistent()
+                .set(&version_key, &target_schema_version);
+            common::extend_persistent_ttl(&env, &quest_key);
+            common::extend_persistent_ttl(&env, &version_key);
+            env.events().publish(
+                (Symbol::new(&env, "quest_migrated"),),
+                (quest_id, target_schema_version),
+            );
+        }
+        extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Returns the recorded schema version; legacy quests are version 1.
+    pub fn get_quest_schema_version(env: Env, quest_id: u32) -> Result<u32, Error> {
+        Self::load_quest(&env, quest_id)?;
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuestSchemaVersion(quest_id))
+            .unwrap_or(1))
     }
 
     /// Verify a creator address. Admin only.

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1409,6 +1409,7 @@ fn test_enrollee_cap() {
 #[test]
 fn test_initialize_admin() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register(QuestContract, ());
     let client = QuestContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -1418,6 +1419,39 @@ fn test_initialize_admin() {
     // Try to initialize again should fail
     let result = client.try_initialize(&admin);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_migrate_quest_data_records_schema_version() {
+    let (env, client, owner, token) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    create_quest_helper(&env, &client, &owner, &token);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(0);
+    client.migrate_quest_data(&admin, &ids, &1);
+
+    assert_eq!(client.get_quest_schema_version(&0), 1);
+}
+
+#[test]
+fn test_migrate_quest_data_validates_entire_batch_before_writing() {
+    let (env, client, owner, token) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    create_quest_helper(&env, &client, &owner, &token);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(0);
+    ids.push_back(99);
+    let result = client.try_migrate_quest_data(&admin, &ids, &1);
+
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+    let version_key = DataKey::QuestSchemaVersion(0);
+    let migrated =
+        env.as_contract(&client.address, || env.storage().persistent().has(&version_key));
+    assert!(!migrated);
 }
 
 #[test]

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 use common::{extend_instance_ttl, QuestInfo, QuestStatus, BUMP, MAX_REWARD_AMOUNT, THRESHOLD};
 use soroban_sdk::{
-    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, Env,
-    Symbol,
+    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
+    Env, Symbol,
 };
 
 // Visibility, QuestStatus, and QuestInfo moved to common.
@@ -119,6 +119,7 @@ impl RewardsContract {
         quest_contract_addr: Address,
         milestone_contract_addr: Address,
     ) -> Result<(), Error> {
+        admin.require_auth();
         if env.storage().instance().has(&DataKey::TokenAddr) {
             return Err(Error::AlreadyInitialized);
         }
@@ -141,6 +142,25 @@ impl RewardsContract {
             .set(&DataKey::RefundGracePeriod, &604_800_u64);
         env.storage().instance().set(&DataKey::Paused, &false);
         extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Returns the address that holds the contract-administrator role.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)
+    }
+
+    /// Upgrade this contract's WASM. Only the stored administrator can invoke it.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = Self::get_admin(env.clone())?;
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
 

--- a/docs/GAS_OPTIMIZATION_REPORT.md
+++ b/docs/GAS_OPTIMIZATION_REPORT.md
@@ -1,0 +1,42 @@
+# Contract Gas Optimization Report
+
+## Scope and method
+
+This report covers the common write paths in `quest`, `milestone`, and
+`rewards`, with particular attention to milestone completion. Measurements in
+[GAS_COSTS.md](GAS_COSTS.md) are planning estimates; production release checks
+must use `stellar contract invoke --build-only` against the target network and
+record the simulated transaction resources before deployment.
+
+## Findings and implemented safeguards
+
+| Path | Cost driver | Optimization in the codebase | Result |
+|---|---|---|---|
+| `get_milestone_count` | Scanning a milestone list | Persistent `MilestoneCount(quest_id)` counter | O(1) count read |
+| `get_quest_completion_rate` | Unbounded enrollee iteration | Explicit, capped page (`MAX_COMPLETION_RATE_PAGE = 100`) | Bounded CPU and read footprint |
+| `create_milestones_batch` | Repeated transaction base fee | Batch entry point with `MAX_BATCH_SIZE = 20` | One base transaction fee for a bounded batch |
+| `verify_completion` | Repeated completion and reward bookkeeping | Persistent completion flag and idempotent payout record | Duplicate calls fail before a token transfer |
+| `refund_pool` | Recomputing outstanding rewards | Persistent reserved-reward and distributed aggregates | Avoids scanning completion history |
+
+## Milestone verification profile
+
+`verify_completion` is intentionally the most expensive normal milestone
+operation because it validates the quest/enrollee relationship, writes the
+completion state, maintains aggregates, and may mint a certificate. The
+estimated profile is approximately four ledger reads and two writes before the
+certificate call. It must remain a single verification transaction: splitting
+the state update from the reward/certificate actions would introduce a
+double-payment or partial-completion risk.
+
+The recommended operational flow is to simulate each production transaction,
+reject a transaction that exceeds the deployed resource budget, and use batch
+creation for setup rather than batching completions. Completion batching would
+make failure recovery and user authorization materially less safe.
+
+## Release checklist
+
+- Run `cargo test --workspace` and `cargo clippy --workspace --all-targets`.
+- Build release WASM and verify the size limits in the upgrade runbook.
+- Simulate `create_milestone`, `verify_completion`, and `distribute_reward`
+  with representative payload sizes on the intended network.
+- Record the resulting resource footprint alongside the release's WASM hash.

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -31,9 +31,9 @@ explicitly.
 > `Admin` address. This function is the only upgrade surface; upgrading via
 > other means is not supported.
 >
-> **Current state (2026-07):** No contract yet ships this entry point. Adding
-> it is a required step before any contract can be upgraded without full
-> redeployment. The runbook tracks this as a prerequisite.
+> **Current state (2026-07):** All four contracts expose an admin-gated
+> `upgrade` entry point. The quest contract additionally exposes a bounded,
+> admin-gated `migrate_quest_data` entry point for schema migration batches.
 
 ---
 

--- a/docs/operations/contract-upgrade-runbook.md
+++ b/docs/operations/contract-upgrade-runbook.md
@@ -33,7 +33,7 @@ Lernza contracts must expose an `upgrade` function before they can be upgraded
 without full redeployment:
 
 ```rust
-// Required in every upgradeable contract (not yet present — see note below)
+// Required in every upgradeable contract
 pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
     admin.require_auth();
     Self::require_admin(&env, &admin)?;
@@ -42,11 +42,6 @@ pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<()
 }
 ```
 
-> **Current state:** No Lernza contract ships this entry point yet. If it is
-> absent, the only upgrade path is a full redeployment followed by
-> re-initialization and frontend reconfiguration. Complete the work to add
-> `upgrade` to a contract **before** scheduling an in-place upgrade.
->
 > Confirm which contracts have `upgrade` before proceeding:
 > ```bash
 > grep -r "fn upgrade" contracts/
@@ -285,6 +280,16 @@ stellar contract invoke \
   -- migrate_<entity> \
   --admin <ADMIN_ADDRESS> \
   --ids '[0, 1, 2, ...]'   # batch of IDs to migrate
+```
+
+For quest data migrations, use the checked batching utility after the WASM
+upgrade succeeds. Start with `--dry-run`, then submit the same command only
+after reviewing the constructed transaction:
+
+```bash
+./scripts/migrate-quest-data.sh \
+  --network testnet --source lernza-admin --contract-id <QUEST_CONTRACT_ID> \
+  --quest-ids 0,1,2 --schema-version 1 --dry-run
 ```
 
 For large state sets, run in batches to stay within the transaction fee budget.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from "react"
+import type { ReactNode } from "react"
 import { Analytics } from "@vercel/analytics/react"
 import { SpeedInsights } from "@vercel/speed-insights/react"
 import { Navbar } from "@/components/navbar"
@@ -11,6 +12,7 @@ import { TermsOfService } from "@/pages/terms"
 import { PrivacyPolicy } from "@/pages/privacy"
 import { PageSkeleton } from "@/components/page-skeleton"
 import { NotificationProvider } from "@/contexts/notification-context"
+import { useWallet } from "@/hooks/use-wallet"
 
 // Code-split heavy pages — they load on first visit to that route.
 const Dashboard = lazy(() => import("@/pages/dashboard").then((m) => ({ default: m.Dashboard })))
@@ -33,6 +35,26 @@ const VALID_PAGES = [
   "privacy",
 ] as const
 type Page = (typeof VALID_PAGES)[number] | "quest" | "creator" | "404"
+const PROTECTED_PAGES: ReadonlySet<Page> = new Set(["dashboard", "profile", "create-quest"])
+
+function SessionGuard({ children, onDenied }: { children: ReactNode; onDenied: () => void }) {
+  const { verifySession } = useWallet()
+  const [verified, setVerified] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    void verifySession().then(isValid => {
+      if (!active) return
+      if (isValid) setVerified(true)
+      else onDenied()
+    })
+    return () => {
+      active = false
+    }
+  }, [onDenied, verifySession])
+
+  return verified ? <>{children}</> : <PageSkeleton />
+}
 
 function pathToPage(pathname: string): {
   page: Page
@@ -100,6 +122,11 @@ function App() {
     window.history.pushState(null, "", path)
     setState({ page: "quest", questId: id, creatorAddress: null })
     window.scrollTo({ top: 0, behavior: "smooth" })
+  }, [])
+
+  const redirectToLanding = useCallback(() => {
+    window.history.replaceState(null, "", "/")
+    setState({ page: "landing", questId: null, creatorAddress: null })
   }, [])
 
   useEffect(() => {
@@ -175,7 +202,13 @@ function App() {
               <Navbar activePage={state.page} onNavigate={handleNavigate} />
             </SectionErrorBoundary>
             <ErrorBoundary key={`${state.page}-${state.questId ?? state.creatorAddress ?? ""}`}>
-              <main id="main-content">{renderPage()}</main>
+              <main id="main-content">
+                {PROTECTED_PAGES.has(state.page) ? (
+                  <SessionGuard onDenied={redirectToLanding}>{renderPage()}</SessionGuard>
+                ) : (
+                  renderPage()
+                )}
+              </main>
             </ErrorBoundary>
             <Analytics />
             <SpeedInsights />

--- a/frontend/src/hooks/use-wallet.test.ts
+++ b/frontend/src/hooks/use-wallet.test.ts
@@ -129,6 +129,38 @@ describe("useWallet - disconnect", () => {
   })
 })
 
+describe("useWallet - session verification", () => {
+  it("rejects a stale connected state when wallet permission has been revoked", async () => {
+    mockFreighter.requestAccess.mockResolvedValue({ address: "GABC1234" })
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+    mockFreighter.getAddress.mockRejectedValue(new Error("Not authorized"))
+
+    await act(async () => {
+      await expect(result.current.verifySession()).resolves.toBe(false)
+    })
+
+    expect(result.current.connected).toBe(false)
+    expect(result.current.address).toBeNull()
+  })
+
+  it("refreshes the account from Freighter before accepting a protected session", async () => {
+    mockFreighter.getAddress.mockResolvedValue({ address: "GVERIFIED" })
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await expect(result.current.verifySession()).resolves.toBe(true)
+    })
+
+    expect(mockFreighter.getAddress).toHaveBeenCalled()
+    expect(result.current.address).toBe("GVERIFIED")
+    expect(result.current.connected).toBe(true)
+  })
+})
+
 describe("useWallet - auto reconnect", () => {
   it("loads address and network when previously authorized", async () => {
     mockFreighter.getAddress.mockResolvedValue({ address: "GXYZ5678" })

--- a/frontend/src/hooks/use-wallet.tsx
+++ b/frontend/src/hooks/use-wallet.tsx
@@ -94,6 +94,8 @@ const freighterApi = freighter as unknown as FreighterApi
 type WalletContextValue = WalletState & {
   installUrl: string
   connect: () => Promise<void>
+  /** Re-checks wallet permission and the active account before protected use. */
+  verifySession: () => Promise<boolean>
   disconnect: () => void
   shortAddress: string | null
 }
@@ -302,6 +304,33 @@ function useWalletState(): WalletContextValue {
     clearConnection()
   }, [clearConnection])
 
+  const verifySession = useCallback(async (): Promise<boolean> => {
+    if (getManualDisconnect()) {
+      clearConnection()
+      return false
+    }
+
+    try {
+      const installed = await detectFreighter()
+      if (!installed) {
+        clearConnection()
+        return false
+      }
+      const { address } = await withTimeout(freighterApi.getAddress(), TIMEOUT_MS, TIMEOUT_ERROR)
+      if (!address) {
+        clearConnection()
+        return false
+      }
+      await syncNetwork()
+      setState(s => ({ ...s, address, connected: true, loading: false, error: null }))
+      return true
+    } catch {
+      // A stale React state value must never be accepted as a valid session.
+      clearConnection()
+      return false
+    }
+  }, [clearConnection, detectFreighter, syncNetwork])
+
   useEffect(() => {
     let active = true
 
@@ -400,12 +429,13 @@ function useWalletState(): WalletContextValue {
       ...state,
       installUrl: FREIGHTER_INSTALL_URL,
       connect,
+      verifySession,
       disconnect,
       shortAddress: state.address
         ? `${state.address.slice(0, 4)}...${state.address.slice(-4)}`
         : null,
     }),
-    [connect, disconnect, state]
+    [connect, disconnect, state, verifySession]
   )
 }
 

--- a/scripts/migrate-quest-data.sh
+++ b/scripts/migrate-quest-data.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Safely migrate bounded batches of quest records after a compatible contract upgrade.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/migrate-quest-data.sh --network <network> --source <key> --contract-id <id> --quest-ids <comma-separated IDs> [options]
+
+Required:
+  --network <network>       Stellar CLI network name (for example: testnet)
+  --source <key>            Administrator key name or address
+  --contract-id <id>        Upgraded quest contract ID
+  --quest-ids <ids>         Comma-separated unique quest IDs (for example: 0,1,2)
+
+Options:
+  --schema-version <n>      Target schema version (default: 1)
+  --batch-size <n>          IDs per invocation, 1-25 (default: 25)
+  --dry-run                 Build transactions without submitting them
+  -h, --help                Show this help
+
+The script invokes the contract's admin-gated migrate_quest_data entry point.
+It validates every ID and submits no transaction until all local validation passes.
+EOF
+}
+
+network=""
+source_key=""
+contract_id=""
+quest_ids=""
+schema_version="1"
+batch_size="25"
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network) network="${2:-}"; shift 2 ;;
+    --source) source_key="${2:-}"; shift 2 ;;
+    --contract-id) contract_id="${2:-}"; shift 2 ;;
+    --quest-ids) quest_ids="${2:-}"; shift 2 ;;
+    --schema-version) schema_version="${2:-}"; shift 2 ;;
+    --batch-size) batch_size="${2:-}"; shift 2 ;;
+    --dry-run) dry_run=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$network" || -z "$source_key" || -z "$contract_id" || -z "$quest_ids" ]]; then
+  echo "--network, --source, --contract-id, and --quest-ids are required." >&2
+  usage >&2
+  exit 2
+fi
+if ! [[ "$schema_version" =~ ^[1-9][0-9]*$ ]] || ! [[ "$batch_size" =~ ^([1-9]|1[0-9]|2[0-5])$ ]]; then
+  echo "Schema version must be positive and batch size must be between 1 and 25." >&2
+  exit 2
+fi
+if ! command -v stellar >/dev/null 2>&1; then
+  echo "stellar CLI is required; install it before running a migration." >&2
+  exit 1
+fi
+
+IFS=',' read -r -a ids <<< "$quest_ids"
+declare -A seen=()
+for id in "${ids[@]}"; do
+  if ! [[ "$id" =~ ^[0-9]+$ ]]; then
+    echo "Invalid quest ID: $id" >&2
+    exit 2
+  fi
+  if [[ -n "${seen[$id]:-}" ]]; then
+    echo "Duplicate quest ID: $id" >&2
+    exit 2
+  fi
+  seen[$id]=1
+done
+
+for ((start = 0; start < ${#ids[@]}; start += batch_size)); do
+  batch=("${ids[@]:start:batch_size}")
+  joined=$(IFS=','; echo "${batch[*]}")
+  args=(contract invoke --network "$network" --source "$source_key" --id "$contract_id")
+  if [[ "$dry_run" == true ]]; then
+    args+=(--build-only)
+  fi
+  args+=(-- migrate_quest_data --admin "$source_key" --quest_ids "[$joined]" --target_schema_version "$schema_version")
+
+  echo "Migrating quest IDs: $joined"
+  stellar "${args[@]}"
+done


### PR DESCRIPTION
## Summary

- Added safe, admin-authorized quest schema migration tooling with bounded batches and dry-run support.
- Enforced authenticated wallet session verification before protected frontend routes render.
- Added admin-only contract upgrade entry points and hardened contract initialization authorization.
- Added a gas optimization report covering milestone verification and common contract paths.

Resolves #1197
Resolves #1194
Resolves #1193
Resolves #1199

## Verification

- `bash -n scripts/migrate-quest-data.sh`
- Migration script help and duplicate-ID validation verified.
- `git diff --check`

Note: full Rust checks could not run because the local Rust 1.80 toolchain is partially installed/corrupt outside the repository. Frontend suite/type-check is also blocked by existing dependency conflicts (React/ReactDOM mismatch, missing Storybook test dependency, and unavailable Playwright browser).