### PR TITLE
fix(milestone): add Percentage distribution mode with integer roundin…

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -90,6 +90,7 @@ pub enum DistributionMode {
     Custom,           // per-milestone reward_amount (default)
     Flat,             // equal reward for all milestones
     Competitive(u32), // max_winners: first N completers rewarded; rest get 0
+    Percentage(u32),  // percent (1..=100) of milestone.reward_amount, rounded to nearest
 }
 
 #[contracttype]
@@ -527,6 +528,10 @@ impl MilestoneContract {
             return Err(Error::InvalidInput);
         }
 
+        if matches!(mode, DistributionMode::Percentage(p) if p == 0 || p > 100) {
+            return Err(Error::InvalidInput);
+        }
+
         let mode_key = DataKey::Mode(quest_id);
         env.storage().persistent().set(&mode_key, &mode);
         env.storage()
@@ -696,6 +701,16 @@ impl MilestoneContract {
                 .persistent()
                 .get(&DataKey::FlatReward(quest_id))
                 .ok_or(Error::FlatRewardNotConfigured)?,
+            DistributionMode::Percentage(pct) => {
+                // Compute reward = round(milestone.reward_amount * pct / 100)
+                let pct_i: i128 = pct as i128;
+                let prod = milestone
+                    .reward_amount
+                    .checked_mul(pct_i)
+                    .ok_or(Error::Overflow)?;
+                let with_round = prod.checked_add(50).ok_or(Error::Overflow)?; // round to nearest
+                with_round / 100
+            }
             DistributionMode::Competitive(max_winners) => {
                 let cnt_key = DataKey::MilestoneCompletionTotal(quest_id, milestone_id);
                 let cnt: u32 = env.storage().persistent().get(&cnt_key).unwrap_or(0);
@@ -1049,6 +1064,15 @@ impl MilestoneContract {
                         return Err(Error::FlatRewardNotConfigured);
                     }
                     snapshot.flat_reward
+                }
+                DistributionMode::Percentage(pct) => {
+                    let pct_i: i128 = pct as i128;
+                    let prod = snapshot
+                        .reward_amount
+                        .checked_mul(pct_i)
+                        .ok_or(Error::Overflow)?;
+                    let with_round = prod.checked_add(50).ok_or(Error::Overflow)?;
+                    with_round / 100
                 }
                 DistributionMode::Competitive(max_winners) => {
                     let cnt_key = DataKey::MilestoneCompletionTotal(quest_id, milestone_id);

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -367,6 +367,31 @@ fn test_get_distribution_mode_and_flat_reward_after_set() {
 }
 
 #[test]
+fn test_percentage_mode_rounding_to_nearest() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    // Milestone with reward_amount 101 to exercise rounding (75% -> 75.75)
+    create_ms(&env, &client, &owner, q_id, "Task", 101);
+
+    // Set Percentage mode to 75%
+    client.set_distribution_mode(&owner, &q_id, &DistributionMode::Percentage(75), &0);
+
+    let enrollee = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &enrollee);
+
+    // 75% of 101 = 75.75 -> rounded to nearest = 76
+    assert_eq!(client.verify_completion(&owner, &q_id, &0, &enrollee), 76);
+
+    // Now test exact case: 100 * 75% = 75
+    let q2 = create_quest(&env, &quest_client, &owner);
+    create_ms(&env, &client, &owner, q2, "Task2", 100);
+    client.set_distribution_mode(&owner, &q2, &DistributionMode::Percentage(75), &0);
+    let e2 = Address::generate(&env);
+    quest_client.add_enrollee(&q2, &e2);
+    assert_eq!(client.verify_completion(&owner, &q2, &0, &e2), 75);
+}
+
+#[test]
 fn test_custom_mode_uses_per_milestone_amounts() {
     let (env, client, quest_client, owner) = setup();
     let q_id = create_quest(&env, &quest_client, &owner);


### PR DESCRIPTION
bug(contracts): Milestone verify_completion with Percentage reward mode doesn't round consistently — off-by-one token possible

Closes #1344
