### PR TITLE
fix(frontend): add deterministic tie-breaker to leaderboard sorting Closes #1337

### DIFF
--- a/frontend/src/pages/leaderboard.test.tsx
+++ b/frontend/src/pages/leaderboard.test.tsx
@@ -23,11 +23,28 @@ vi.mock("@/lib/contracts/client", () => ({
   withTimeout: <T,>(promise: Promise<T>) => promise,
 }))
 
+vi.mock("@/lib/contracts/quest", () => ({
+  questClient: {
+    listPublicQuests: vi.fn(),
+    getEnrollees: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/contracts/rewards", () => ({
+  rewardsClient: {
+    getUserEarnings: vi.fn(),
+  },
+}))
+
 import { useAsyncData } from "@/hooks/use-async-data"
 import { useWallet } from "@/hooks/use-wallet"
+import { questClient } from "@/lib/contracts/quest"
+import { rewardsClient } from "@/lib/contracts/rewards"
 
 const mockUseWallet = vi.mocked(useWallet)
-import { Leaderboard } from "./leaderboard"
+const mockQuestClient = vi.mocked(questClient, true)
+const mockRewardsClient = vi.mocked(rewardsClient, true)
+import { Leaderboard, fetchTopEarners, fetchMostActiveQuests } from "./leaderboard"
 
 const mockUseAsyncData = vi.mocked(useAsyncData)
 
@@ -90,5 +107,59 @@ describe("Leaderboard", () => {
 
     const questLink = screen.getByText("Quest Alpha").closest("a")
     expect(questLink).toHaveAttribute("href", "/quest/42")
+  })
+})
+
+describe("fetchTopEarners tie-breaking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("orders tied earners deterministically by address, regardless of enrollee order", async () => {
+    mockQuestClient.listPublicQuests.mockResolvedValue([
+      { id: 1, name: "Quest One" } as unknown as Awaited<
+        ReturnType<typeof questClient.listPublicQuests>
+      >[number],
+    ])
+    // Enrollee order is not sorted by address on purpose, to prove the
+    // ranking doesn't just fall out of Set insertion order.
+    mockQuestClient.getEnrollees.mockResolvedValue(["GBBB", "GAAA", "GCCC"])
+    // All three have identical earnings, so this is a full tie.
+    mockRewardsClient.getUserEarnings.mockResolvedValue(100n)
+
+    const runs = await Promise.all([fetchTopEarners(), fetchTopEarners(), fetchTopEarners()])
+
+    const addressOrder = runs.map(run => run.map(e => e.address))
+    // Every run should produce the exact same order.
+    expect(addressOrder[1]).toEqual(addressOrder[0])
+    expect(addressOrder[2]).toEqual(addressOrder[0])
+    // And that order should be ascending by address, not insertion order.
+    expect(addressOrder[0]).toEqual(["GAAA", "GBBB", "GCCC"])
+  })
+})
+
+describe("fetchMostActiveQuests tie-breaking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("orders quests with equal enrollee counts deterministically by id", async () => {
+    mockQuestClient.listPublicQuests.mockResolvedValue([
+      { id: 30, name: "Quest C" },
+      { id: 10, name: "Quest A" },
+      { id: 20, name: "Quest B" },
+    ] as unknown as Awaited<ReturnType<typeof questClient.listPublicQuests>>)
+    mockQuestClient.getEnrollees.mockResolvedValue(["G1", "G2"]) // same count for all quests
+
+    const runs = await Promise.all([
+      fetchMostActiveQuests(),
+      fetchMostActiveQuests(),
+      fetchMostActiveQuests(),
+    ])
+
+    const idOrder = runs.map(run => run.map(q => q.id))
+    expect(idOrder[1]).toEqual(idOrder[0])
+    expect(idOrder[2]).toEqual(idOrder[0])
+    expect(idOrder[0]).toEqual([10, 20, 30])
   })
 })

--- a/frontend/src/pages/leaderboard.tsx
+++ b/frontend/src/pages/leaderboard.tsx
@@ -29,7 +29,7 @@ interface ActiveQuestEntry {
 
 const PAGE_SIZE = 50
 
-async function fetchTopEarners(offset: number = 0): Promise<EarnerEntry[]> {
+export async function fetchTopEarners(offset: number = 0): Promise<EarnerEntry[]> {
   const quests = await questClient.listPublicQuests(offset, PAGE_SIZE)
   const enrolleeSets = await Promise.all(quests.map(q => questClient.getEnrollees(q.id)))
 
@@ -48,11 +48,17 @@ async function fetchTopEarners(offset: number = 0): Promise<EarnerEntry[]> {
   )
 
   return entries
-    .sort((a, b) => (b.totalEarned > a.totalEarned ? 1 : b.totalEarned < a.totalEarned ? -1 : 0))
+    .sort((a, b) => {
+      if (b.totalEarned > a.totalEarned) return 1
+      if (b.totalEarned < a.totalEarned) return -1
+      // Tie-breaker: deterministic ascending address order so ranking
+      // doesn't reshuffle between refreshes when earnings are equal.
+      return a.address.localeCompare(b.address)
+    })
     .map((e, i) => ({ ...e, rank: offset + i + 1 }))
 }
 
-async function fetchMostActiveQuests(offset: number = 0): Promise<ActiveQuestEntry[]> {
+export async function fetchMostActiveQuests(offset: number = 0): Promise<ActiveQuestEntry[]> {
   const quests = await questClient.listPublicQuests(offset, PAGE_SIZE)
   const withCounts = await Promise.all(
     quests.map(async q => {
@@ -62,7 +68,12 @@ async function fetchMostActiveQuests(offset: number = 0): Promise<ActiveQuestEnt
   )
 
   return withCounts
-    .sort((a, b) => b.enrolleeCount - a.enrolleeCount)
+    .sort((a, b) => {
+      if (b.enrolleeCount !== a.enrolleeCount) return b.enrolleeCount - a.enrolleeCount
+      // Tie-breaker: deterministic ascending id order so ranking
+      // doesn't reshuffle between refreshes when enrollee counts are equal.
+      return a.id - b.id
+    })
     .map((q, i) => ({ ...q, rank: offset + i + 1 }))
 }
 


### PR DESCRIPTION

Summary

Fixes #1337 — leaderboard sort order was non-deterministic between refreshes when multiple users/quests tied on the primary sort key.

Root cause

Both leaderboard queries sorted only on a primary key with no secondary tie-breaker:

Top Earners — sorted by totalEarned only
Most Active Quests — sorted by enrolleeCount only

When two or more entries tied on that key, their relative order fell out of upstream iteration order (Set insertion order for addresses, async resolution timing for enrollee lists) rather than anything deterministic — so refreshing the page could reshuffle tied users/quests.

Fix

Added a deterministic secondary sort to both comparators in frontend/src/pages/leaderboard.tsx:

Top Earners: on equal totalEarned, tie-break by address (ascending, localeCompare)
Most Active Quests: on equal enrolleeCount, tie-break by id (ascending)

Both tie-breakers use data already present on each entry — no new fields or API calls needed.

Testing
Exported fetchTopEarners / fetchMostActiveQuests so they can be unit tested directly
Added tests that feed in fully-tied scores/counts with scrambled input order, run each function 3x, and assert identical, address/id-ascending output on every run
npx tsc --noEmit — clean
npx eslint — 0 errors (2 pre-existing warnings unchanged, 2 new non-blocking react-refresh warnings from exporting the two functions for testability)

Notes for reviewers
While testing, found the existing test "quest row links to the quest detail page" fails on main as well (unrelated getByRole query issue) — not touched by this PR, flagging separately in case it's worth its own issue.
If you'd rather avoid the react-refresh/only-export-components lint warnings, I'm happy to move the two fetch functions into a separate lib/ module instead — let me know your preference.