### PR TITLE
fix(frontend): validate uploaded CSV file size

### DIFF
--- a/frontend/src/pages/create-quest/csv-import-dialog.tsx
+++ b/frontend/src/pages/create-quest/csv-import-dialog.tsx
@@ -19,24 +19,50 @@ export function CsvImportDialog({ isOpen, onClose, onImport }: CsvImportDialogPr
 
   if (!isOpen) return null
 
-  const handleFileSelect = (selectedFile: File) => {
-    if (!selectedFile.name.endsWith(".csv")) {
-      setParseResult({
-        milestones: [],
-        errors: [{ row: 0, field: "file", message: "Only .csv files are supported" }],
-      })
-      return
-    }
+const handleFileSelect = (selectedFile: File) => {
+  const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2 MB
 
-    setFile(selectedFile)
-    const reader = new FileReader()
-    reader.onload = e => {
-      const text = e.target?.result as string
-      const result = parseCsvMilestones(text || "")
-      setParseResult(result)
-    }
-    reader.readAsText(selectedFile)
+  if (selectedFile.size > MAX_FILE_SIZE) {
+    setFile(null)
+    setParseResult({
+      milestones: [],
+      errors: [
+        {
+          row: 0,
+          field: "file",
+          message: "File size must be 2 MB or smaller.",
+        },
+      ],
+    })
+    return
   }
+
+  if (!selectedFile.name.endsWith(".csv")) {
+    setFile(null)
+    setParseResult({
+      milestones: [],
+      errors: [
+        {
+          row: 0,
+          field: "file",
+          message: "Only .csv files are supported.",
+        },
+      ],
+    })
+    return
+  }
+
+  setFile(selectedFile)
+
+  const reader = new FileReader()
+  reader.onload = e => {
+    const text = e.target?.result as string
+    const result = parseCsvMilestones(text || "")
+    setParseResult(result)
+  }
+
+  reader.readAsText(selectedFile)
+}
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files


### PR DESCRIPTION
## What does this PR do?

Adds client-side file size validation to the existing CSV import dialog. Files larger than 2 MB are rejected with a clear validation message before processing begins.

Closes #1341 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## How Has This Been Tested?

- Selected a CSV file smaller than 2 MB and verified it imports normally.
- Selected a file larger than 2 MB and verified a validation error is shown.
- Verified existing CSV parsing behavior remains unchanged.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have tested my changes locally.
- [x] I have not introduced unrelated changes.
- [x] My changes are focused on improving client-side validation.
