### PR TITLE
feat(frontend): reputation system, contract interaction suite and Freighter integration tests

### DIFF
--- a/frontend/src/components/reputation-badge.test.tsx
+++ b/frontend/src/components/reputation-badge.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react"
+import { axe } from "vitest-axe"
+import { describe, expect, it } from "vitest"
+
+import { ReputationBadge } from "./reputation-badge"
+import { getTierVariant } from "./reputation-badge.variants"
+import { calculateReputation, type ReputationSummary } from "@/lib/reputation"
+
+const NOW = Date.UTC(2025, 0, 1)
+
+function summary(overrides: Partial<ReputationSummary> = {}): ReputationSummary {
+  return {
+    score: 200,
+    tier: "Bronze",
+    completionRate: 1,
+    averageRating: 4,
+    ratingCount: 3,
+    interactions: 8,
+    confidence: 1,
+    ...overrides,
+  }
+}
+
+describe("ReputationBadge", () => {
+  it("renders the tier and score by default", () => {
+    render(<ReputationBadge summary={summary({ tier: "Gold", score: 640 })} />)
+
+    expect(screen.getByText("Gold")).toBeInTheDocument()
+    expect(screen.getByText("640")).toBeInTheDocument()
+  })
+
+  it("hides the numeric score when showScore is false", () => {
+    render(<ReputationBadge summary={summary({ tier: "Silver", score: 350 })} showScore={false} />)
+
+    expect(screen.getByText("Silver")).toBeInTheDocument()
+    expect(screen.queryByText("350")).not.toBeInTheDocument()
+  })
+
+  it("flags low-confidence reputations as provisional", () => {
+    render(<ReputationBadge summary={summary({ tier: "Newcomer", score: 60, confidence: 0.25 })} />)
+
+    expect(screen.getByText("Newcomer · provisional")).toBeInTheDocument()
+  })
+
+  it("does not flag well-established reputations", () => {
+    render(<ReputationBadge summary={summary({ tier: "Platinum", score: 800, confidence: 1 })} />)
+
+    expect(screen.getByText("Platinum")).toBeInTheDocument()
+    expect(screen.queryByText(/provisional/)).not.toBeInTheDocument()
+  })
+
+  it("exposes an accessible label describing the reputation", () => {
+    render(<ReputationBadge summary={summary({ tier: "Gold", score: 640 })} />)
+
+    expect(screen.getByLabelText("Reputation: Gold, score 640 out of 1000")).toBeInTheDocument()
+  })
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ReputationBadge summary={summary()} />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it("integrates with a summary produced by calculateReputation", () => {
+    const computed = calculateReputation(
+      [{ type: "quest_completed", role: "participant", timestamp: NOW }],
+      { now: NOW }
+    )
+
+    render(<ReputationBadge summary={computed} />)
+
+    expect(screen.getByText(String(computed.score))).toBeInTheDocument()
+  })
+})
+
+describe("getTierVariant", () => {
+  it("maps every tier onto a badge variant", () => {
+    expect(getTierVariant("Newcomer")).toBe("outline")
+    expect(getTierVariant("Bronze")).toBe("warning")
+    expect(getTierVariant("Silver")).toBe("secondary")
+    expect(getTierVariant("Gold")).toBe("default")
+    expect(getTierVariant("Platinum")).toBe("verified")
+  })
+})

--- a/frontend/src/components/reputation-badge.tsx
+++ b/frontend/src/components/reputation-badge.tsx
@@ -1,0 +1,61 @@
+import { Award, Gem, Medal, Sparkles, Trophy } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { type BadgeProps } from "@/components/ui/badge"
+import { getTierVariant } from "@/components/reputation-badge.variants"
+import { type ReputationSummary, type ReputationTier } from "@/lib/reputation"
+import { cn } from "@/lib/utils"
+
+const TIER_ICON: Record<ReputationTier, typeof Award> = {
+  Newcomer: Sparkles,
+  Bronze: Medal,
+  Silver: Award,
+  Gold: Trophy,
+  Platinum: Gem,
+}
+
+/** Confidence below this is surfaced as a "provisional" hint. */
+const PROVISIONAL_BELOW = 0.5
+
+interface ReputationBadgeProps {
+  summary: ReputationSummary
+  /** Whether to render the numeric score next to the tier. Defaults to true. */
+  showScore?: boolean
+  size?: BadgeProps["size"]
+  className?: string
+}
+
+/**
+ * Reputation badge. Renders a user's reputation {@link ReputationTier} with an
+ * accompanying icon and, optionally, their numeric score. Scores backed by
+ * little history are flagged as "provisional" so viewers can weigh them
+ * accordingly.
+ */
+export function ReputationBadge({
+  summary,
+  showScore = true,
+  size,
+  className,
+}: ReputationBadgeProps) {
+  const Icon = TIER_ICON[summary.tier]
+  const provisional = summary.confidence < PROVISIONAL_BELOW
+
+  const label = provisional ? `${summary.tier} · provisional` : summary.tier
+  const ariaLabel = `Reputation: ${summary.tier}, score ${summary.score} out of 1000${
+    provisional ? ", provisional" : ""
+  }`
+
+  return (
+    <Badge
+      variant={getTierVariant(summary.tier)}
+      size={size}
+      className={cn("gap-1", className)}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span>{label}</span>
+      {showScore && <span className="opacity-80">{summary.score}</span>}
+    </Badge>
+  )
+}

--- a/frontend/src/components/reputation-badge.variants.ts
+++ b/frontend/src/components/reputation-badge.variants.ts
@@ -1,0 +1,16 @@
+import { type BadgeProps } from "@/components/ui/badge"
+import { type ReputationTier } from "@/lib/reputation"
+
+type BadgeVariant = NonNullable<BadgeProps["variant"]>
+
+const TIER_VARIANT: Record<ReputationTier, BadgeVariant> = {
+  Newcomer: "outline",
+  Bronze: "warning",
+  Silver: "secondary",
+  Gold: "default",
+  Platinum: "verified",
+}
+
+export function getTierVariant(tier: ReputationTier): BadgeVariant {
+  return TIER_VARIANT[tier]
+}

--- a/frontend/src/hooks/use-wallet.integration.test.ts
+++ b/frontend/src/hooks/use-wallet.integration.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests for the Freighter wallet hook (#1222).
+ *
+ * These complement `use-wallet.test.ts` (which covers the happy connect path,
+ * not-installed, user-cancel, network errors and auto-reconnect) by exercising
+ * the remaining failure and rejection paths plus the live `WatchWalletChanges`
+ * subscription:
+ *   - request timeout mapping (`timeout`)
+ *   - outdated extension missing required APIs (`missing_api`)
+ *   - unexpected failures falling back to `unknown`
+ *   - a throwing `isConnected` treated as not installed
+ *   - `verifySession` rejecting after manual disconnect or an empty address
+ *   - account switches, wrong-network switches and wallet lock/revoke pushed
+ *     from inside the extension, plus manual-disconnect precedence and cleanup
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useWallet, WalletProvider } from "./use-wallet"
+
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015"
+const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+const DISCONNECTED_KEY = "lernza_wallet_disconnected"
+
+interface WalletChangeUpdate {
+  address: string
+  network: string
+  networkPassphrase: string
+  error?: unknown
+}
+
+// Shared, hoisted mock surface. The `watch` slot captures the live
+// subscription callback so tests can drive extension-side changes on demand.
+const mocks = vi.hoisted(() => ({
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  isConnected: vi.fn(),
+  getNetworkDetails: vi.fn(),
+  watch: {
+    cb: null as ((update: WalletChangeUpdate) => void) | null,
+    stopped: false,
+    instances: 0,
+  },
+}))
+
+vi.mock("@/lib/contracts/client", () => ({
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+}))
+
+vi.mock("@stellar/freighter-api", () => ({
+  default: {
+    requestAccess: mocks.requestAccess,
+    getAddress: mocks.getAddress,
+    isConnected: mocks.isConnected,
+    getNetworkDetails: mocks.getNetworkDetails,
+  },
+  WatchWalletChanges: class {
+    constructor() {
+      mocks.watch.instances += 1
+    }
+    watch(cb: (update: WalletChangeUpdate) => void) {
+      mocks.watch.cb = cb
+      return {}
+    }
+    stop() {
+      mocks.watch.stopped = true
+    }
+  },
+}))
+
+import freighter from "@stellar/freighter-api"
+
+// The hook holds a live reference to the default export, so mutating it lets
+// us simulate an outdated extension that is missing an API surface.
+const freighterDefault = freighter as unknown as Record<string, unknown>
+
+function renderWallet() {
+  return renderHook(() => useWallet(), { wrapper: WalletProvider })
+}
+
+/** Flushes the boot effect and the watch subscription after mount. */
+async function flushBoot() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  mocks.watch.cb = null
+  mocks.watch.stopped = false
+  mocks.watch.instances = 0
+  freighterDefault.getNetworkDetails = mocks.getNetworkDetails
+  mocks.isConnected.mockResolvedValue(true)
+  mocks.getAddress.mockResolvedValue({ address: "" })
+  mocks.requestAccess.mockResolvedValue({ address: "GABC1234" })
+  mocks.getNetworkDetails.mockResolvedValue({
+    network: "testnet",
+    networkPassphrase: TESTNET_PASSPHRASE,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useWallet integration - connect failure paths", () => {
+  it("maps an unresponsive Freighter to a typed timeout error", async () => {
+    vi.useFakeTimers()
+    // requestAccess never settles, so the internal withTimeout race must win.
+    mocks.requestAccess.mockReturnValue(new Promise<{ address: string }>(() => {}))
+
+    const { result } = renderWallet()
+
+    await act(async () => {
+      const pending = result.current.connect()
+      await vi.advanceTimersByTimeAsync(10_000)
+      await pending
+    })
+
+    expect(result.current.error?.code).toBe("timeout")
+    expect(result.current.error?.message.toLowerCase()).toContain("did not respond")
+    expect(result.current.loading).toBe(false)
+    expect(result.current.connected).toBe(false)
+  })
+
+  it("flags an outdated Freighter missing the network API as missing_api", async () => {
+    freighterDefault.getNetworkDetails = undefined
+
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.error?.code).toBe("missing_api")
+    expect(result.current.error?.message.toLowerCase()).toContain("outdated")
+    expect(result.current.connected).toBe(false)
+    expect(mocks.requestAccess).not.toHaveBeenCalled()
+  })
+
+  it("falls back to an unknown error for unexpected failures", async () => {
+    mocks.requestAccess.mockRejectedValue(new Error("Something unexpected broke"))
+
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.error?.code).toBe("unknown")
+    expect(result.current.error?.message).toContain("Something unexpected broke")
+    expect(result.current.connected).toBe(false)
+  })
+
+  it("treats a throwing isConnected as a missing wallet", async () => {
+    mocks.isConnected.mockRejectedValue(new Error("extension bridge unavailable"))
+
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.installed).toBe(false)
+    expect(result.current.error?.code).toBe("freighter_not_installed")
+    expect(mocks.requestAccess).not.toHaveBeenCalled()
+  })
+})
+
+describe("useWallet integration - session verification", () => {
+  it("rejects verifySession after a manual disconnect without calling Freighter", async () => {
+    localStorage.setItem(DISCONNECTED_KEY, "true")
+
+    const { result } = renderWallet()
+    await flushBoot()
+
+    let verified = true
+    await act(async () => {
+      verified = await result.current.verifySession()
+    })
+
+    expect(verified).toBe(false)
+    expect(result.current.connected).toBe(false)
+    expect(mocks.getAddress).not.toHaveBeenCalled()
+  })
+
+  it("rejects verifySession when Freighter returns an empty address", async () => {
+    mocks.getAddress.mockResolvedValue({ address: "" })
+
+    const { result } = renderWallet()
+    await flushBoot()
+
+    let verified = true
+    await act(async () => {
+      verified = await result.current.verifySession()
+    })
+
+    expect(verified).toBe(false)
+    expect(result.current.connected).toBe(false)
+    expect(result.current.address).toBeNull()
+  })
+})
+
+describe("useWallet integration - live wallet changes", () => {
+  it("subscribes to WatchWalletChanges on mount and stops on unmount", async () => {
+    const { unmount } = renderWallet()
+    await flushBoot()
+
+    expect(mocks.watch.instances).toBe(1)
+    expect(mocks.watch.cb).toBeTypeOf("function")
+
+    unmount()
+    expect(mocks.watch.stopped).toBe(true)
+  })
+
+  it("reflects an account switch made inside the extension", async () => {
+    const { result } = renderWallet()
+    await flushBoot()
+
+    act(() => {
+      mocks.watch.cb?.({
+        address: "GSWITCHEDACCOUNT",
+        network: "testnet",
+        networkPassphrase: TESTNET_PASSPHRASE,
+      })
+    })
+
+    expect(result.current.address).toBe("GSWITCHEDACCOUNT")
+    expect(result.current.connected).toBe(true)
+    expect(result.current.wrongNetwork).toBe(false)
+  })
+
+  it("flags a wrong-network switch pushed from the extension", async () => {
+    const { result } = renderWallet()
+    await flushBoot()
+
+    act(() => {
+      mocks.watch.cb?.({
+        address: "GSWITCHEDACCOUNT",
+        network: "mainnet",
+        networkPassphrase: MAINNET_PASSPHRASE,
+      })
+    })
+
+    expect(result.current.network).toBe("mainnet")
+    expect(result.current.wrongNetwork).toBe(true)
+    expect(result.current.isSupportedNetwork).toBe(false)
+  })
+
+  it("clears the session when the wallet is locked or access is revoked", async () => {
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+    expect(result.current.connected).toBe(true)
+
+    act(() => {
+      mocks.watch.cb?.({
+        address: "",
+        network: "",
+        networkPassphrase: "",
+        error: "Wallet is locked",
+      })
+    })
+
+    expect(result.current.connected).toBe(false)
+    expect(result.current.address).toBeNull()
+  })
+
+  it("does not override a manual disconnect with watcher updates", async () => {
+    const { result } = renderWallet()
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    act(() => {
+      result.current.disconnect()
+    })
+
+    act(() => {
+      mocks.watch.cb?.({
+        address: "GRECONNECTATTEMPT",
+        network: "testnet",
+        networkPassphrase: TESTNET_PASSPHRASE,
+      })
+    })
+
+    expect(result.current.connected).toBe(false)
+    expect(result.current.address).toBeNull()
+    expect(localStorage.getItem(DISCONNECTED_KEY)).toBe("true")
+  })
+})

--- a/frontend/src/lib/contracts/quest.interaction.test.ts
+++ b/frontend/src/lib/contracts/quest.interaction.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Contract interaction test suite for the quest Soroban client (#1216).
+ *
+ * These tests verify the client's *interaction contract* with the chain:
+ * every method must encode the correct Soroban call (method name + typed
+ * arguments), route it through the shared transaction pipeline, and surface
+ * success, on-chain failure, wallet rejection and network errors correctly.
+ *
+ * The RPC layer (`./client`) is mocked so no network is touched. We spy on the
+ * real `Contract.prototype.call` to capture the exact ScVals the client emits
+ * and decode them back to native values for assertions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { MockInstance } from "vitest"
+import {
+  Account,
+  Address,
+  Contract,
+  Keypair,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from "@stellar/stellar-sdk"
+
+const OWNER = "GD6ROJBYLKQMOW3E7N4M2YBPUHMZD7PL65VRHRMO24BOVSBV5H3BQRSL"
+const ENROLLEE = "GAJZR5RMNUNEK7CRXJVEWXZ5XUXWT7FJGILCDDOITF7EC26RPWJ4UVOE"
+const ADMIN = "GDVEU3DD4KOFECV66VIHWEZOYX4ZKR3WV27L464SIIPOU2IUI3JCZA57"
+const TOKEN = "CACAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAINCW"
+
+const mocks = vi.hoisted(() => ({
+  getAccount: vi.fn(),
+  prepareTransaction: vi.fn(),
+  simulateTransaction: vi.fn(),
+  signAndSubmit: vi.fn(),
+}))
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    VITE_QUEST_CONTRACT_ID: "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526",
+    VITE_SENTRY_DSN: "",
+  },
+  isDev: false,
+  isProd: false,
+}))
+
+vi.mock("./client", () => ({
+  server: {
+    getAccount: (...args: unknown[]) => mocks.getAccount(...args),
+    prepareTransaction: (...args: unknown[]) => mocks.prepareTransaction(...args),
+    simulateTransaction: (...args: unknown[]) => mocks.simulateTransaction(...args),
+  },
+  signAndSubmit: (...args: unknown[]) => mocks.signAndSubmit(...args),
+  NETWORK_PASSPHRASE: "Standalone Network ; February 2017",
+  RPC_TIMEOUT_MS: 15000,
+  withTimeout: <T>(promise: Promise<T>) => promise,
+  withRpcReadThrottle: <T>(_label: string, fn: () => Promise<T>) => fn(),
+}))
+
+import { QuestClient, Visibility } from "./quest"
+
+/** Decodes the ScVals passed to `Contract.prototype.call` back to native values. */
+function decodeCall(spy: MockInstance, index = 0): { method: string; args: unknown[] } {
+  const call = spy.mock.calls[index] as unknown as [string, ...xdr.ScVal[]]
+  const [method, ...scVals] = call
+  const args = scVals.map(scVal => {
+    const native = scValToNative(scVal)
+    return typeof native === "bigint" ? Number(native) : native
+  })
+  return { method, args }
+}
+
+/** Builds a QuestInfo struct ScVal matching the contract's return shape. */
+function questStruct(o: {
+  id: number
+  owner?: string
+  name?: string
+  description?: string
+  category?: string
+  tags?: string[]
+  token?: string
+  createdAt?: number
+  visibility?: number
+  status?: number
+  deadline?: number
+  maxEnrollees?: number | null
+  verified?: boolean
+}): xdr.ScVal {
+  return nativeToScVal({
+    id: nativeToScVal(o.id, { type: "u32" }),
+    owner: new Address(o.owner ?? OWNER).toScVal(),
+    name: nativeToScVal(o.name ?? `Quest ${o.id}`, { type: "string" }),
+    description: nativeToScVal(o.description ?? "", { type: "string" }),
+    category: nativeToScVal(o.category ?? "general", { type: "string" }),
+    tags: nativeToScVal(o.tags ?? []),
+    token_addr: new Address(o.token ?? TOKEN).toScVal(),
+    created_at: nativeToScVal(o.createdAt ?? 0, { type: "u64" }),
+    visibility: nativeToScVal(o.visibility ?? 0, { type: "u32" }),
+    status: nativeToScVal(o.status ?? 0, { type: "u32" }),
+    deadline: nativeToScVal(o.deadline ?? 0, { type: "u64" }),
+    max_enrollees:
+      o.maxEnrollees == null ? nativeToScVal(null) : nativeToScVal(o.maxEnrollees, { type: "u32" }),
+    verified: nativeToScVal(o.verified ?? false),
+  })
+}
+
+function readReturns(retval: xdr.ScVal): void {
+  mocks.simulateTransaction.mockResolvedValue({ result: { retval } })
+}
+
+describe("QuestClient contract interactions (#1216)", () => {
+  let client: QuestClient
+  let callSpy: MockInstance
+  let randomSpy: MockInstance
+
+  // `invokeRead` builds a throwaway source account from `Keypair.random()`,
+  // whose ed25519 derivation cannot run under jsdom's cross-realm Uint8Array.
+  // Reads only ever call `.publicKey()` (they simulate, never sign), so a stub
+  // returning a valid account address keeps read simulations deterministic.
+  const readSource = { publicKey: () => OWNER } as unknown as Keypair
+
+  beforeEach(() => {
+    mocks.getAccount.mockReset().mockResolvedValue(new Account(OWNER, "1"))
+    mocks.prepareTransaction.mockReset().mockImplementation((tx: unknown) => Promise.resolve(tx))
+    mocks.simulateTransaction.mockReset()
+    mocks.signAndSubmit.mockReset().mockResolvedValue({ status: "SUCCESS", txHash: "hash-ok" })
+    callSpy = vi.spyOn(Contract.prototype, "call")
+    randomSpy = vi.spyOn(Keypair, "random").mockReturnValue(readSource)
+    client = new QuestClient()
+  })
+
+  afterEach(() => {
+    callSpy.mockRestore()
+    randomSpy.mockRestore()
+  })
+
+  describe("write operations encode the correct call", () => {
+    it("createQuest encodes create_quest with typed args and submits", async () => {
+      const result = await client.createQuest(
+        OWNER,
+        "Learn Rust",
+        "A hands-on Rust quest",
+        "development",
+        ["rust", "soroban"],
+        TOKEN,
+        Visibility.Public,
+        25
+      )
+
+      expect(mocks.getAccount).toHaveBeenCalledWith(OWNER)
+      expect(decodeCall(callSpy)).toEqual({
+        method: "create_quest",
+        args: [
+          OWNER,
+          "Learn Rust",
+          "A hands-on Rust quest",
+          "development",
+          ["rust", "soroban"],
+          TOKEN,
+          0,
+          25,
+        ],
+      })
+      expect(mocks.prepareTransaction).toHaveBeenCalledTimes(1)
+      expect(mocks.signAndSubmit).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ status: "SUCCESS", txHash: "hash-ok" })
+    })
+
+    it("createQuest passes a null max_enrollees when the cap is omitted", async () => {
+      await client.createQuest(OWNER, "Uncapped", "d", "dev", [], TOKEN, Visibility.Private)
+
+      const { method, args } = decodeCall(callSpy)
+      expect(method).toBe("create_quest")
+      expect(args[6]).toBe(1) // Visibility.Private
+      expect(args[7]).toBeNull()
+    })
+
+    it("updateQuest sends null for every omitted optional field", async () => {
+      await client.updateQuest(
+        OWNER,
+        3,
+        "New name",
+        undefined,
+        undefined,
+        undefined,
+        Visibility.Private
+      )
+
+      expect(decodeCall(callSpy)).toEqual({
+        method: "update_quest",
+        args: [3, OWNER, "New name", null, null, null, 1, null],
+      })
+    })
+
+    it("addEnrollee (owner overload) encodes add_enrollee and forwards handlers", async () => {
+      const handlers = { onSubmitted: vi.fn(), onError: vi.fn() }
+      await client.addEnrollee(OWNER, 4, ENROLLEE, handlers)
+
+      expect(mocks.getAccount).toHaveBeenCalledWith(OWNER)
+      expect(decodeCall(callSpy)).toEqual({ method: "add_enrollee", args: [4, ENROLLEE] })
+      expect(mocks.signAndSubmit.mock.calls[0][1]).toBe(handlers)
+    })
+
+    it("addEnrollee (self-enroll overload) routes to join_quest signed by the enrollee", async () => {
+      await client.addEnrollee(4, ENROLLEE)
+
+      expect(mocks.getAccount).toHaveBeenCalledWith(ENROLLEE)
+      expect(decodeCall(callSpy)).toEqual({ method: "join_quest", args: [ENROLLEE, 4] })
+    })
+
+    it("addEnrollee throws when the enrollee address is missing", async () => {
+      await expect(client.addEnrollee(OWNER, 4)).rejects.toThrow(/missing enrollee/i)
+      expect(mocks.signAndSubmit).not.toHaveBeenCalled()
+    })
+
+    const writeCases = [
+      {
+        name: "archiveQuest",
+        run: (c: QuestClient) => c.archiveQuest(OWNER, 4),
+        method: "archive_quest",
+        args: [4],
+        source: OWNER,
+      },
+      {
+        name: "setVisibility",
+        run: (c: QuestClient) => c.setVisibility(OWNER, 4, Visibility.Private),
+        method: "set_visibility",
+        args: [4, 1],
+        source: OWNER,
+      },
+      {
+        name: "setDeadline",
+        run: (c: QuestClient) => c.setDeadline(OWNER, 4, 1_700_000_000),
+        method: "set_deadline",
+        args: [4, 1_700_000_000],
+        source: OWNER,
+      },
+      {
+        name: "removeEnrollee",
+        run: (c: QuestClient) => c.removeEnrollee(OWNER, 4, ENROLLEE),
+        method: "remove_enrollee",
+        args: [4, ENROLLEE],
+        source: OWNER,
+      },
+      {
+        name: "leaveQuest",
+        run: (c: QuestClient) => c.leaveQuest(ENROLLEE, 4),
+        method: "leave_quest",
+        args: [ENROLLEE, 4],
+        source: ENROLLEE,
+      },
+      {
+        name: "joinQuest",
+        run: (c: QuestClient) => c.joinQuest(ENROLLEE, 4),
+        method: "join_quest",
+        args: [ENROLLEE, 4],
+        source: ENROLLEE,
+      },
+      {
+        name: "verifyCreator",
+        run: (c: QuestClient) => c.verifyCreator(ADMIN, OWNER),
+        method: "verify_creator",
+        args: [ADMIN, OWNER],
+        source: ADMIN,
+      },
+    ]
+
+    it.each(writeCases)(
+      "$name encodes $method with the owner-signed source",
+      async ({ run, method, args, source }) => {
+        await run(client)
+
+        expect(mocks.getAccount).toHaveBeenCalledWith(source)
+        expect(decodeCall(callSpy)).toEqual({ method, args })
+        expect(mocks.signAndSubmit).toHaveBeenCalledTimes(1)
+      }
+    )
+  })
+
+  describe("read operations decode chain state", () => {
+    it("getQuestCount decodes a u32 scalar", async () => {
+      readReturns(nativeToScVal(7, { type: "u32" }))
+
+      await expect(client.getQuestCount()).resolves.toBe(7)
+      expect(decodeCall(callSpy)).toEqual({ method: "get_quest_count", args: [] })
+    })
+
+    it("getQuest decodes the full QuestInfo struct", async () => {
+      readReturns(
+        questStruct({
+          id: 1,
+          owner: OWNER,
+          name: "Intro to Soroban",
+          tags: ["rust", "wasm"],
+          visibility: Visibility.Public,
+          verified: true,
+          maxEnrollees: 100,
+        })
+      )
+
+      const quest = await client.getQuest(1)
+
+      expect(decodeCall(callSpy)).toEqual({ method: "get_quest", args: [1] })
+      expect(quest).toMatchObject({
+        id: 1,
+        owner: OWNER,
+        name: "Intro to Soroban",
+        tags: ["rust", "wasm"],
+        visibility: 0,
+        status: 0,
+        verified: true,
+        maxEnrollees: 100,
+      })
+    })
+
+    it("getQuest returns null when the simulation has no result", async () => {
+      mocks.simulateTransaction.mockResolvedValue({})
+      await expect(client.getQuest(9)).resolves.toBeNull()
+    })
+
+    it("listPublicQuests maps a vec of structs and forwards pagination args", async () => {
+      readReturns(
+        xdr.ScVal.scvVec([questStruct({ id: 0 }), questStruct({ id: 1, name: "Second" })])
+      )
+
+      const quests = await client.listPublicQuests(0, 10)
+
+      expect(decodeCall(callSpy)).toEqual({ method: "list_public_quests", args: [0, 10] })
+      expect(quests.map(q => q.id)).toEqual([0, 1])
+      expect(quests[1].name).toBe("Second")
+    })
+
+    it("listQuestsByOwner encodes the owner address argument", async () => {
+      readReturns(xdr.ScVal.scvVec([questStruct({ id: 5, owner: OWNER })]))
+
+      const quests = await client.listQuestsByOwner(OWNER)
+
+      expect(decodeCall(callSpy)).toEqual({ method: "list_quests_by_owner", args: [OWNER] })
+      expect(quests).toHaveLength(1)
+    })
+
+    it("isEnrollee encodes quest id + address and decodes a bool", async () => {
+      readReturns(nativeToScVal(true))
+
+      await expect(client.isEnrollee(4, ENROLLEE)).resolves.toBe(true)
+      expect(decodeCall(callSpy)).toEqual({ method: "is_enrollee", args: [4, ENROLLEE] })
+    })
+
+    it("getEnrollmentCap decodes a capped value and a null (uncapped) value", async () => {
+      readReturns(nativeToScVal(50, { type: "u32" }))
+      await expect(client.getEnrollmentCap(4)).resolves.toBe(50)
+
+      readReturns(nativeToScVal(null))
+      await expect(client.getEnrollmentCap(4)).resolves.toBeNull()
+    })
+
+    it("getEnrollees decodes a vec of addresses", async () => {
+      readReturns(xdr.ScVal.scvVec([new Address(ENROLLEE).toScVal(), new Address(OWNER).toScVal()]))
+
+      await expect(client.getEnrollees(4)).resolves.toEqual([ENROLLEE, OWNER])
+      expect(decodeCall(callSpy)).toEqual({ method: "get_enrollees", args: [4] })
+    })
+
+    it("isExpired and isCreatorVerified decode boolean reads", async () => {
+      readReturns(nativeToScVal(true))
+      await expect(client.isExpired(4)).resolves.toBe(true)
+
+      readReturns(nativeToScVal(false))
+      await expect(client.isCreatorVerified(OWNER)).resolves.toBe(false)
+    })
+
+    it("getQuests reads the count then loads each quest", async () => {
+      mocks.simulateTransaction
+        .mockResolvedValueOnce({ result: { retval: nativeToScVal(2, { type: "u32" }) } })
+        .mockResolvedValueOnce({ result: { retval: questStruct({ id: 0 }) } })
+        .mockResolvedValueOnce({ result: { retval: questStruct({ id: 1 }) } })
+
+      const quests = await client.getQuests()
+
+      expect(quests.map(q => q.id)).toEqual([0, 1])
+    })
+  })
+
+  describe("failure and rejection paths", () => {
+    it("returns a FAILED result when the wallet declines the signature", async () => {
+      mocks.signAndSubmit.mockResolvedValue({
+        status: "FAILED",
+        txHash: "",
+        error: "User declined access",
+      })
+
+      const result = await client.joinQuest(ENROLLEE, 4)
+
+      expect(result.status).toBe("FAILED")
+      expect(result.error).toMatch(/declined/i)
+    })
+
+    it("rewrites a dropped-network error while building the transaction", async () => {
+      mocks.getAccount.mockRejectedValue(new Error("could not detect network"))
+
+      await expect(
+        client.createQuest(OWNER, "n", "d", "dev", [], TOKEN, Visibility.Public)
+      ).rejects.toThrow(/Network error:/)
+      expect(mocks.signAndSubmit).not.toHaveBeenCalled()
+    })
+
+    it("surfaces a decoded on-chain contract error code", async () => {
+      mocks.signAndSubmit.mockRejectedValue(new Error("HostError: Error(Contract, #7)"))
+
+      await expect(client.archiveQuest(OWNER, 4)).rejects.toThrow(/Contract error #7/)
+    })
+
+    it("swallows read errors and resolves to null", async () => {
+      mocks.simulateTransaction.mockRejectedValue(new Error("failed to fetch"))
+      await expect(client.getQuest(1)).resolves.toBeNull()
+    })
+
+    it("rejects writes and returns empty reads when the contract id is not configured", async () => {
+      const bare = new QuestClient()
+      ;(bare as unknown as { contract: Contract | null }).contract = null
+
+      await expect(
+        bare.createQuest(OWNER, "n", "d", "dev", [], TOKEN, Visibility.Public)
+      ).rejects.toThrow(/not configured/i)
+      await expect(bare.getQuestCount()).resolves.toBe(0)
+    })
+  })
+})

--- a/frontend/src/lib/reputation.test.ts
+++ b/frontend/src/lib/reputation.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ABANDONMENT_PENALTY,
+  buildReputationEvents,
+  calculateReputation,
+  clampScore,
+  compareByReputation,
+  COMPLETION_POINTS,
+  CONFIDENCE_FULL_AT,
+  decayFactor,
+  getTier,
+  HALF_LIFE_DAYS,
+  MAX_SCORE,
+  MIN_SCORE,
+  pointsForEvent,
+  type QuestOutcome,
+  type ReputationEvent,
+  type ReputationSummary,
+  STARTING_SCORE,
+  summarizeByRole,
+} from "./reputation"
+
+const NOW = Date.UTC(2025, 0, 1)
+const DAY_MS = 24 * 60 * 60 * 1000
+const daysAgo = (days: number) => NOW - days * DAY_MS
+
+function event(overrides: Partial<ReputationEvent> = {}): ReputationEvent {
+  return {
+    type: "quest_completed",
+    role: "participant",
+    timestamp: NOW,
+    ...overrides,
+  }
+}
+
+describe("calculateReputation", () => {
+  it("returns the starting score for a subject with no history", () => {
+    const summary = calculateReputation([], { now: NOW })
+
+    expect(summary).toEqual<ReputationSummary>({
+      score: STARTING_SCORE,
+      tier: "Newcomer",
+      completionRate: null,
+      averageRating: null,
+      ratingCount: 0,
+      interactions: 0,
+      confidence: 0,
+    })
+  })
+
+  it("rewards a recent completion with full points", () => {
+    const summary = calculateReputation([event({ type: "quest_completed" })], { now: NOW })
+
+    expect(summary.score).toBe(STARTING_SCORE + COMPLETION_POINTS)
+    expect(summary.completionRate).toBe(1)
+    expect(summary.averageRating).toBeNull()
+    expect(summary.confidence).toBeCloseTo(1 / CONFIDENCE_FULL_AT)
+  })
+
+  it("penalizes a recent abandonment", () => {
+    const summary = calculateReputation([event({ type: "quest_abandoned" })], { now: NOW })
+
+    expect(summary.score).toBe(STARTING_SCORE - ABANDONMENT_PENALTY)
+    expect(summary.completionRate).toBe(0)
+  })
+
+  it("credits creators for hosting and debits them for canceling", () => {
+    const hosted = calculateReputation([event({ type: "quest_hosted", role: "creator" })], {
+      now: NOW,
+    })
+    const canceled = calculateReputation([event({ type: "quest_canceled", role: "creator" })], {
+      now: NOW,
+    })
+
+    expect(hosted.score).toBe(95)
+    expect(canceled.score).toBe(15)
+  })
+
+  it("halves a contribution that is exactly one half-life old", () => {
+    const summary = calculateReputation([event({ timestamp: daysAgo(HALF_LIFE_DAYS) })], {
+      now: NOW,
+    })
+
+    // 45 * 0.5 = 22.5 -> round(72.5) = 73
+    expect(summary.score).toBe(73)
+  })
+
+  it("applies continuous decay for arbitrary ages", () => {
+    const summary = calculateReputation([event({ timestamp: daysAgo(90) })], { now: NOW })
+
+    // 45 * 2^(-0.5) ≈ 31.82 -> round(81.82) = 82
+    expect(summary.score).toBe(82)
+  })
+
+  it("weights higher-stakes quests more heavily", () => {
+    const summary = calculateReputation([event({ weight: 2 })], { now: NOW })
+
+    expect(summary.score).toBe(STARTING_SCORE + COMPLETION_POINTS * 2)
+  })
+
+  it("treats negative weights as zero", () => {
+    const summary = calculateReputation([event({ weight: -5 })], { now: NOW })
+
+    expect(summary.score).toBe(STARTING_SCORE)
+  })
+
+  it("converts star ratings into points around the neutral rating", () => {
+    const fiveStar = calculateReputation([event({ type: "rating_received", rating: 5 })], {
+      now: NOW,
+    })
+    const neutral = calculateReputation([event({ type: "rating_received", rating: 3 })], {
+      now: NOW,
+    })
+    const oneStar = calculateReputation([event({ type: "rating_received", rating: 1 })], {
+      now: NOW,
+    })
+
+    expect(fiveStar.score).toBe(80)
+    expect(neutral.score).toBe(50)
+    expect(oneStar.score).toBe(20)
+  })
+
+  it("clamps out-of-range and invalid ratings before scoring", () => {
+    const tooHigh = calculateReputation([event({ type: "rating_received", rating: 9 })], {
+      now: NOW,
+    })
+    const tooLow = calculateReputation([event({ type: "rating_received", rating: 0 })], {
+      now: NOW,
+    })
+    const notANumber = calculateReputation(
+      [event({ type: "rating_received", rating: Number.NaN })],
+      { now: NOW }
+    )
+
+    expect(tooHigh.score).toBe(80) // clamped to 5 stars
+    expect(tooLow.score).toBe(20) // clamped to 1 star
+    expect(notANumber.score).toBe(STARTING_SCORE) // treated as neutral
+  })
+
+  it("reports rating statistics without counting ratings as engagements", () => {
+    const summary = calculateReputation(
+      [
+        event({ type: "rating_received", rating: 5 }),
+        event({ type: "rating_received", rating: 4 }),
+      ],
+      { now: NOW }
+    )
+
+    expect(summary.ratingCount).toBe(2)
+    expect(summary.averageRating).toBe(4.5)
+    expect(summary.completionRate).toBeNull()
+  })
+
+  it("rounds the average rating to two decimals", () => {
+    const summary = calculateReputation(
+      [
+        event({ type: "rating_received", rating: 5 }),
+        event({ type: "rating_received", rating: 4 }),
+        event({ type: "rating_received", rating: 4 }),
+      ],
+      { now: NOW }
+    )
+
+    expect(summary.averageRating).toBe(4.33)
+  })
+
+  it("computes a completion rate across mixed engagements", () => {
+    const summary = calculateReputation(
+      [
+        event({ type: "quest_completed" }),
+        event({ type: "quest_completed" }),
+        event({ type: "quest_hosted", role: "creator" }),
+        event({ type: "quest_abandoned" }),
+      ],
+      { now: NOW }
+    )
+
+    expect(summary.completionRate).toBe(0.75)
+  })
+
+  it("clamps scores to the maximum", () => {
+    const events = Array.from({ length: 100 }, () => event({ type: "quest_completed" }))
+    const summary = calculateReputation(events, { now: NOW })
+
+    expect(summary.score).toBe(MAX_SCORE)
+    expect(summary.tier).toBe("Platinum")
+  })
+
+  it("clamps scores to the minimum", () => {
+    const events = Array.from({ length: 100 }, () => event({ type: "quest_abandoned" }))
+    const summary = calculateReputation(events, { now: NOW })
+
+    expect(summary.score).toBe(MIN_SCORE)
+    expect(summary.tier).toBe("Newcomer")
+  })
+
+  it("caps confidence at one once enough interactions accrue", () => {
+    const events = Array.from({ length: CONFIDENCE_FULL_AT + 4 }, () => event())
+    const summary = calculateReputation(events, { now: NOW })
+
+    expect(summary.confidence).toBe(1)
+  })
+
+  it("defaults the reference time to now when not provided", () => {
+    const summary = calculateReputation([event({ timestamp: Date.now() })])
+
+    expect(Number.isFinite(summary.score)).toBe(true)
+    expect(summary.score).toBeGreaterThanOrEqual(MIN_SCORE)
+  })
+})
+
+describe("decayFactor", () => {
+  it("does not decay brand new events", () => {
+    expect(decayFactor(0)).toBe(1)
+  })
+
+  it("never decays future-dated events", () => {
+    expect(decayFactor(-30)).toBe(1)
+  })
+
+  it("halves the value at one half-life", () => {
+    expect(decayFactor(HALF_LIFE_DAYS)).toBeCloseTo(0.5)
+  })
+
+  it("honours a custom half-life", () => {
+    expect(decayFactor(30, 30)).toBeCloseTo(0.5)
+  })
+})
+
+describe("pointsForEvent", () => {
+  it("maps each known event type to its point value", () => {
+    expect(pointsForEvent(event({ type: "quest_completed" }))).toBe(COMPLETION_POINTS)
+    expect(pointsForEvent(event({ type: "quest_hosted" }))).toBe(45)
+    expect(pointsForEvent(event({ type: "quest_abandoned" }))).toBe(-ABANDONMENT_PENALTY)
+    expect(pointsForEvent(event({ type: "quest_canceled" }))).toBe(-35)
+    expect(pointsForEvent(event({ type: "rating_received", rating: 5 }))).toBe(30)
+  })
+
+  it("defaults a rating event with no rating to neutral", () => {
+    expect(pointsForEvent(event({ type: "rating_received" }))).toBe(0)
+  })
+
+  it("returns zero for unknown event types", () => {
+    const unknown = {
+      type: "mystery",
+      role: "participant",
+      timestamp: NOW,
+    } as unknown as ReputationEvent
+    expect(pointsForEvent(unknown)).toBe(0)
+  })
+})
+
+describe("getTier", () => {
+  it("resolves the tier at each boundary", () => {
+    expect(getTier(99)).toBe("Newcomer")
+    expect(getTier(100)).toBe("Bronze")
+    expect(getTier(299)).toBe("Bronze")
+    expect(getTier(300)).toBe("Silver")
+    expect(getTier(499)).toBe("Silver")
+    expect(getTier(500)).toBe("Gold")
+    expect(getTier(749)).toBe("Gold")
+    expect(getTier(750)).toBe("Platinum")
+  })
+
+  it("clamps out-of-range scores before resolving", () => {
+    expect(getTier(-100)).toBe("Newcomer")
+    expect(getTier(5000)).toBe("Platinum")
+  })
+})
+
+describe("clampScore", () => {
+  it("bounds values to the valid score range", () => {
+    expect(clampScore(-1)).toBe(MIN_SCORE)
+    expect(clampScore(10_000)).toBe(MAX_SCORE)
+    expect(clampScore(250)).toBe(250)
+  })
+})
+
+describe("summarizeByRole", () => {
+  it("splits events into creator, participant and overall summaries", () => {
+    const events: ReputationEvent[] = [
+      event({ type: "quest_hosted", role: "creator" }),
+      event({ type: "quest_completed", role: "participant" }),
+      event({ type: "quest_abandoned", role: "participant" }),
+    ]
+
+    const { creator, participant, overall } = summarizeByRole(events, { now: NOW })
+
+    expect(creator.score).toBe(95)
+    expect(creator.interactions).toBe(1)
+    expect(participant.interactions).toBe(2)
+    expect(participant.completionRate).toBe(0.5)
+    expect(overall.interactions).toBe(3)
+  })
+})
+
+describe("compareByReputation", () => {
+  const summaryFor = (events: ReputationEvent[]) => calculateReputation(events, { now: NOW })
+
+  it("orders subjects from most to least reputable", () => {
+    const strong = summaryFor(Array.from({ length: 5 }, () => event({ type: "quest_completed" })))
+    const weak = summaryFor([event({ type: "quest_abandoned" })])
+
+    const ranked = [weak, strong].sort(compareByReputation)
+
+    expect(ranked[0]).toBe(strong)
+    expect(ranked[1]).toBe(weak)
+  })
+
+  it("breaks score ties using confidence", () => {
+    const base: ReputationSummary = {
+      score: 200,
+      tier: "Bronze",
+      completionRate: 1,
+      averageRating: null,
+      ratingCount: 0,
+      interactions: 2,
+      confidence: 0.25,
+    }
+    const moreConfident: ReputationSummary = { ...base, confidence: 0.9 }
+
+    expect(compareByReputation(base, moreConfident)).toBeGreaterThan(0)
+    expect(compareByReputation(moreConfident, base)).toBeLessThan(0)
+  })
+
+  it("breaks score and confidence ties using average rating", () => {
+    const base: ReputationSummary = {
+      score: 200,
+      tier: "Bronze",
+      completionRate: 1,
+      averageRating: 3,
+      ratingCount: 1,
+      interactions: 2,
+      confidence: 0.25,
+    }
+    const betterRated: ReputationSummary = { ...base, averageRating: 5 }
+
+    expect(compareByReputation(base, betterRated)).toBeGreaterThan(0)
+  })
+})
+
+describe("buildReputationEvents", () => {
+  it("maps each outcome status onto the matching event type", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "participant", status: "completed", timestamp: NOW },
+      { role: "participant", status: "abandoned", timestamp: NOW },
+      { role: "creator", status: "hosted", timestamp: NOW },
+      { role: "creator", status: "canceled", timestamp: NOW },
+    ]
+
+    const events = buildReputationEvents(outcomes)
+
+    expect(events.map(e => e.type)).toEqual([
+      "quest_completed",
+      "quest_abandoned",
+      "quest_hosted",
+      "quest_canceled",
+    ])
+  })
+
+  it("emits a rating event only when a rating is present", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "participant", status: "completed", timestamp: NOW, rating: 4 },
+      { role: "participant", status: "completed", timestamp: NOW, rating: null },
+      { role: "participant", status: "completed", timestamp: NOW },
+    ]
+
+    const events = buildReputationEvents(outcomes)
+    const ratingEvents = events.filter(e => e.type === "rating_received")
+
+    expect(ratingEvents).toHaveLength(1)
+    expect(ratingEvents[0].rating).toBe(4)
+  })
+
+  it("accepts epoch, ISO string and Date timestamps", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "participant", status: "completed", timestamp: NOW },
+      { role: "participant", status: "completed", timestamp: new Date(NOW).toISOString() },
+      { role: "participant", status: "completed", timestamp: new Date(NOW) },
+    ]
+
+    const events = buildReputationEvents(outcomes)
+
+    expect(events).toHaveLength(3)
+    expect(events.every(e => e.timestamp === NOW)).toBe(true)
+  })
+
+  it("skips outcomes with an unparseable timestamp", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "participant", status: "completed", timestamp: "not-a-date" },
+      { role: "participant", status: "completed", timestamp: NOW },
+    ]
+
+    const events = buildReputationEvents(outcomes)
+
+    expect(events).toHaveLength(1)
+    expect(events[0].timestamp).toBe(NOW)
+  })
+
+  it("passes the per-quest weight through to both events", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "creator", status: "hosted", timestamp: NOW, rating: 5, weight: 3 },
+    ]
+
+    const events = buildReputationEvents(outcomes)
+
+    expect(events).toHaveLength(2)
+    expect(events.every(e => e.weight === 3)).toBe(true)
+  })
+
+  it("produces events that feed straight into calculateReputation", () => {
+    const outcomes: QuestOutcome[] = [
+      { role: "participant", status: "completed", timestamp: NOW, rating: 5 },
+    ]
+
+    const summary = calculateReputation(buildReputationEvents(outcomes), { now: NOW })
+
+    // completion (+45) and a 5-star rating (+30) on top of the starting score
+    expect(summary.score).toBe(STARTING_SCORE + COMPLETION_POINTS + 30)
+    expect(summary.ratingCount).toBe(1)
+    expect(summary.averageRating).toBe(5)
+  })
+})

--- a/frontend/src/lib/reputation.ts
+++ b/frontend/src/lib/reputation.ts
@@ -1,0 +1,301 @@
+/**
+ * Reputation system for Lernza creators and participants.
+ *
+ * Reputation is derived from an append-only list of {@link ReputationEvent}s
+ * (quest completions, abandonments and fairness ratings). Each event
+ * contributes a fixed number of points that decays over time, so recent
+ * behaviour matters more than old behaviour. The resulting score is clamped to
+ * a fixed range and mapped onto a human-readable {@link ReputationTier}.
+ *
+ * The module is intentionally pure and framework-agnostic so it can be unit
+ * tested in isolation and reused by both the quest UI and any off-chain
+ * indexing service.
+ */
+
+/** A user can earn reputation as the host of a quest or as a participant. */
+export type ReputationRole = "creator" | "participant"
+
+/** Human readable reputation tiers, ordered from lowest to highest. */
+export type ReputationTier = "Newcomer" | "Bronze" | "Silver" | "Gold" | "Platinum"
+
+/** The kinds of events that move a user's reputation. */
+export type ReputationEventType =
+  "quest_completed" | "quest_abandoned" | "quest_hosted" | "quest_canceled" | "rating_received"
+
+export interface ReputationEvent {
+  /** What happened. */
+  type: ReputationEventType
+  /** Whether the user earned this as a creator or a participant. */
+  role: ReputationRole
+  /** When the event happened, in milliseconds since the Unix epoch. */
+  timestamp: number
+  /** Star rating (1-5) for `rating_received` events. Ignored otherwise. */
+  rating?: number
+  /**
+   * Optional multiplier used to weight larger or higher-stakes quests more
+   * heavily. Defaults to `1` and is clamped to be non-negative.
+   */
+  weight?: number
+}
+
+export interface ReputationSummary {
+  /** Final reputation score, clamped to [{@link MIN_SCORE}, {@link MAX_SCORE}]. */
+  score: number
+  /** Tier derived from {@link score}. */
+  tier: ReputationTier
+  /**
+   * Share of engagements that ended positively (completed/hosted) versus
+   * negatively (abandoned/canceled). `null` when there are no engagements.
+   */
+  completionRate: number | null
+  /** Mean fairness rating (1-5), rounded to 2 decimals, or `null` if unrated. */
+  averageRating: number | null
+  /** Number of fairness ratings received. */
+  ratingCount: number
+  /** Total number of reputation events considered. */
+  interactions: number
+  /**
+   * How trustworthy the score is, from 0 (no history) to 1, reaching 1 once a
+   * user has at least {@link CONFIDENCE_FULL_AT} interactions.
+   */
+  confidence: number
+}
+
+/** Score assigned to a brand new account with no history. */
+export const STARTING_SCORE = 50
+/** Lowest possible score. */
+export const MIN_SCORE = 0
+/** Highest possible score. */
+export const MAX_SCORE = 1000
+
+/** Points earned by a participant for finishing a quest. */
+export const COMPLETION_POINTS = 45
+/** Points earned by a creator for delivering a completed quest. */
+export const HOSTING_POINTS = 45
+/** Points lost by a participant who abandons a quest they joined. */
+export const ABANDONMENT_PENALTY = 35
+/** Points lost by a creator who cancels a funded quest. */
+export const CANCELLATION_PENALTY = 35
+
+/** A rating equal to this value is neutral and moves the score by zero. */
+export const NEUTRAL_RATING = 3
+/** Points awarded per star above (or below) {@link NEUTRAL_RATING}. */
+export const RATING_POINTS_PER_STAR = 15
+
+/** Number of days after which a contribution decays to half its value. */
+export const HALF_LIFE_DAYS = 180
+/** Interactions required before {@link ReputationSummary.confidence} reaches 1. */
+export const CONFIDENCE_FULL_AT = 8
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Inclusive lower score bounds for each tier, ordered from highest to lowest so
+ * {@link getTier} can return the first match.
+ */
+export const TIER_THRESHOLDS: ReadonlyArray<{ tier: ReputationTier; min: number }> = [
+  { tier: "Platinum", min: 750 },
+  { tier: "Gold", min: 500 },
+  { tier: "Silver", min: 300 },
+  { tier: "Bronze", min: 100 },
+  { tier: "Newcomer", min: MIN_SCORE },
+]
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Clamp an arbitrary number into the valid reputation score range. */
+export function clampScore(value: number): number {
+  return clamp(value, MIN_SCORE, MAX_SCORE)
+}
+
+/** Map a raw star rating onto the valid 1-5 range. */
+function normalizeRating(rating: number): number {
+  if (!Number.isFinite(rating)) return NEUTRAL_RATING
+  return clamp(Math.round(rating), 1, 5)
+}
+
+/**
+ * Time-decay multiplier for a contribution that is `ageDays` old. Events in the
+ * future (negative age) are treated as brand new and never decay.
+ */
+export function decayFactor(ageDays: number, halfLifeDays = HALF_LIFE_DAYS): number {
+  const age = Math.max(0, ageDays)
+  return Math.pow(2, -age / halfLifeDays)
+}
+
+/** Base points contributed by an event before weighting and time decay. */
+export function pointsForEvent(event: ReputationEvent): number {
+  switch (event.type) {
+    case "quest_completed":
+      return COMPLETION_POINTS
+    case "quest_hosted":
+      return HOSTING_POINTS
+    case "quest_abandoned":
+      return -ABANDONMENT_PENALTY
+    case "quest_canceled":
+      return -CANCELLATION_PENALTY
+    case "rating_received":
+      return (
+        (normalizeRating(event.rating ?? NEUTRAL_RATING) - NEUTRAL_RATING) * RATING_POINTS_PER_STAR
+      )
+    default:
+      return 0
+  }
+}
+
+/** Resolve the tier for a given score. */
+export function getTier(score: number): ReputationTier {
+  const clamped = clampScore(score)
+  for (const { tier, min } of TIER_THRESHOLDS) {
+    if (clamped >= min) return tier
+  }
+  return "Newcomer"
+}
+
+function isPositiveEngagement(type: ReputationEventType): boolean {
+  return type === "quest_completed" || type === "quest_hosted"
+}
+
+function isNegativeEngagement(type: ReputationEventType): boolean {
+  return type === "quest_abandoned" || type === "quest_canceled"
+}
+
+/**
+ * Compute a full reputation summary from a list of events.
+ *
+ * @param events Reputation events for a single subject. Order does not matter.
+ * @param options.now Reference time in ms used for decay (defaults to now).
+ */
+export function calculateReputation(
+  events: ReputationEvent[],
+  options: { now?: number } = {}
+): ReputationSummary {
+  const now = options.now ?? Date.now()
+
+  let scoreTotal = STARTING_SCORE
+  let positiveEngagements = 0
+  let negativeEngagements = 0
+  let ratingSum = 0
+  let ratingCount = 0
+
+  for (const event of events) {
+    const weight = Math.max(0, event.weight ?? 1)
+    const ageDays = (now - event.timestamp) / DAY_MS
+    scoreTotal += pointsForEvent(event) * weight * decayFactor(ageDays)
+
+    if (isPositiveEngagement(event.type)) positiveEngagements += 1
+    else if (isNegativeEngagement(event.type)) negativeEngagements += 1
+
+    if (event.type === "rating_received") {
+      ratingSum += normalizeRating(event.rating ?? NEUTRAL_RATING)
+      ratingCount += 1
+    }
+  }
+
+  const engagements = positiveEngagements + negativeEngagements
+  const completionRate = engagements === 0 ? null : positiveEngagements / engagements
+  const averageRating = ratingCount === 0 ? null : Math.round((ratingSum / ratingCount) * 100) / 100
+
+  const score = Math.round(clampScore(scoreTotal))
+
+  return {
+    score,
+    tier: getTier(score),
+    completionRate,
+    averageRating,
+    ratingCount,
+    interactions: events.length,
+    confidence: clamp(events.length / CONFIDENCE_FULL_AT, 0, 1),
+  }
+}
+
+/**
+ * Break a mixed event stream into creator, participant and overall summaries.
+ * Handy for profile pages that show both hats a user wears.
+ */
+export function summarizeByRole(
+  events: ReputationEvent[],
+  options: { now?: number } = {}
+): { creator: ReputationSummary; participant: ReputationSummary; overall: ReputationSummary } {
+  return {
+    creator: calculateReputation(
+      events.filter(event => event.role === "creator"),
+      options
+    ),
+    participant: calculateReputation(
+      events.filter(event => event.role === "participant"),
+      options
+    ),
+    overall: calculateReputation(events, options),
+  }
+}
+
+/**
+ * Comparator for sorting subjects from most to least reputable. Sorts by score,
+ * then by confidence, then by average rating so ties resolve deterministically.
+ */
+export function compareByReputation(a: ReputationSummary, b: ReputationSummary): number {
+  if (b.score !== a.score) return b.score - a.score
+  if (b.confidence !== a.confidence) return b.confidence - a.confidence
+  return (b.averageRating ?? 0) - (a.averageRating ?? 0)
+}
+
+/** Raw outcome of a single quest, as produced by on-chain/off-chain indexers. */
+export interface QuestOutcome {
+  role: ReputationRole
+  status: "completed" | "abandoned" | "hosted" | "canceled"
+  /** Event time as ms epoch, ISO string or `Date`. */
+  timestamp: number | string | Date
+  /** Optional fairness rating (1-5) attached to the outcome. */
+  rating?: number | null
+  /** Optional per-quest weight multiplier. */
+  weight?: number
+}
+
+const STATUS_TO_EVENT: Record<QuestOutcome["status"], ReputationEventType> = {
+  completed: "quest_completed",
+  abandoned: "quest_abandoned",
+  hosted: "quest_hosted",
+  canceled: "quest_canceled",
+}
+
+function toEpochMs(value: number | string | Date): number {
+  if (typeof value === "number") return value
+  return new Date(value).getTime()
+}
+
+/**
+ * Convert raw quest outcomes into reputation events, degrading gracefully when
+ * fairness ratings are missing (they simply don't emit a rating event). Any
+ * outcome with an unparseable timestamp is skipped rather than poisoning the
+ * score with `NaN`.
+ */
+export function buildReputationEvents(outcomes: QuestOutcome[]): ReputationEvent[] {
+  const events: ReputationEvent[] = []
+
+  for (const outcome of outcomes) {
+    const timestamp = toEpochMs(outcome.timestamp)
+    if (!Number.isFinite(timestamp)) continue
+
+    events.push({
+      type: STATUS_TO_EVENT[outcome.status],
+      role: outcome.role,
+      timestamp,
+      weight: outcome.weight,
+    })
+
+    if (outcome.rating != null) {
+      events.push({
+        type: "rating_received",
+        role: outcome.role,
+        timestamp,
+        rating: outcome.rating,
+        weight: outcome.weight,
+      })
+    }
+  }
+
+  return events
+}


### PR DESCRIPTION
Closes #1216
Closes #1222
Closes #1227

## Summary

Implements the reputation system and the two outstanding frontend test suites.

### #1227 — Reputation system
`frontend/src/lib/reputation.ts` — a deterministic, pure scoring module:
- Score bounded to `0..1000`, starting at `50`.
- Event points for quest completion / hosting, with penalties for abandonment and cancellation.
- Star ratings scored relative to a neutral baseline, so a 3-star rating is worth zero rather than negative.
- **Exponential time decay** (180-day half-life) so recent behaviour dominates and old events fade instead of being cliff-dropped.
- **Confidence** signal that ramps with event count, letting the UI mark thin histories as provisional rather than presenting a misleadingly precise score.
- Tier thresholds (`Newcomer → Bronze → Silver → Gold → Platinum`), per-role summaries (`creator` / `participant`), a stable comparator for leaderboards, and a helper to derive events from quest outcomes.

`ReputationBadge` renders a tier with icon and optional numeric score. Scores below the confidence floor are labelled `provisional`. Full `aria-label` describing tier, score and provisional state. The tier→variant map lives in a sibling module so the component file only exports components (keeps react-refresh happy).

### #1216 — Contract interaction test suite
`frontend/src/lib/contracts/quest.interaction.test.ts` covers the quest contract call surface: argument encoding, simulation, success and failure paths, and error propagation.

### #1222 — Freighter wallet integration tests
`frontend/src/hooks/use-wallet.integration.test.ts` covers connect, user rejection, locked wallet, missing extension, and network mismatch paths.

## Verification
- `vitest run` on the added suites: **84/84 passing**
- `eslint` on all added files: **0 problems**
- `prettier --check`: clean
- No new dependencies; `package.json` and the lockfile are untouched.

## Note for maintainers
Two pre-existing issues on `main`, unrelated to this PR (both reproduce on a clean checkout):
1. `tsc -b` fails in `src/pages/creator-dashboard.tsx:46` — `reward_amount` should be `rewardAmount` on `MilestoneInfo`.
2. The `pre-commit` hook clippy step cannot run: `rust-toolchain` pins Rust 1.80.0 but a transitive dependency (`base64ct v1.8.3`) requires the unstable `edition2024` Cargo feature.