### PR TITLE
test(e2e): add E2E scenarios for quest creation, participation, and e…

### DIFF
--- a/frontend/e2e/create-quest.spec.ts
+++ b/frontend/e2e/create-quest.spec.ts
@@ -1,35 +1,5 @@
-import { test, expect, type Page } from "@playwright/test"
-
-/**
- * Stub window.freighter so the @stellar/freighter-api SDK sees a connected wallet.
- * This must run before any page scripts via addInitScript.
- */
-async function mockWallet(page: Page) {
-  await page.addInitScript(() => {
-    const mockAddress = "GBMOCKADDRESS123STELLAR456WALLET789ABCDEFGH"
-
-    const stub = {
-      isConnected: () => Promise.resolve(true),
-      getAddress: () => Promise.resolve({ address: mockAddress }),
-      getNetwork: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      getNetworkDetails: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      requestAccess: () => Promise.resolve({ address: mockAddress }),
-      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr }),
-    }
-
-    Object.defineProperty(window, "freighter", { value: stub, writable: true })
-    // Some versions of @stellar/freighter-api read from window.freighterApi
-    Object.defineProperty(window, "freighterApi", { value: stub, writable: true })
-  })
-}
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
 
 test.describe("Create Quest wizard — wallet not connected", () => {
   test.beforeEach(async ({ page }) => {

--- a/frontend/e2e/earning.spec.ts
+++ b/frontend/e2e/earning.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
+
+/**
+ * Tests covering the earning/reward flow:
+ *   - Profile page: wallet connect guard, earnings display, tabs
+ *   - Leaderboard: earners tab ranks, quests tab, tab switching
+ *   - Creator dashboard: reward pool section
+ */
+
+// ─── Profile page ─────────────────────────────────────────────────────────────
+
+test.describe("Earning — profile page", () => {
+  test("shows connect wallet prompt when no wallet is connected", async ({ page }) => {
+    await page.goto("/profile")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByText(/connect your wallet/i)).toBeVisible()
+  })
+
+  test("shows Not Connected status badge without wallet", async ({ page }) => {
+    await page.goto("/profile")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByText(/not connected/i)).toBeVisible()
+  })
+
+  test("shows Connect Wallet button on profile without wallet", async ({ page }) => {
+    await page.goto("/profile")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByRole("button", { name: /connect wallet/i })).toBeVisible()
+  })
+
+  test.describe("with wallet connected", () => {
+    test.beforeEach(async ({ page }) => {
+      await mockWallet(page)
+      await page.goto("/profile")
+      await page.waitForLoadState("networkidle")
+      await page.waitForTimeout(800)
+    })
+
+    test("profile page renders without crashing when wallet connected", async ({ page }) => {
+      await expect(page.locator("main")).toBeVisible()
+    })
+
+    test("shows wallet address or truncated address on profile", async ({ page }) => {
+      // Profile should display the connected wallet address somewhere
+      const body = await page.textContent("body")
+      // Mock address starts with GB — should appear somewhere in the page
+      const hasAddress = body?.includes("GB") ?? false
+      expect(hasAddress).toBe(true)
+    })
+
+    test("shows earnings section (loading, error, or value)", async ({ page }) => {
+      // The earnings section always renders in one of three states
+      const hasEarnings = await page
+        .getByText(/usdc earned|on-chain earnings|loading on-chain/i)
+        .isVisible()
+        .catch(() => false)
+      const hasConnectedContent = await page.locator("main").isVisible()
+      expect(hasEarnings || hasConnectedContent).toBe(true)
+    })
+
+    test("Overview tab is available", async ({ page }) => {
+      const hasOverview = await page
+        .getByRole("button", { name: /view overview/i })
+        .isVisible()
+        .catch(() => false)
+      const hasTab = await page
+        .getByText(/overview/i)
+        .isVisible()
+        .catch(() => false)
+      expect(hasOverview || hasTab).toBe(true)
+    })
+
+    test("Activity tab is available and switches content", async ({ page }) => {
+      const activityTab = page
+        .getByRole("button", { name: /view activity/i })
+      const hasActivityTab = await activityTab.isVisible().catch(() => false)
+      if (!hasActivityTab) test.skip()
+
+      await activityTab.click()
+      await expect(page.locator("main")).toBeVisible()
+
+      // Activity tab should show wallet timeline or loading state
+      const body = await page.textContent("body")
+      expect(body).toBeTruthy()
+    })
+
+    test("copy address button is present", async ({ page }) => {
+      const copyBtn = page.getByRole("button", { name: /copy address/i })
+      const hasCopy = await copyBtn.isVisible().catch(() => false)
+      if (!hasCopy) test.skip()
+
+      await expect(copyBtn).toBeEnabled()
+    })
+  })
+})
+
+// ─── Leaderboard — earning ranks ──────────────────────────────────────────────
+
+test.describe("Earning — leaderboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/leaderboard")
+    await page.waitForLoadState("domcontentloaded")
+  })
+
+  test("leaderboard page renders without crashing", async ({ page }) => {
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("shows the Leaderboard page heading", async ({ page }) => {
+    await expect(page.getByText(/top performers|leaderboard/i)).toBeVisible()
+  })
+
+  test("earners tab is present and selectable", async ({ page }) => {
+    await expect(page.getByRole("tab", { name: /earners/i })).toBeVisible()
+  })
+
+  test("quests tab is present and selectable", async ({ page }) => {
+    await expect(page.getByRole("tab", { name: /quests/i })).toBeVisible()
+  })
+
+  test("clicking earners tab keeps page stable", async ({ page }) => {
+    await page.getByRole("tab", { name: /earners/i }).click()
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("clicking quests tab switches to active quests list", async ({ page }) => {
+    await page.getByRole("tab", { name: /quests/i }).click()
+    await expect(page.locator("main")).toBeVisible()
+    const body = await page.textContent("body")
+    expect(body).toBeTruthy()
+  })
+
+  test("Refresh button is present on leaderboard", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /refresh/i })).toBeVisible()
+  })
+
+  test("Refresh button is clickable without crashing", async ({ page }) => {
+    await page.getByRole("button", { name: /refresh/i }).click()
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("shows loading, empty, or data state — never blank white screen", async ({ page }) => {
+    const body = await page.textContent("body")
+    expect(body!.trim().length).toBeGreaterThan(20)
+  })
+
+  test("earners tab has aria-selected=true when active", async ({ page }) => {
+    const earnersTab = page.getByRole("tab", { name: /earners/i })
+    const selected = await earnersTab.getAttribute("aria-selected")
+    expect(selected).toBe("true")
+  })
+
+  test("quests tab has aria-selected=true after click", async ({ page }) => {
+    const questsTab = page.getByRole("tab", { name: /quests/i })
+    await questsTab.click()
+    const selected = await questsTab.getAttribute("aria-selected")
+    expect(selected).toBe("true")
+  })
+})
+
+// ─── Creator dashboard — reward pool ──────────────────────────────────────────
+
+test.describe("Earning — creator dashboard", () => {
+  test("shows connect wallet prompt without wallet", async ({ page }) => {
+    await page.goto("/creator-dashboard")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByText(/connect your wallet/i)).toBeVisible()
+  })
+
+  test("shows Connect Wallet button without wallet", async ({ page }) => {
+    await page.goto("/creator-dashboard")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByRole("button", { name: /connect wallet/i })).toBeVisible()
+  })
+
+  test.describe("with wallet connected", () => {
+    test.beforeEach(async ({ page }) => {
+      await mockWallet(page)
+      await page.goto("/creator-dashboard")
+      await page.waitForLoadState("networkidle")
+      await page.waitForTimeout(800)
+    })
+
+    test("creator dashboard renders without crashing", async ({ page }) => {
+      await expect(page.locator("main")).toBeVisible()
+    })
+
+    test("shows Creator Dashboard heading", async ({ page }) => {
+      await expect(page.getByText(/creator dashboard|manage your quests/i)).toBeVisible()
+    })
+
+    test("Create Quest button is present on creator dashboard", async ({ page }) => {
+      const hasCreate = await page
+        .getByRole("button", { name: /create quest/i })
+        .isVisible()
+        .catch(() => false)
+      const hasLink = await page
+        .getByText(/create quest/i)
+        .isVisible()
+        .catch(() => false)
+      expect(hasCreate || hasLink).toBe(true)
+    })
+
+    test("Refresh button is present on creator dashboard", async ({ page }) => {
+      const hasRefresh = await page
+        .getByRole("button", { name: /refresh/i })
+        .isVisible()
+        .catch(() => false)
+      if (!hasRefresh) test.skip()
+      await expect(page.getByRole("button", { name: /refresh/i })).toBeEnabled()
+    })
+
+    test("shows loading skeleton or quest analytics on creator dashboard", async ({ page }) => {
+      const body = await page.textContent("body")
+      expect(body!.trim().length).toBeGreaterThan(20)
+    })
+  })
+})

--- a/frontend/e2e/helpers/mock-wallet.ts
+++ b/frontend/e2e/helpers/mock-wallet.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test"
+
+export const MOCK_ADDRESS = "GBMOCKADDRESS123STELLAR456WALLET789ABCDEFGH"
+
+/**
+ * Inject a stubbed Freighter wallet into the page before any scripts run.
+ * Must be called before page.goto().
+ */
+export async function mockWallet(page: Page, address = MOCK_ADDRESS) {
+  await page.addInitScript((addr: string) => {
+    const stub = {
+      isConnected: () => Promise.resolve(true),
+      getAddress: () => Promise.resolve({ address: addr }),
+      getNetwork: () =>
+        Promise.resolve({
+          network: "TESTNET",
+          networkPassphrase: "Test SDF Network ; September 2015",
+        }),
+      getNetworkDetails: () =>
+        Promise.resolve({
+          network: "TESTNET",
+          networkPassphrase: "Test SDF Network ; September 2015",
+        }),
+      requestAccess: () => Promise.resolve({ address: addr }),
+      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr }),
+    }
+    Object.defineProperty(window, "freighter", { value: stub, writable: true })
+    Object.defineProperty(window, "freighterApi", { value: stub, writable: true })
+  }, address)
+}

--- a/frontend/e2e/milestone-completion.spec.ts
+++ b/frontend/e2e/milestone-completion.spec.ts
@@ -1,28 +1,5 @@
-import { test, expect, type Page } from "@playwright/test"
-
-async function mockWallet(page: Page) {
-  await page.addInitScript(() => {
-    const mockAddress = "GBMOCKADDRESS123STELLAR456WALLET789ABCDEFGH"
-    const stub = {
-      isConnected: () => Promise.resolve(true),
-      getAddress: () => Promise.resolve({ address: mockAddress }),
-      getNetwork: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      getNetworkDetails: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      requestAccess: () => Promise.resolve({ address: mockAddress }),
-      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr }),
-    }
-    Object.defineProperty(window, "freighter", { value: stub, writable: true })
-    Object.defineProperty(window, "freighterApi", { value: stub, writable: true })
-  })
-}
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
 
 test.describe("Milestone completion happy path", () => {
   test("create quest page is accessible and renders form", async ({ page }) => {

--- a/frontend/e2e/quest-creation-wizard.spec.ts
+++ b/frontend/e2e/quest-creation-wizard.spec.ts
@@ -1,0 +1,343 @@
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
+
+// ─── Shared setup ─────────────────────────────────────────────────────────────
+
+test.describe("Quest creation wizard", () => {
+  // ── Unauthenticated guard ────────────────────────────────────────────────────
+
+  test.describe("wallet not connected", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/quest/create")
+      await page.waitForLoadState("networkidle")
+    })
+
+    test("shows wallet connect prompt instead of form", async ({ page }) => {
+      await expect(page.getByText(/connect your wallet/i)).toBeVisible()
+    })
+
+    test("shows Connect Wallet CTA button", async ({ page }) => {
+      await expect(
+        page.getByRole("main").getByRole("button", { name: /connect wallet/i })
+      ).toBeVisible()
+    })
+
+    test("shows Not Connected status badge", async ({ page }) => {
+      await expect(page.getByText(/not connected/i)).toBeVisible()
+    })
+
+    test("shows Back to Dashboard link", async ({ page }) => {
+      await expect(page.getByText(/back to dashboard/i)).toBeVisible()
+    })
+  })
+
+  // ── Step 1 — Quest basics ────────────────────────────────────────────────────
+
+  test.describe("step 1 — quest basics", () => {
+    test.beforeEach(async ({ page }) => {
+      await mockWallet(page)
+      await page.goto("/quest/create")
+      await page.waitForLoadState("networkidle")
+      await page.waitForTimeout(800)
+    })
+
+    test("renders step 1 heading when wallet is connected", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      await expect(page.getByText(/quest basics/i)).toBeVisible()
+    })
+
+    test("quest name field is present and accepts input", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      const nameInput = page.getByRole("textbox", { name: /quest name/i })
+      await expect(nameInput).toBeVisible()
+      await nameInput.fill("My Test Quest")
+      await expect(nameInput).toHaveValue("My Test Quest")
+    })
+
+    test("description field is present and accepts input", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      const desc = page.getByRole("textbox", { name: /description/i })
+      await expect(desc).toBeVisible()
+      await desc.fill("A meaningful quest description")
+      await expect(desc).toHaveValue("A meaningful quest description")
+    })
+
+    test("category field is present and accepts input", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      const category = page.getByRole("textbox", { name: /category/i })
+      await expect(category).toBeVisible()
+      await category.fill("Programming")
+      await expect(category).toHaveValue("Programming")
+    })
+
+    test("tag can be added and shows as pill", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      const tagInput = page.locator("#quest-tag-input")
+      await tagInput.fill("soroban")
+      await page.getByRole("button", { name: /add tag/i }).click()
+
+      await expect(page.getByText("#soroban")).toBeVisible()
+    })
+
+    test("tag can be removed by clicking the X button", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      const tagInput = page.locator("#quest-tag-input")
+      await tagInput.fill("rust")
+      await page.getByRole("button", { name: /add tag/i }).click()
+      await expect(page.getByText("#rust")).toBeVisible()
+
+      await page.getByRole("button", { name: /remove tag rust/i }).click()
+      await expect(page.getByText("#rust")).not.toBeVisible()
+    })
+
+    test("pressing Enter in the tag input adds the tag", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      await page.locator("#quest-tag-input").fill("stellar")
+      await page.keyboard.press("Enter")
+      await expect(page.getByText("#stellar")).toBeVisible()
+    })
+
+    test("shows character counter for name field", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      await page.getByRole("textbox", { name: /quest name/i }).fill("Hello")
+      await expect(page.getByText(/5\/64/)).toBeVisible()
+    })
+
+    test("shows validation errors when Next is clicked with empty fields", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      await page.getByRole("button", { name: /next/i }).click()
+      const errors = page.locator("[role='alert'], .text-destructive")
+      await expect(errors.first()).toBeVisible()
+    })
+
+    test("Next button advances to step 2 when form is valid", async ({ page }) => {
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) test.skip()
+
+      await page.getByRole("textbox", { name: /quest name/i }).fill("Learn Soroban")
+      await page.getByRole("textbox", { name: /description/i }).fill("Build smart contracts on Stellar from scratch.")
+      await page.getByRole("textbox", { name: /category/i }).fill("Blockchain")
+
+      await page.getByRole("button", { name: /next/i }).click()
+      await expect(page.getByText(/step 2/i)).toBeVisible()
+    })
+  })
+
+  // ── Step 2 — Milestones ──────────────────────────────────────────────────────
+
+  test.describe("step 2 — milestones", () => {
+    /**
+     * Navigates to step 2 by filling step 1 with valid data.
+     */
+    async function advanceToStep2(page: import("@playwright/test").Page) {
+      await mockWallet(page)
+      await page.goto("/quest/create")
+      await page.waitForLoadState("networkidle")
+      await page.waitForTimeout(800)
+
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) return false
+
+      await page.getByRole("textbox", { name: /quest name/i }).fill("Learn Soroban")
+      await page
+        .getByRole("textbox", { name: /description/i })
+        .fill("Build smart contracts on Stellar from scratch.")
+      await page.getByRole("textbox", { name: /category/i }).fill("Blockchain")
+      await page.getByRole("button", { name: /next/i }).click()
+      await expect(page.getByText(/step 2/i)).toBeVisible()
+      return true
+    }
+
+    test("shows milestones heading", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await expect(page.getByText(/milestones/i)).toBeVisible()
+    })
+
+    test("first milestone row is pre-populated in the form", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await expect(page.locator("#milestone-0-title")).toBeVisible()
+      await expect(page.locator("#milestone-0-description")).toBeVisible()
+      await expect(page.locator("#milestone-0-reward")).toBeVisible()
+    })
+
+    test("can fill in milestone title and description", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await page.locator("#milestone-0-title").fill("Hello World")
+      await page.locator("#milestone-0-description").fill("Write your first program.")
+      await page.locator("#milestone-0-reward").fill("50")
+
+      await expect(page.locator("#milestone-0-title")).toHaveValue("Hello World")
+    })
+
+    test("Add Milestone button appends a new milestone row", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      const before = await page.locator("[id^='milestone-'][id$='-title']").count()
+      await page.getByRole("button", { name: /add milestone/i }).click()
+      const after = await page.locator("[id^='milestone-'][id$='-title']").count()
+      expect(after).toBe(before + 1)
+    })
+
+    test("Remove button deletes a milestone row (when more than one exists)", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      // Add a second milestone first
+      await page.getByRole("button", { name: /add milestone/i }).click()
+      const before = await page.locator("[id^='milestone-'][id$='-title']").count()
+
+      await page.getByRole("button", { name: /remove milestone 2/i }).click()
+      const after = await page.locator("[id^='milestone-'][id$='-title']").count()
+      expect(after).toBe(before - 1)
+    })
+
+    test("total reward pool updates as reward amounts are entered", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await page.locator("#milestone-0-title").fill("First Step")
+      await page.locator("#milestone-0-description").fill("Do the first thing.")
+      await page.locator("#milestone-0-reward").fill("100")
+
+      // The running total badge should reflect 100 USDC
+      await expect(page.getByText(/100/)).toBeVisible()
+    })
+
+    test("Back button returns to step 1", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await page.getByRole("button", { name: /back/i }).click()
+      await expect(page.getByText(/step 1/i)).toBeVisible()
+    })
+
+    test("Next advances to step 3 when at least one valid milestone exists", async ({ page }) => {
+      const ok = await advanceToStep2(page)
+      if (!ok) test.skip()
+
+      await page.locator("#milestone-0-title").fill("Hello World")
+      await page.locator("#milestone-0-description").fill("Write your first program.")
+      await page.locator("#milestone-0-reward").fill("50")
+
+      await page.getByRole("button", { name: /next|fund/i }).click()
+      await expect(page.getByText(/step 3/i)).toBeVisible()
+    })
+  })
+
+  // ── Step 3 — Fund & Review ───────────────────────────────────────────────────
+
+  test.describe("step 3 — fund & review", () => {
+    async function advanceToStep3(page: import("@playwright/test").Page) {
+      await mockWallet(page)
+      await page.goto("/quest/create")
+      await page.waitForLoadState("networkidle")
+      await page.waitForTimeout(800)
+
+      const isStep1 = await page.getByText(/step 1/i).isVisible().catch(() => false)
+      if (!isStep1) return false
+
+      // Step 1
+      await page.getByRole("textbox", { name: /quest name/i }).fill("Learn Soroban")
+      await page
+        .getByRole("textbox", { name: /description/i })
+        .fill("Build smart contracts on Stellar from scratch.")
+      await page.getByRole("textbox", { name: /category/i }).fill("Blockchain")
+      await page.getByRole("button", { name: /next/i }).click()
+      await expect(page.getByText(/step 2/i)).toBeVisible()
+
+      // Step 2
+      await page.locator("#milestone-0-title").fill("Hello World")
+      await page.locator("#milestone-0-description").fill("Write your first program.")
+      await page.locator("#milestone-0-reward").fill("50")
+      await page.getByRole("button", { name: /next|fund/i }).click()
+      await expect(page.getByText(/step 3/i)).toBeVisible()
+      return true
+    }
+
+    test("displays quest name from step 1 in the review panel", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      await expect(page.getByText("Learn Soroban")).toBeVisible()
+    })
+
+    test("displays milestone count from step 2", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      await expect(page.getByText(/milestones \(1\)/i)).toBeVisible()
+    })
+
+    test("displays total reward pool amount", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      await expect(page.getByText(/50/)).toBeVisible()
+    })
+
+    test("Fund Reward Pool button is visible and clickable", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      const fundBtn = page.getByRole("button", { name: /fund reward pool/i })
+      await expect(fundBtn).toBeVisible()
+      await expect(fundBtn).toBeEnabled()
+    })
+
+    test("Confirm & Create Quest button is disabled before pool is funded", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      const createBtn = page.getByRole("button", { name: /confirm.*create quest/i })
+      await expect(createBtn).toBeDisabled()
+    })
+
+    test("funding the pool enables the Create Quest button", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      await page.getByRole("button", { name: /fund reward pool/i }).click()
+
+      // Wait for simulated 2 s funding tx
+      await expect(
+        page.getByRole("button", { name: /reward pool funded/i })
+      ).toBeVisible({ timeout: 5000 })
+
+      const createBtn = page.getByRole("button", { name: /confirm.*create quest/i })
+      await expect(createBtn).toBeEnabled()
+    })
+
+    test("Back button returns to step 2", async ({ page }) => {
+      const ok = await advanceToStep3(page)
+      if (!ok) test.skip()
+
+      await page.getByRole("button", { name: /back/i }).click()
+      await expect(page.getByText(/step 2/i)).toBeVisible()
+    })
+  })
+})

--- a/frontend/e2e/quest-participation.spec.ts
+++ b/frontend/e2e/quest-participation.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
+
+/**
+ * Tests covering the quest participation flow:
+ *   - Browse quests on the dashboard
+ *   - View quest detail page (milestones + enrollees tabs)
+ *   - Enroll interaction
+ *   - Navigation between quest detail and dashboard
+ */
+
+test.describe("Quest participation — dashboard browsing", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWallet(page)
+    await page.goto("/dashboard")
+    await page.waitForLoadState("networkidle")
+    await page.waitForTimeout(800)
+  })
+
+  test("dashboard renders without crashing", async ({ page }) => {
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("shows quest list or loading/empty state", async ({ page }) => {
+    const hasContent =
+      (await page.locator("main").textContent()) !== ""
+    expect(hasContent).toBe(true)
+  })
+
+  test("filter bar is present on dashboard", async ({ page }) => {
+    // The dashboard has All / Owned / Enrolled filter tabs
+    const hasAll = await page.getByRole("button", { name: /^all$/i }).isVisible().catch(() => false)
+    const hasFilter = await page.getByText(/all|owned|enrolled/i).isVisible().catch(() => false)
+    expect(hasAll || hasFilter).toBe(true)
+  })
+
+  test("Create Quest button is present on dashboard", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: /create quest/i })
+    ).toBeVisible()
+  })
+
+  test("clicking Create Quest navigates to quest creation wizard", async ({ page }) => {
+    await page.getByRole("button", { name: /create quest/i }).click()
+    await expect(page).toHaveURL(/\/create-quest|\/quest\/create/)
+  })
+})
+
+test.describe("Quest participation — quest detail page", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWallet(page)
+    await page.goto("/quest/0")
+    await page.waitForLoadState("networkidle")
+    await page.waitForTimeout(600)
+  })
+
+  test("quest detail page renders without crashing", async ({ page }) => {
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("shows quest name from mock data", async ({ page }) => {
+    // Quest 0 is "Learn to Code with Alex"
+    await expect(page.getByText(/learn to code with alex/i)).toBeVisible()
+  })
+
+  test("shows Milestones tab", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: /milestones/i })
+    ).toBeVisible()
+  })
+
+  test("shows Enrollees tab", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: /enrollees/i })
+    ).toBeVisible()
+  })
+
+  test("milestones tab is active by default and shows milestone list", async ({ page }) => {
+    // Mock milestones for quest 0: Hello World, Build a CLI Tool, etc.
+    const hasMilestones = await page
+      .getByText(/hello world|build a cli|milestone/i)
+      .isVisible()
+      .catch(() => false)
+    const hasTab = await page.getByRole("button", { name: /milestones/i }).isVisible().catch(() => false)
+    expect(hasMilestones || hasTab).toBe(true)
+  })
+
+  test("clicking Enrollees tab shows enrollees section", async ({ page }) => {
+    const enrolleesTab = page.getByRole("button", { name: /enrollees/i })
+    await enrolleesTab.click()
+    // Page should not crash
+    await expect(page.locator("main")).toBeVisible()
+    // Some enrollee-related content or empty state should appear
+    const body = await page.textContent("body")
+    expect(body).toBeTruthy()
+  })
+
+  test("clicking Milestones tab after Enrollees tab switches back", async ({ page }) => {
+    await page.getByRole("button", { name: /enrollees/i }).click()
+    await page.getByRole("button", { name: /milestones/i }).click()
+
+    const hasMilestonesContent = await page
+      .getByText(/hello world|build a cli|reward|usdc/i)
+      .isVisible()
+      .catch(() => false)
+    const tabVisible = await page.getByRole("button", { name: /milestones/i }).isVisible()
+    expect(hasMilestonesContent || tabVisible).toBe(true)
+  })
+
+  test("quest stats panel renders (enrollees, milestones, pool)", async ({ page }) => {
+    // Stats panel should show numbers. Mock quest 0 has 3 enrollees, 5 milestones.
+    const body = await page.textContent("body")
+    // At least some numerical content should be visible
+    expect(body).toMatch(/\d/)
+  })
+
+  test("Back button is present and navigates away from quest detail", async ({ page }) => {
+    const backBtn = page.getByRole("button", { name: /back/i })
+    const hasBack = await backBtn.isVisible().catch(() => false)
+    if (!hasBack) test.skip()
+
+    await backBtn.click()
+    // Should navigate to dashboard or landing
+    await expect(page).toHaveURL(/\/dashboard|\//)
+  })
+})
+
+test.describe("Quest participation — quest not found", () => {
+  test("renders not-found message for unknown quest id", async ({ page }) => {
+    await mockWallet(page)
+    await page.goto("/quest/99999")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByText(/quest not found/i)).toBeVisible()
+  })
+
+  test("shows Go back button on quest not found", async ({ page }) => {
+    await page.goto("/quest/99999")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByRole("button", { name: /go back/i })).toBeVisible()
+  })
+})
+
+test.describe("Quest participation — navigation flows", () => {
+  test("navigates from dashboard quest card to quest detail", async ({ page }) => {
+    await mockWallet(page)
+    await page.goto("/dashboard")
+    await page.waitForLoadState("networkidle")
+    await page.waitForTimeout(800)
+
+    // If any quest card links exist, click the first one
+    const questLink = page.locator("a[href^='/quest/']").first()
+    const hasLink = await questLink.isVisible().catch(() => false)
+    if (!hasLink) {
+      // Alternatively navigate directly — still a valid participation entry point
+      await page.goto("/quest/0")
+      await page.waitForLoadState("networkidle")
+      await expect(page.locator("main")).toBeVisible()
+      return
+    }
+
+    await questLink.click()
+    await expect(page).toHaveURL(/\/quest\/\d+/)
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("creator profile page renders for a quest owner address", async ({ page }) => {
+    const mockAddr = "GBXRK2YQABCDEF"
+    await page.goto(`/creator/${mockAddr}`)
+    await page.waitForLoadState("networkidle")
+    await expect(page.locator("main")).toBeVisible()
+  })
+
+  test("quest detail at /quest/1 renders Stellar Development Bootcamp", async ({ page }) => {
+    await mockWallet(page)
+    await page.goto("/quest/1")
+    await page.waitForLoadState("networkidle")
+
+    await expect(page.getByText(/stellar development bootcamp/i)).toBeVisible()
+  })
+})

--- a/frontend/e2e/transaction-confirm-dialog.spec.ts
+++ b/frontend/e2e/transaction-confirm-dialog.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "@playwright/test"
+import { test, expect } from "@playwright/test"
+import { mockWallet } from "./helpers/mock-wallet"
 
 /**
  * The TransactionConfirmDialog is rendered inside the quest page when a
@@ -11,32 +12,8 @@ import { test, expect, type Page } from "@playwright/test"
  * verifying the ARIA attributes, focus-trap, and ESC-to-close behaviour.
  */
 
-async function mockWallet(page: Page) {
-  await page.addInitScript(() => {
-    const mockAddress = "GBMOCKADDRESS123STELLAR456WALLET789ABCDEFGH"
-    const stub = {
-      isConnected: () => Promise.resolve(true),
-      getAddress: () => Promise.resolve({ address: mockAddress }),
-      getNetwork: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      getNetworkDetails: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
-      requestAccess: () => Promise.resolve({ address: mockAddress }),
-      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr }),
-    }
-    Object.defineProperty(window, "freighter", { value: stub, writable: true })
-    Object.defineProperty(window, "freighterApi", { value: stub, writable: true })
-  })
-}
-
 /** Inject a mounted TransactionConfirmDialog into the page via a script tag. */
-async function openDialogViaInjection(page: Page) {
+async function openDialogViaInjection(page: import("@playwright/test").Page) {
   await page.evaluate(() => {
     // Find the React root and dispatch a custom event that the app can listen to,
     // or directly manipulate the DOM to simulate the dialog being open.


### PR DESCRIPTION
…arning (#1217)

- Add shared mock-wallet helper (DRY up wallet stub across all specs)
- Add quest-creation-wizard.spec.ts: full 3-step wizard flow (step1 form validation, step2 milestone CRUD, step3 fund+review sequence)
- Add quest-participation.spec.ts: dashboard browsing, quest detail tabs (milestones/enrollees), not-found guard, cross-page navigation
- Add earning.spec.ts: profile page earnings display, leaderboard tab switching + ARIA contract, creator-dashboard reward pool UI
- Refactor create-quest.spec.ts, milestone-completion.spec.ts, and transaction-confirm-dialog.spec.ts to import from shared helper

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

closes #1217 
