### PR TITLE
fix(frontend): add validation and logging for dashboard deduplication

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -76,23 +76,44 @@ export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} 
           ])
         : [[], []]
 
-      const accessibleQuests = Array.from(
-        new Map(
-          [...publicQuests, ...ownedQuests, ...enrolledQuests].map(
-            quest => [quest.id, quest] as const
-          )
-        ).values()
+      const allQuests = [...publicQuests, ...ownedQuests, ...enrolledQuests]
+      if (allQuests.length === 0) {
+        console.warn("[Dashboard] No quests loaded from any source")
+      }
+
+      const questMap = new Map(allQuests.map(quest => [quest.id, quest] as const))
+
+      if (questMap.size < allQuests.length) {
+        console.warn(
+          `[Dashboard] Deduplication lost ${allQuests.length - questMap.size} quest(s)`,
+          { before: allQuests.length, after: questMap.size }
+        )
+      }
+
+      const accessibleQuests = Array.from(questMap.values())
+
+      const previewAllQuests = [
+        ...publicQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
+        ...ownedQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
+        ...enrolledQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
+      ]
+
+      if (previewAllQuests.length === 0) {
+        console.warn("[Dashboard] No preview quests loaded from any source")
+      }
+
+      const previewQuestMap = new Map(
+        previewAllQuests.map(quest => [quest.id, quest] as const)
       )
 
-      const previewQuests = Array.from(
-        new Map(
-          [
-            ...publicQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
-            ...ownedQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
-            ...enrolledQuests.slice(0, DASHBOARD_QUEST_PAGE_SIZE),
-          ].map(quest => [quest.id, quest] as const)
-        ).values()
-      )
+      if (previewQuestMap.size < previewAllQuests.length) {
+        console.warn(
+          `[Dashboard] Preview deduplication lost ${previewAllQuests.length - previewQuestMap.size} quest(s)`,
+          { before: previewAllQuests.length, after: previewQuestMap.size }
+        )
+      }
+
+      const previewQuests = Array.from(previewQuestMap.values())
 
       let questCompletions: Record<number, number> = {}
       let userEarnings = 0n


### PR DESCRIPTION
# PR #1275 — Dashboard Deduplication Validation and Logging
## Summary
This PR fixes silent data loss in the dashboard component's quest deduplication logic. The original implementation used a `Map` to merge quests from multiple sources (public, owned, enrolled) without any validation that the deduplication succeeded or that the resulting set was non-empty. This made it impossible to distinguish between "no quests available" and "a data loading error," and silently dropped duplicate quest IDs without any warning.
## Problem
The dashboard component at `frontend/src/pages/dashboard.tsx` deduplicated quests using a `Map` with quest ID as key, but had no validation or logging:
1. **Silent data loss**: If two sources returned the same quest ID with different data, the `Map` kept only one (later one wins) with no indication.
2. **Unclear semantics**: It was ambiguous which quest "wins" when there's a conflict across sources.
3. **Empty result ambiguity**: When all sources returned empty arrays, the component rendered with no quests, which could be confused with a data loading error rather than an intentional empty state.
## Solution
Added validation and logging around both deduplication blocks (`accessibleQuests` and `previewQuests`):
1. **Empty source warning**: A `console.warn` is emitted when all quest sources return empty arrays, making it clear that no data was loaded.
2. **Deduplication loss warning**: A `console.warn` is emitted when the `Map` size is smaller than the input array length, indicating that duplicate quest IDs were encountered and data was lost. The warning includes the before/after counts for debugging.
3. **Separate validation for preview quests**: The same validation pattern is applied to the preview quest deduplication block.
## Changes
- `frontend/src/pages/dashboard.tsx`: Replaced inline `Map` deduplication with validated versions that log warnings for empty sources and duplicate data loss.
## Verification
- The `pnpm build` type-check passes with the new code.
- The `console.warn` calls provide actionable debugging information when deduplication issues occur.
## Related Issue
closes #1275