### PR TITLE
fix(frontend): include category in quest search placeholder and add test coverage

### DIFF
--- a/frontend/src/pages/dashboard-search.test.tsx
+++ b/frontend/src/pages/dashboard-search.test.tsx
@@ -145,11 +145,25 @@ describe("Dashboard quest search, category filter, and sort", () => {
     } as unknown as ReturnType<typeof useWallet>)
   })
 
-  it("filters quests by search text across name, description, and tags", async () => {
+  it("filters quests by search text across name, description, category, and tags", async () => {
     const { container } = render(<Dashboard />)
 
     const search = await screen.findByPlaceholderText(/search quests/i)
     fireEvent.change(search, { target: { value: "soroban" } })
+
+    const grid = getQuestGrid(container)
+    expect(await within(grid).findByText("Advanced Soroban")).toBeInTheDocument()
+    expect(within(grid).queryByText("Rust Basics")).not.toBeInTheDocument()
+    expect(within(grid).queryByText("Design Fundamentals")).not.toBeInTheDocument()
+  })
+
+  it("finds quests by searching category name even when name and tags do not match", async () => {
+    const { container } = render(<Dashboard />)
+
+    const search = await screen.findByPlaceholderText(/search quests/i)
+    // "Blockchain" only appears in the category field of "Advanced Soroban",
+    // not in its name, description, or tags.
+    fireEvent.change(search, { target: { value: "blockchain" } })
 
     const grid = getQuestGrid(container)
     expect(await within(grid).findByText("Advanced Soroban")).toBeInTheDocument()

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -405,7 +405,11 @@ export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} 
                 <h2 className="flex items-center gap-2 text-xl font-semibold">
                   <LayoutDashboard className="h-5 w-5" /> Your Quests
                 </h2>
-                <div className="border-border flex gap-0 border shadow-md" role="group" aria-label="Quest filter">
+                <div
+                  className="border-border flex gap-0 border shadow-md"
+                  role="group"
+                  aria-label="Quest filter"
+                >
                   {(["all", "owned", "enrolled"] as const).map(f => (
                     <button
                       key={f}
@@ -429,7 +433,7 @@ export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} 
                     type="text"
                     value={search}
                     onChange={e => setSearch(e.target.value)}
-                    placeholder="Search quests by name, description, or tag"
+                    placeholder="Search quests by name, description, category, or tag"
                     aria-label="Search quests"
                     className="border-border bg-background w-full border py-2.5 pr-9 pl-9 text-sm font-medium transition-shadow focus:shadow-md focus:outline-none"
                   />


### PR DESCRIPTION
## Summary

Adds category name to the quest search placeholder text and adds test coverage for searching quests by category name.

The haystack on line 191 of `dashboard.tsx` already indexes `q.category`, so the core search logic was working correctly. This change updates the placeholder text and tests to accurately reflect that categories are searchable.

Closes #1343

## Changes

- **`dashboard.tsx`** — Updated the search input placeholder from "Search quests by name, description, or tag" to "Search quests by name, description, category, or tag"
- **`dashboard-search.test.tsx`** — Added a new test case `"finds quests by searching category name even when name and tags do not match"` that verifies searching "blockchain" finds the "Advanced Soroban" quest (which has category "Blockchain" but whose name/description/tags don't contain "blockchain"). Also updated the existing test description to include "category".

## Verification

- ✅ TypeScript: `tsc --noEmit` passes
- ✅ ESLint: `--max-warnings=0` passes for changed files
- ✅ All pre-commit checks pass
