### PR TITLE
feat(frontend): add guided onboarding tutorial flow for new users (#1225)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.27.0",
     "react": "^19.2.8",
-    "react-dom": "^19.2.7",
+    "react-dom": "^19.2.8",
     "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.83.0",
     "recharts": "^3.10.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8
       react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.8)
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       react-helmet-async:
         specifier: ^3.0.0
         version: 3.0.0(react@19.2.8)
@@ -49,7 +49,7 @@ importers:
         version: 7.83.0(react@19.2.8)
       recharts:
         specifier: ^3.10.1
-        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1)
+        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.6.0
@@ -92,7 +92,7 @@ importers:
         version: 10.5.5(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: ^10.5.5
-        version: 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -104,7 +104,7 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -2356,6 +2356,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2503,11 +2508,15 @@ packages:
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.7:
@@ -3653,6 +3662,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -3909,10 +3922,10 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -6097,9 +6110,9 @@ snapshots:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.8)
       '@storybook/csf-plugin': 10.5.5(esbuild@0.28.1)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@storybook/icons': 2.1.0(react@19.2.8)
-      '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
+      '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
       ts-dedent: 2.3.0
     optionalDependencies:
@@ -6175,26 +6188,26 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/react-dom-shim@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))':
+  '@storybook/react-dom-shim@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))':
     dependencies:
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
+  '@storybook/react-vite@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       '@storybook/builder-vite': 10.5.5(esbuild@0.28.1)(rollup@4.62.3)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
-      '@storybook/react': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)
+      '@storybook/react': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.8
       react-docgen: 8.0.3
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
       tsconfig-paths: 4.2.0
@@ -6209,14 +6222,14 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)':
+  '@storybook/react@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
+      '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
       react: 19.2.8
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
@@ -6330,12 +6343,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -6729,6 +6742,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  acorn@8.18.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -6907,11 +6922,15 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7568,7 +7587,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
@@ -8078,13 +8097,17 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.8
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -8318,7 +8341,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@19.2.7(react@19.2.8):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
@@ -8359,7 +8382,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1):
+  recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@17.0.2)(react@19.2.8)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
       clsx: 2.1.1
@@ -8368,7 +8391,7 @@ snapshots:
       eventemitter3: 5.0.4
       immer: 11.1.15
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       react-is: 17.0.2
       react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1)
       reselect: 5.2.0
@@ -8757,7 +8780,7 @@ snapshots:
   terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import { PrivacyPolicy } from "@/pages/privacy"
 import { PageSkeleton } from "@/components/page-skeleton"
 import { NotificationProvider } from "@/contexts/notification-context"
 import { useWallet } from "@/hooks/use-wallet"
+import { OnboardingTutorial } from "@/components/onboarding-tutorial"
+import { useOnboarding } from "@/hooks/use-onboarding"
 
 // Code-split heavy pages — they load on first visit to that route.
 const Dashboard = lazy(() => import("@/pages/dashboard").then((m) => ({ default: m.Dashboard })))
@@ -107,6 +109,17 @@ function pageToPath(page: Page, questId: number | null, creatorAddress: string |
 function App() {
   const [state, setState] = useState(() => pathToPage(window.location.pathname))
   const { toasts, addToast, removeToast } = useToast()
+  const onboarding = useOnboarding()
+  const { connected } = useWallet()
+
+  // Auto-trigger the tutorial the first time a wallet connects (if not yet completed)
+  useEffect(() => {
+    if (connected && !onboarding.completed && !onboarding.isOpen) {
+      onboarding.open(0)
+    }
+    // We only want this to fire when `connected` transitions to true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connected])
 
   useEffect(() => {
     const onPopState = () => setState(pathToPage(window.location.pathname))
@@ -159,6 +172,7 @@ function App() {
             <Dashboard
               onSelectQuest={handleSelectQuest}
               onCreateQuest={() => handleNavigate("create-quest")}
+              onLaunchTutorial={() => onboarding.open(0)}
             />
           </Suspense>
         )
@@ -210,7 +224,7 @@ function App() {
               Skip to main content
             </a>
             <SectionErrorBoundary label="Navigation">
-              <Navbar activePage={state.page} onNavigate={handleNavigate} />
+              <Navbar activePage={state.page} onNavigate={handleNavigate} onLaunchTutorial={() => onboarding.open(0)} />
             </SectionErrorBoundary>
             <ErrorBoundary key={`${state.page}-${state.questId ?? state.creatorAddress ?? ""}`}>
               <main id="main-content">
@@ -224,6 +238,20 @@ function App() {
             <Analytics />
             <SpeedInsights />
             <ToastContainer toasts={toasts} onRemove={removeToast} />
+            <OnboardingTutorial
+              isOpen={onboarding.isOpen}
+              currentStep={onboarding.currentStep}
+              step={onboarding.step}
+              totalSteps={onboarding.totalSteps}
+              isFirstStep={onboarding.isFirstStep}
+              isLastStep={onboarding.isLastStep}
+              onNext={onboarding.next}
+              onBack={onboarding.back}
+              onSkip={onboarding.skip}
+              onComplete={onboarding.complete}
+              onClose={onboarding.close}
+              onJumpTo={onboarding.open}
+            />
           </div>
         </ErrorBoundary>
       </ErrorBoundaryProvider>

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Wallet, LogOut, Menu, X, Sun, Moon } from "lucide-react"
+import { Wallet, LogOut, Menu, X, Sun, Moon, BookOpen } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useWallet } from "@/hooks/use-wallet"
 import { useColorScheme } from "@/hooks/use-color-scheme"
@@ -15,6 +15,8 @@ const NAV_ITEMS = [
 interface NavbarProps {
   activePage: string
   onNavigate: (page: string) => void
+  /** Optional callback to open the onboarding tutorial */
+  onLaunchTutorial?: () => void
 }
 
 function LogoMark({ className }: { className?: string }) {
@@ -59,7 +61,7 @@ function ThemeToggle() {
   )
 }
 
-export function Navbar({ activePage, onNavigate }: NavbarProps) {
+export function Navbar({ activePage, onNavigate, onLaunchTutorial }: NavbarProps) {
   const { connected, shortAddress, connect, disconnect, loading } = useWallet()
   const [mobileOpen, setMobileOpen] = useState(false)
 
@@ -102,9 +104,26 @@ export function Navbar({ activePage, onNavigate }: NavbarProps) {
           </ul>
         </nav>
 
-        {/* Right side: theme toggle + wallet + mobile menu */}
+        {/* Right side: theme toggle + tutorial + wallet + mobile menu */}
         <div className="flex items-center gap-2">
           <ThemeToggle />
+
+          {/* Tutorial launch button */}
+          {onLaunchTutorial && (
+            <button
+              onClick={onLaunchTutorial}
+              aria-label="Open getting started tutorial"
+              title="Getting started guide"
+              data-onboarding="tutorial-button"
+              className={cn(
+                "border-border h-11 w-11 border shadow-sm sm:h-9 sm:w-9",
+                "neo-press flex cursor-pointer items-center justify-center",
+                "bg-background text-foreground hover:bg-secondary transition-colors duration-300"
+              )}
+            >
+              <BookOpen className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
 
           {connected ? (
             <>

--- a/frontend/src/components/onboarding-tutorial.tsx
+++ b/frontend/src/components/onboarding-tutorial.tsx
@@ -1,0 +1,225 @@
+import { useEffect } from "react"
+import { ArrowRight, ArrowLeft, X, BookOpen, Wallet, LayoutDashboard, Users, CheckSquare, Coins } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useScrollLock } from "@/hooks/use-scroll-lock"
+import { cn } from "@/lib/utils"
+import type { OnboardingStep } from "@/hooks/use-onboarding"
+
+// ─── Step icon map ────────────────────────────────────────────────────────────
+
+const STEP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  welcome: BookOpen,
+  "connect-wallet": Wallet,
+  "browse-quests": LayoutDashboard,
+  enroll: Users,
+  "complete-milestones": CheckSquare,
+  "earn-rewards": Coins,
+}
+
+// ─── Step dot progress indicator ─────────────────────────────────────────────
+
+interface StepDotsProps {
+  total: number
+  current: number
+  onJump: (index: number) => void
+}
+
+function StepDots({ total, current, onJump }: StepDotsProps) {
+  return (
+    <div className="flex items-center gap-2" role="tablist" aria-label="Tutorial steps">
+      {Array.from({ length: total }).map((_, i) => (
+        <button
+          key={i}
+          role="tab"
+          aria-selected={i === current}
+          aria-label={`Step ${i + 1}`}
+          onClick={() => onJump(i)}
+          className={cn(
+            "border-border cursor-pointer border transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            i === current
+              ? "bg-accent h-2.5 w-6"
+              : i < current
+                ? "bg-foreground/40 h-2.5 w-2.5 hover:bg-foreground/60"
+                : "bg-muted h-2.5 w-2.5 hover:bg-muted-foreground/40"
+          )}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface OnboardingTutorialProps {
+  isOpen: boolean
+  currentStep: number
+  step: OnboardingStep
+  totalSteps: number
+  isFirstStep: boolean
+  isLastStep: boolean
+  onNext: () => void
+  onBack: () => void
+  onSkip: () => void
+  onComplete: () => void
+  onClose: () => void
+  onJumpTo: (index: number) => void
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+/**
+ * Full-screen overlay tutorial that guides new users through Lernza's
+ * quest participation and earning mechanics.
+ */
+export function OnboardingTutorial({
+  isOpen,
+  currentStep,
+  step,
+  totalSteps,
+  isFirstStep,
+  isLastStep,
+  onNext,
+  onBack,
+  onSkip,
+  onComplete,
+  onClose,
+  onJumpTo,
+}: OnboardingTutorialProps) {
+  // Prevent body scroll while the tutorial is open
+  useScrollLock(isOpen)
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const StepIcon = STEP_ICONS[step.id] ?? BookOpen
+  const progressPct = ((currentStep + 1) / totalSteps) * 100
+
+  return (
+    /* Backdrop */
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Lernza onboarding tutorial"
+      className="fixed inset-0 z-[9000] flex items-center justify-center p-4 sm:p-8"
+    >
+      {/* Dimmed overlay — clicking it closes the tutorial */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal card */}
+      <div
+        className={cn(
+          "bg-card text-card-foreground border-border relative z-10 w-full max-w-lg border shadow-xl",
+          "animate-fade-in-up"
+        )}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* ── Progress bar ── */}
+        <div className="bg-muted border-border h-1.5 w-full border-b">
+          <div
+            className="bg-accent h-full transition-all duration-500 ease-out"
+            style={{ width: `${progressPct}%` }}
+            role="progressbar"
+            aria-valuenow={currentStep + 1}
+            aria-valuemin={1}
+            aria-valuemax={totalSteps}
+            aria-label={`Step ${currentStep + 1} of ${totalSteps}`}
+          />
+        </div>
+
+        {/* ── Header ── */}
+        <div className="border-border flex items-center justify-between border-b px-6 py-4">
+          <span className="text-muted-foreground text-xs font-semibold tracking-widest uppercase">
+            Getting started — {currentStep + 1} / {totalSteps}
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close tutorial"
+            className="border-border hover:bg-secondary neo-press flex h-8 w-8 cursor-pointer items-center justify-center border transition-colors"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* ── Body ── */}
+        <div className="px-6 py-8">
+          {/* Icon */}
+          <div
+            className="bg-accent/10 border-border mb-6 flex h-14 w-14 items-center justify-center border"
+            aria-hidden="true"
+          >
+            <StepIcon className="text-accent h-7 w-7" />
+          </div>
+
+          {/* Text */}
+          <h2 className="mb-3 text-2xl font-bold tracking-tight">{step.title}</h2>
+          <p className="text-muted-foreground leading-relaxed">{step.description}</p>
+        </div>
+
+        {/* ── Footer ── */}
+        <div className="border-border flex flex-col gap-4 border-t px-6 py-5">
+          {/* Step dots */}
+          <div className="flex items-center justify-between">
+            <StepDots total={totalSteps} current={currentStep} onJump={onJumpTo} />
+            {/* Close/skip link — only visible when not on last step */}
+            {!isLastStep && (
+              <button
+                onClick={onSkip}
+                className="text-muted-foreground hover:text-foreground cursor-pointer text-xs font-medium underline-offset-2 transition-colors hover:underline"
+              >
+                Close and skip
+              </button>
+            )}
+          </div>
+
+          {/* Nav buttons */}
+          <div className="flex items-center gap-3">
+            {!isFirstStep && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={onBack}
+                aria-label="Previous step"
+                className="flex items-center gap-1.5"
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Back
+              </Button>
+            )}
+
+            <Button
+              size="sm"
+              onClick={isLastStep ? onComplete : onNext}
+              aria-label={isLastStep ? "Start earning — complete tutorial" : "Next step"}
+              className="ml-auto flex items-center gap-1.5"
+            >
+              {isLastStep ? (
+                <>
+                  Start earning
+                  <Coins className="h-4 w-4" aria-hidden="true" />
+                </>
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-onboarding.test.ts
+++ b/frontend/src/hooks/use-onboarding.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useOnboarding, ONBOARDING_STEPS, TOTAL_STEPS } from "./use-onboarding"
+
+// ─── localStorage helpers ────────────────────────────────────────────────────
+
+const STORAGE_KEY = "lernza_onboarding_completed"
+const STORAGE_STEP_KEY = "lernza_onboarding_step"
+
+function clearStorage() {
+  localStorage.removeItem(STORAGE_KEY)
+  localStorage.removeItem(STORAGE_STEP_KEY)
+}
+
+beforeEach(() => {
+  clearStorage()
+})
+
+afterEach(() => {
+  clearStorage()
+})
+
+// ─── Initial state ───────────────────────────────────────────────────────────
+
+describe("useOnboarding – initial state", () => {
+  it("starts closed, on step 0, not completed", () => {
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.currentStep).toBe(0)
+    expect(result.current.completed).toBe(false)
+  })
+
+  it("reports the correct total steps", () => {
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.totalSteps).toBe(TOTAL_STEPS)
+    expect(TOTAL_STEPS).toBe(ONBOARDING_STEPS.length)
+  })
+
+  it("initial step data matches the first ONBOARDING_STEPS entry", () => {
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.step).toEqual(ONBOARDING_STEPS[0])
+  })
+
+  it("isFirstStep is true on step 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.isFirstStep).toBe(true)
+  })
+
+  it("isLastStep is false on step 0 when total > 1", () => {
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.isLastStep).toBe(false)
+  })
+
+  it("reads completed=true from localStorage if already set", () => {
+    localStorage.setItem(STORAGE_KEY, "true")
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.completed).toBe(true)
+  })
+
+  it("reads saved step index from localStorage", () => {
+    localStorage.setItem(STORAGE_STEP_KEY, "2")
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.currentStep).toBe(2)
+  })
+
+  it("clamps out-of-range saved step to last valid index", () => {
+    localStorage.setItem(STORAGE_STEP_KEY, "999")
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.currentStep).toBe(TOTAL_STEPS - 1)
+  })
+
+  it("clamps negative saved step to 0", () => {
+    localStorage.setItem(STORAGE_STEP_KEY, "-5")
+    const { result } = renderHook(() => useOnboarding())
+    expect(result.current.currentStep).toBe(0)
+  })
+})
+
+// ─── open / close ────────────────────────────────────────────────────────────
+
+describe("useOnboarding – open / close", () => {
+  it("open() sets isOpen to true", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it("open(n) jumps to that step and opens", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(3) })
+    expect(result.current.currentStep).toBe(3)
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it("open() clamps negative index to 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(-5) })
+    expect(result.current.currentStep).toBe(0)
+  })
+
+  it("open() clamps index beyond total to last step", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(999) })
+    expect(result.current.currentStep).toBe(TOTAL_STEPS - 1)
+  })
+
+  it("close() sets isOpen to false without marking complete", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.close() })
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.completed).toBe(false)
+  })
+
+  it("close() does not write completed to localStorage", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.close() })
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})
+
+// ─── next / back ─────────────────────────────────────────────────────────────
+
+describe("useOnboarding – next / back", () => {
+  it("next() advances currentStep by 1", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.next() })
+    expect(result.current.currentStep).toBe(1)
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it("next() persists the new step index in localStorage", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.next() })
+    expect(localStorage.getItem(STORAGE_STEP_KEY)).toBe("1")
+  })
+
+  it("next() from the last step closes and marks complete", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(TOTAL_STEPS - 1) })
+    act(() => { result.current.next() })
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.completed).toBe(true)
+  })
+
+  it("next() from last step persists completed in localStorage", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(TOTAL_STEPS - 1) })
+    act(() => { result.current.next() })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true")
+  })
+
+  it("back() decrements currentStep by 1", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(2) })
+    act(() => { result.current.back() })
+    expect(result.current.currentStep).toBe(1)
+  })
+
+  it("back() on step 0 stays at 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(0) })
+    act(() => { result.current.back() })
+    expect(result.current.currentStep).toBe(0)
+  })
+
+  it("step data reflects the current step after next()", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.next() })
+    expect(result.current.step).toEqual(ONBOARDING_STEPS[1])
+  })
+
+  it("isLastStep is true on the final step", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(TOTAL_STEPS - 1) })
+    expect(result.current.isLastStep).toBe(true)
+  })
+
+  it("isFirstStep becomes false after advancing past step 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.next() })
+    expect(result.current.isFirstStep).toBe(false)
+  })
+})
+
+// ─── skip ─────────────────────────────────────────────────────────────────────
+
+describe("useOnboarding – skip", () => {
+  it("skip() closes the tutorial", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.skip() })
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it("skip() marks the tutorial as completed", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.skip() })
+    expect(result.current.completed).toBe(true)
+  })
+
+  it("skip() persists completed=true in localStorage", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open() })
+    act(() => { result.current.skip() })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true")
+  })
+})
+
+// ─── complete ────────────────────────────────────────────────────────────────
+
+describe("useOnboarding – complete", () => {
+  it("complete() closes and marks the tutorial done", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(TOTAL_STEPS - 1) })
+    act(() => { result.current.complete() })
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.completed).toBe(true)
+  })
+
+  it("complete() persists the completed flag to localStorage", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.complete() })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true")
+  })
+
+  it("complete() clears the saved step from localStorage", () => {
+    localStorage.setItem(STORAGE_STEP_KEY, "3")
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.complete() })
+    expect(localStorage.getItem(STORAGE_STEP_KEY)).toBeNull()
+  })
+})
+
+// ─── reset ───────────────────────────────────────────────────────────────────
+
+describe("useOnboarding – reset", () => {
+  it("reset() clears the completed flag", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.complete() })
+    act(() => { result.current.reset() })
+    expect(result.current.completed).toBe(false)
+  })
+
+  it("reset() returns to step 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.open(3) })
+    act(() => { result.current.reset() })
+    expect(result.current.currentStep).toBe(0)
+  })
+
+  it("reset() clears both localStorage keys", () => {
+    localStorage.setItem(STORAGE_KEY, "true")
+    localStorage.setItem(STORAGE_STEP_KEY, "3")
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.reset() })
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(STORAGE_STEP_KEY)).toBeNull()
+  })
+
+  it("after reset(), open() shows the tutorial again from step 0", () => {
+    const { result } = renderHook(() => useOnboarding())
+    act(() => { result.current.skip() })
+    act(() => { result.current.reset() })
+    act(() => { result.current.open() })
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.completed).toBe(false)
+    expect(result.current.currentStep).toBe(0)
+  })
+})
+
+// ─── ONBOARDING_STEPS data integrity ─────────────────────────────────────────
+
+describe("ONBOARDING_STEPS – data integrity", () => {
+  it("has at least 4 steps", () => {
+    expect(ONBOARDING_STEPS.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it("every step has a non-empty id, title, and description", () => {
+    for (const step of ONBOARDING_STEPS) {
+      expect(step.id.trim()).not.toBe("")
+      expect(step.title.trim()).not.toBe("")
+      expect(step.description.trim()).not.toBe("")
+    }
+  })
+
+  it("all step ids are unique", () => {
+    const ids = ONBOARDING_STEPS.map(s => s.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/frontend/src/hooks/use-onboarding.ts
+++ b/frontend/src/hooks/use-onboarding.ts
@@ -1,0 +1,219 @@
+import { useState, useCallback } from "react"
+
+const STORAGE_KEY = "lernza_onboarding_completed"
+const STORAGE_STEP_KEY = "lernza_onboarding_step"
+
+export interface OnboardingStep {
+  id: string
+  title: string
+  description: string
+  /** Optional highlight element selector (for future spotlight support) */
+  target?: string
+}
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: "welcome",
+    title: "Welcome to Lernza 👋",
+    description:
+      "Lernza is a learn-to-earn platform built on Stellar. Creators fund Quests with real tokens — you complete milestones and earn them. Let's walk you through how it works.",
+  },
+  {
+    id: "connect-wallet",
+    title: "Connect Your Wallet",
+    description:
+      "Install the Freighter browser extension and connect to Stellar Testnet. Your wallet is your identity — no accounts, no passwords. Just your keys.",
+    target: "[data-onboarding='connect-wallet']",
+  },
+  {
+    id: "browse-quests",
+    title: "Browse Available Quests",
+    description:
+      "Head to the Dashboard to see all open quests. Each quest has a title, description, a reward pool funded with tokens, and a set of milestones you need to complete.",
+    target: "[data-onboarding='dashboard-link']",
+  },
+  {
+    id: "enroll",
+    title: "Enroll in a Quest",
+    description:
+      "Click into any quest and hit Enroll. Once enrolled, the quest owner can also invite you directly. Enrollment is recorded on-chain — no backing out required.",
+    target: "[data-onboarding='quest-enroll']",
+  },
+  {
+    id: "complete-milestones",
+    title: "Complete Milestones",
+    description:
+      "Each quest has milestones — specific tasks like 'Deploy a smart contract' or 'Build your first API'. Complete them off-chain, then the quest owner verifies your work on-chain.",
+    target: "[data-onboarding='milestones']",
+  },
+  {
+    id: "earn-rewards",
+    title: "Earn Your Rewards 🎉",
+    description:
+      "After a milestone is verified, the quest owner distributes your reward directly to your wallet. Tokens are locked in the reward pool up front — no trust needed.",
+    target: "[data-onboarding='rewards']",
+  },
+]
+
+export const TOTAL_STEPS = ONBOARDING_STEPS.length
+
+function readCompleted(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+function readSavedStep(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_STEP_KEY)
+    if (raw === null) return 0
+    const parsed = parseInt(raw, 10)
+    return isNaN(parsed) ? 0 : Math.max(0, Math.min(parsed, TOTAL_STEPS - 1))
+  } catch {
+    return 0
+  }
+}
+
+function persistCompleted() {
+  try {
+    localStorage.setItem(STORAGE_KEY, "true")
+    localStorage.removeItem(STORAGE_STEP_KEY)
+  } catch {
+    // localStorage unavailable — best effort only.
+  }
+}
+
+function persistStep(step: number) {
+  try {
+    localStorage.setItem(STORAGE_STEP_KEY, String(step))
+  } catch {
+    // localStorage unavailable — best effort only.
+  }
+}
+
+function clearPersisted() {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+    localStorage.removeItem(STORAGE_STEP_KEY)
+  } catch {
+    // localStorage unavailable — best effort only.
+  }
+}
+
+export interface UseOnboardingReturn {
+  /** Whether the tutorial modal is currently visible */
+  isOpen: boolean
+  /** Index of the currently displayed step (0-based) */
+  currentStep: number
+  /** The step data for the current step */
+  step: OnboardingStep
+  /** Total number of steps */
+  totalSteps: number
+  /** Whether the user has already completed / dismissed the tutorial */
+  completed: boolean
+  /** Whether this is the last step */
+  isLastStep: boolean
+  /** Whether this is the first step */
+  isFirstStep: boolean
+  /** Open the tutorial (optionally from a specific step) */
+  open: (step?: number) => void
+  /** Close without marking complete */
+  close: () => void
+  /** Advance one step (closes and completes on the last step) */
+  next: () => void
+  /** Go back one step */
+  back: () => void
+  /** Skip and dismiss the tutorial permanently */
+  skip: () => void
+  /** Mark as complete and close */
+  complete: () => void
+  /** Reset so it will show again on next open */
+  reset: () => void
+}
+
+/**
+ * Manages the guided onboarding tutorial state.
+ * Progress is persisted to localStorage so the user can resume where they left off.
+ */
+export function useOnboarding(): UseOnboardingReturn {
+  const [completed, setCompleted] = useState<boolean>(readCompleted)
+  const [currentStep, setCurrentStep] = useState<number>(readSavedStep)
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(
+    (step?: number) => {
+      if (step !== undefined) {
+        const clamped = Math.max(0, Math.min(step, TOTAL_STEPS - 1))
+        setCurrentStep(clamped)
+        persistStep(clamped)
+      }
+      setCompleted(false)
+      setIsOpen(true)
+    },
+    []
+  )
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  const skip = useCallback(() => {
+    setIsOpen(false)
+    setCompleted(true)
+    persistCompleted()
+  }, [])
+
+  const complete = useCallback(() => {
+    setIsOpen(false)
+    setCompleted(true)
+    persistCompleted()
+  }, [])
+
+  const next = useCallback(() => {
+    setCurrentStep(prev => {
+      const nextStep = prev + 1
+      if (nextStep >= TOTAL_STEPS) {
+        // Complete the tutorial
+        setIsOpen(false)
+        setCompleted(true)
+        persistCompleted()
+        return prev
+      }
+      persistStep(nextStep)
+      return nextStep
+    })
+  }, [])
+
+  const back = useCallback(() => {
+    setCurrentStep(prev => {
+      const prevStep = Math.max(0, prev - 1)
+      persistStep(prevStep)
+      return prevStep
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    setCompleted(false)
+    setCurrentStep(0)
+    clearPersisted()
+  }, [])
+
+  return {
+    isOpen,
+    currentStep,
+    step: ONBOARDING_STEPS[currentStep],
+    totalSteps: TOTAL_STEPS,
+    completed,
+    isLastStep: currentStep === TOTAL_STEPS - 1,
+    isFirstStep: currentStep === 0,
+    open,
+    close,
+    next,
+    back,
+    skip,
+    complete,
+    reset,
+  }
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Search,
   X,
+  BookOpen,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -44,9 +45,11 @@ const RECENT_ACTIVITY_LIMIT = 5
 interface DashboardProps {
   onSelectQuest?: (id: number) => void
   onCreateQuest?: () => void
+  /** Optional callback to open the onboarding tutorial */
+  onLaunchTutorial?: () => void
 }
 
-export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} as DashboardProps) {
+export function Dashboard({ onSelectQuest, onCreateQuest, onLaunchTutorial }: DashboardProps = {} as DashboardProps) {
   const { connected, connect, shortAddress, address, loading: walletConnecting } = useWallet()
   const [filter, setFilter] = useState<"all" | "owned" | "enrolled">("all")
   const [preset, setPreset] = useState<
@@ -374,6 +377,18 @@ export function Dashboard({ onSelectQuest, onCreateQuest }: DashboardProps = {} 
             <Plus className="h-4 w-4" />
             Create quest
           </Button>
+          {onLaunchTutorial && (
+            <Button
+              variant="outline"
+              onClick={onLaunchTutorial}
+              data-onboarding="tutorial-button"
+              className="flex-shrink-0 flex items-center gap-2"
+              aria-label="Open getting started tutorial"
+            >
+              <BookOpen className="h-4 w-4" aria-hidden="true" />
+              Take the tour
+            </Button>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## What does this PR do?

Implements a complete, multi-step guided onboarding tutorial flow for new users explaining quest participation and earning mechanics on Lernza. The tutorial appears automatically on a user's first wallet connection and can be relaunched at any time from the Navbar or the Dashboard welcome banner.

## Related Issue

Closes #1225

## Type of Change

- [x] New feature
- [x] Tests

## Overview

This PR introduces the full guided onboarding experience described in issue #1225. New users now have a structured, step-by-step walkthrough that covers every stage of the Lernza platform — from connecting a Freighter wallet all the way through completing milestones and receiving token rewards into their wallet.

---

## Implementation Details

### 1. `useOnboarding` hook — `frontend/src/hooks/use-onboarding.ts`

A purpose-built React hook that owns all tutorial state. Key design decisions:

- **6 canonical steps** defined as `ONBOARDING_STEPS: OnboardingStep[]`, each with a unique `id`, `title`, `description`, and optional `target` selector for future spotlight targeting:
  1. **Welcome to Lernza** — brief platform intro
  2. **Connect Your Wallet** — Freighter extension and Testnet setup
  3. **Browse Available Quests** — navigating to the Dashboard
  4. **Enroll in a Quest** — on-chain enrollment mechanics
  5. **Complete Milestones** — off-chain work + owner verification flow
  6. **Earn Your Rewards** — token distribution directly to wallet

- **localStorage persistence** — the current step index (`lernza_onboarding_step`) is written on every `next()` / `back()` / `open(n)` call. If the user closes mid-tutorial and returns, they resume exactly where they left off. Completing or skipping writes `lernza_onboarding_completed = true` and removes the step key.

- **Full action surface**: `open(step?)`, `close()`, `next()`, `back()`, `skip()`, `complete()`, `reset()` — all memoised with `useCallback` to be safe as `useEffect` dependencies.

- **Step clamping** — `open(n)` and the initial read from storage both clamp to `[0, TOTAL_STEPS - 1]` so out-of-range or corrupted values are handled silently.

- **Auto-complete on last step** — calling `next()` on the final step closes the modal, writes `completed`, and removes the step key atomically (no separate `complete()` call required from the nav buttons, though `complete()` is also wired up directly on the CTA button).

- **`reset()`** — clears both localStorage keys and returns state to step 0, `completed = false`. Exposed for developer tooling or future account-switch scenarios.

### 2. `OnboardingTutorial` component — `frontend/src/components/onboarding-tutorial.tsx`

A focused, zero-dependency modal overlay component that renders the tutorial UI. Design choices:

- **Full-screen dimmed backdrop** with `backdrop-blur-sm`. Clicking the backdrop calls `onClose()` (close without completing, same as the ✕ button).
- **Animated modal card** — uses the project's existing `animate-fade-in-up` class, matching landing page and dashboard animation conventions.
- **Animated progress bar** — 500 ms ease-out transition fills left-to-right as steps advance, with ARIA `progressbar` role, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`.
- **Per-step icon mapping** — each step `id` maps to a Lucide icon: `BookOpen` (welcome), `Wallet` (connect), `LayoutDashboard` (browse), `Users` (enroll), `CheckSquare` (milestones), `Coins` (rewards). Renders in an ochre-tinted square matching the design system accent colour.
- **Clickable step dot navigation** — renders a `role=tablist` row of dots. The active step is a wider pill (`w-6`), completed steps are a solid mid-tone (`bg-foreground/40`), future steps are muted. Clicking any dot jumps directly to that step via `onJumpTo(i)`.
- **`Close and skip` link** — visible only when not on the last step; calls `onSkip()` which marks the tutorial permanently completed in localStorage so it will not auto-reappear.
- **Back / Next / Start earning buttons** — Back is `variant="secondary"`, hidden on step 0. The primary CTA switches to `Start earning` with a Coins icon on the last step.
- **Escape-key listener** — `useEffect` binds a `keydown` listener while the modal is open; pressing Escape calls `onClose()`.
- **Scroll lock** — delegates to the existing `useScrollLock(isLocked)` hook so the page behind the overlay cannot be scrolled while the tutorial is active.
- **Accessibility** — modal has `role="dialog"`, `aria-modal="true"`, `aria-label="Lernza onboarding tutorial"`. Backdrop has `aria-hidden="true"`. All icon-only elements have `aria-hidden="true"`. Buttons have descriptive `aria-label` attributes.

### 3. App-level integration — `frontend/src/App.tsx`

- **Auto-trigger on first wallet connect** — a `useEffect` watches the `connected` value from `useWallet()`. The first time it transitions to `true`, if the tutorial has not been completed/skipped yet, `onboarding.open(0)` fires automatically. The dependency array is intentionally limited to `[connected]` to avoid repeated triggers on re-renders.
- **Portal-level render** — `<OnboardingTutorial />` is rendered at the root of the app `div`, above all page content and below only the `<ToastContainer />`, ensuring the z-index stack (`z-[9000]`) is never clipped by page containers.
- **`onLaunchTutorial` prop wiring** — `() => onboarding.open(0)` is passed down to both `<Navbar>` and `<Dashboard>` so either surface can relaunch the tutorial.

### 4. Navbar — `frontend/src/components/navbar.tsx`

- Added optional `onLaunchTutorial?: () => void` to `NavbarProps` (backward-compatible, renders nothing if not provided).
- Added a `BookOpen` icon button in the right-side action area (between the theme toggle and the wallet connect button), matching the existing `ThemeToggle` sizing (`h-11 w-11` / `sm:h-9 sm:w-9`), border, and `neo-press` interaction style. Has `aria-label="Open getting started tutorial"` and `data-onboarding="tutorial-button"` for future E2E targeting.

### 5. Dashboard — `frontend/src/pages/dashboard.tsx`

- Added optional `onLaunchTutorial?: () => void` to `DashboardProps`.
- Added a **Take the tour** `<Button variant="outline">` next to the existing **Create quest** button in the welcome banner, visible only to connected users (the banner itself is already gated on `connected`). Includes the `BookOpen` icon and `data-onboarding="tutorial-button"`.

### 6. Dependency update — `frontend/package.json` / `frontend/pnpm-lock.yaml`

Resolved a pre-existing lockfile inconsistency where `react` was pinned at `^19.2.8` but `react-dom` resolved to `19.2.7` in the lockfile, causing a React version mismatch error in the jsdom test environment. Updated both to `19.2.8` in the lockfile.

---

## Test Coverage

New file: **`frontend/src/hooks/use-onboarding.test.ts`** — 37 tests, all passing:

| Suite | Count |
|---|---|
| `useOnboarding – initial state` | 9 |
| `useOnboarding – open / close` | 6 |
| `useOnboarding – next / back` | 9 |
| `useOnboarding – skip` | 3 |
| `useOnboarding – complete` | 3 |
| `useOnboarding – reset` | 4 |
| `ONBOARDING_STEPS – data integrity` | 3 |
| **Total** | **37** |

Covers: initial state and localStorage hydration, step clamping, auto-complete on last step, localStorage persistence for every action, close-without-completing, and data integrity of the steps array.

---

## CI Checklist

- [x] `pnpm lint` passes — 0 errors introduced (19 pre-existing warnings in unrelated files remain unchanged)
- [x] `pnpm run test` passes for all new test files (37/37) — pre-existing failures in `share-button.test.tsx`, `csv-import.test.tsx`, and storybook browser tests are unrelated to this PR
- [x] `pnpm run build` passes — production build completes in ~2.3 s with no new TypeScript errors
- [x] `pnpm install --frozen-lockfile` will succeed — lockfile updated and committed
- [x] No stale `workspace` references introduced in docs or contracts
- [x] No merge conflicts — branch based on latest `main` (`1e40ff1`)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(frontend):`)
- [x] I have added/updated tests for my changes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 new errors)

## Files Changed

| File | Change |
|---|---|
| `frontend/src/hooks/use-onboarding.ts` | New — tutorial state hook |
| `frontend/src/components/onboarding-tutorial.tsx` | New — tutorial overlay component |
| `frontend/src/hooks/use-onboarding.test.ts` | New — 37 unit tests |
| `frontend/src/App.tsx` | Modified — auto-trigger + render tutorial |
| `frontend/src/components/navbar.tsx` | Modified — tutorial launch button |
| `frontend/src/pages/dashboard.tsx` | Modified — 'Take the tour' button |
| `frontend/package.json` | Modified — react-dom version alignment |
| `frontend/pnpm-lock.yaml` | Modified — lockfile updated |