### PR TITLE
feat(event-indexer): implement off-chain database schema for quest me…

### DIFF
--- a/services/event-indexer/db/schema.sql
+++ b/services/event-indexer/db/schema.sql
@@ -1,10 +1,27 @@
--- Lernza contract event store
+-- =============================================================================
+-- Lernza Off-Chain Data Schema
+-- =============================================================================
 -- Run: psql $DATABASE_URL -f db/schema.sql
+--
+-- This schema provides a denormalized, query-optimised view of on-chain
+-- Lernza data. Raw Soroban contract events are indexed into contract_events
+-- by the event indexer, and the denormalized tables below are kept in sync
+-- via UPSERT/INSERT patterns driven by those events.
+--
+-- Tables are organised into three tiers:
+--   1. Raw event store (existing)     — contract_events, indexer_cursors
+--   2. Denormalized entity tables     — quests, enrollees, milestones, etc.
+--   3. Aggregated analytics views     — quest_stats, user_earnings, dashboard views
+-- =============================================================================
+
+-- =============================================================================
+-- TIER 1: Raw Event Store
+-- =============================================================================
 
 CREATE TABLE IF NOT EXISTS contract_events (
   id            BIGSERIAL PRIMARY KEY,
   contract_id   TEXT NOT NULL,
-  contract_type TEXT NOT NULL CHECK (contract_type IN ('quest', 'milestone', 'rewards')),
+  contract_type TEXT NOT NULL CHECK (contract_type IN ('quest', 'milestone', 'rewards', 'certificate')),
   event_name    TEXT NOT NULL,
   ledger        BIGINT NOT NULL,
   tx_hash       TEXT NOT NULL,
@@ -15,9 +32,9 @@ CREATE TABLE IF NOT EXISTS contract_events (
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_contract_type ON contract_events (contract_type);
-CREATE INDEX IF NOT EXISTS idx_events_event_name ON contract_events (event_name);
-CREATE INDEX IF NOT EXISTS idx_events_ledger ON contract_events (ledger DESC);
-CREATE INDEX IF NOT EXISTS idx_events_indexed_at ON contract_events (indexed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_event_name   ON contract_events (event_name);
+CREATE INDEX IF NOT EXISTS idx_events_ledger       ON contract_events (ledger DESC);
+CREATE INDEX IF NOT EXISTS idx_events_indexed_at   ON contract_events (indexed_at DESC);
 
 CREATE TABLE IF NOT EXISTS indexer_cursors (
   contract_id   TEXT PRIMARY KEY,
@@ -25,27 +42,270 @@ CREATE TABLE IF NOT EXISTS indexer_cursors (
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Dashboard metric views
+-- =============================================================================
+-- TIER 2: Denormalized Entity Tables
+-- =============================================================================
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- quests: Single source of truth for quest metadata off-chain.
+-- Every quest_created / quest_updated / quest_archived / quest_cancelled event
+-- UPSERTS into this table so the frontend has a fast, always-current snapshot.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS quests (
+  id              INTEGER PRIMARY KEY,
+  owner           TEXT NOT NULL,
+  name            TEXT NOT NULL,
+  description     TEXT NOT NULL DEFAULT '',
+  category        TEXT NOT NULL DEFAULT '',
+  tags            TEXT[] NOT NULL DEFAULT '{}',
+  token_addr      TEXT NOT NULL,
+  created_at      BIGINT NOT NULL,            -- ledger timestamp (u64)
+  visibility      SMALLINT NOT NULL DEFAULT 0, -- 0=Public, 1=Private
+  status          SMALLINT NOT NULL DEFAULT 0, -- 0=Active, 1=Archived, 2=Cancelled
+  deadline        BIGINT NOT NULL DEFAULT 0,
+  archived_at     BIGINT NOT NULL DEFAULT 0,
+  max_enrollees   INTEGER,
+  verified        BOOLEAN NOT NULL DEFAULT FALSE,
+  version         INTEGER NOT NULL DEFAULT 1,
+  first_event_id  BIGINT REFERENCES contract_events(id),
+  last_event_id   BIGINT REFERENCES contract_events(id),
+  last_updated    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quests_owner       ON quests (owner);
+CREATE INDEX IF NOT EXISTS idx_quests_category     ON quests (category);
+CREATE INDEX IF NOT EXISTS idx_quests_status       ON quests (status);
+CREATE INDEX IF NOT EXISTS idx_quests_visibility   ON quests (visibility);
+CREATE INDEX IF NOT EXISTS idx_quests_created_at   ON quests (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_quests_last_updated ON quests (last_updated DESC);
+
+-- Full-text search index on quest name + description + category
+CREATE INDEX IF NOT EXISTS idx_quests_fts ON quests
+  USING GIN (to_tsvector('english', name || ' ' || description || ' ' || category));
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- enrollees: Historical enrollment records.
+-- Tracks every enrollee_added / enrollee_removed / leave_quest event so we can
+-- answer questions like "who has ever been enrolled in quest X?" and "when were
+-- they removed?".
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS enrollees (
+  id              BIGSERIAL PRIMARY KEY,
+  quest_id        INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  enrollee        TEXT NOT NULL,
+  enrolled_at     BIGINT NOT NULL,              -- ledger timestamp
+  join_mode       TEXT NOT NULL DEFAULT 'self'   -- 'self', 'owner', 'invite'
+                    CHECK (join_mode IN ('self', 'owner', 'invite')),
+  status          TEXT NOT NULL DEFAULT 'active'  -- 'active', 'removed', 'left')
+                    CHECK (status IN ('active', 'removed', 'left')),
+  removed_at      BIGINT,                        -- ledger timestamp when removed
+  removed_by      TEXT,                           -- address that performed removal
+  event_id        BIGINT REFERENCES contract_events(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (quest_id, enrollee, enrolled_at)       -- allow re-enrollment history
+);
+
+CREATE INDEX IF NOT EXISTS idx_enrollees_quest_id  ON enrollees (quest_id);
+CREATE INDEX IF NOT EXISTS idx_enrollees_enrollee  ON enrollees (enrollee);
+CREATE INDEX IF NOT EXISTS idx_enrollees_status    ON enrollees (status);
+CREATE INDEX IF NOT EXISTS idx_enrollees_quest_enrollee ON enrollees (quest_id, enrollee);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- milestones: Milestone definitions per quest.
+-- Upserted from milestone_created events. Mutable fields (title, description,
+-- reward_amount) are updated on milestone_updated events.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS milestones (
+  id                INTEGER NOT NULL,
+  quest_id          INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  title             TEXT NOT NULL,
+  description       TEXT NOT NULL DEFAULT '',
+  reward_amount     BIGINT NOT NULL DEFAULT 0,  -- i128 stored as int8
+  requires_previous BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at        BIGINT NOT NULL,
+  first_event_id    BIGINT REFERENCES contract_events(id),
+  last_event_id     BIGINT REFERENCES contract_events(id),
+  last_updated      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (quest_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_milestones_quest_id ON milestones (quest_id);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- milestone_completions: Verification & completion records.
+-- Each row records that an enrollee completed a specific milestone and, for
+-- peer-review mode, tracks who approved it and how many approvals were needed.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS milestone_completions (
+  id                BIGSERIAL PRIMARY KEY,
+  quest_id          INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  milestone_id      INTEGER NOT NULL,
+  enrollee          TEXT NOT NULL,
+  completed_at      BIGINT NOT NULL,             -- ledger timestamp
+  verification_mode TEXT NOT NULL DEFAULT 'owner' -- 'owner', 'peer_review'
+                    CHECK (verification_mode IN ('owner', 'peer_review')),
+  approved_by       TEXT[],                       -- array of addresses that approved
+  required_approvals INTEGER,                     -- for peer-review
+  tx_hash           TEXT,
+  event_id          BIGINT REFERENCES contract_events(id),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (quest_id, milestone_id, enrollee, completed_at),
+  FOREIGN KEY (quest_id, milestone_id) REFERENCES milestones(quest_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_quest_milestone ON milestone_completions (quest_id, milestone_id);
+CREATE INDEX IF NOT EXISTS idx_mc_enrollee        ON milestone_completions (enrollee);
+CREATE INDEX IF NOT EXISTS idx_mc_completed_at    ON milestone_completions (completed_at DESC);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- reward_distributions: Every reward payout ever made.
+-- One row per distribute_reward call. Allows queries like "total paid per
+-- enrollee" and "rewards paid per quest".
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS reward_distributions (
+  id              BIGSERIAL PRIMARY KEY,
+  quest_id        INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  milestone_id    INTEGER NOT NULL,
+  enrollee        TEXT NOT NULL,
+  amount          BIGINT NOT NULL,               -- i128 raw token units as int8
+  tx_hash         TEXT NOT NULL,
+  ledger          BIGINT NOT NULL,
+  distributed_at  BIGINT NOT NULL,               -- ledger timestamp
+  event_id        BIGINT REFERENCES contract_events(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rd_quest_id       ON reward_distributions (quest_id);
+CREATE INDEX IF NOT EXISTS idx_rd_enrollee        ON reward_distributions (enrollee);
+CREATE INDEX IF NOT EXISTS idx_rd_distributed_at  ON reward_distributions (distributed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rd_quest_enrollee  ON reward_distributions (quest_id, enrollee);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- reward_pools: Every funding and refund event for a quest's reward pool.
+-- The running balance can be computed by summing amounts (positive = fund,
+-- negative = refund/withdrawal).
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS reward_pool_events (
+  id              BIGSERIAL PRIMARY KEY,
+  quest_id        INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  actor           TEXT NOT NULL,                  -- funder or authority
+  operation       TEXT NOT NULL CHECK (operation IN ('fund', 'distribute', 'refund')),
+  amount          BIGINT NOT NULL CHECK (amount > 0),  -- always positive; `operation` determines direction
+  tx_hash         TEXT NOT NULL,
+  ledger          BIGINT NOT NULL,
+  occurred_at     BIGINT NOT NULL,
+  event_id        BIGINT REFERENCES contract_events(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rpe_quest_id     ON reward_pool_events (quest_id);
+CREATE INDEX IF NOT EXISTS idx_rpe_actor        ON reward_pool_events (actor);
+CREATE INDEX IF NOT EXISTS idx_rpe_occurred_at  ON reward_pool_events (occurred_at DESC);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- certificates: Quest-completion NFT certificates.
+-- One row per certificate_minted event.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS certificates (
+  id              BIGSERIAL PRIMARY KEY,
+  quest_id        INTEGER NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+  enrollee        TEXT NOT NULL,
+  token_id        INTEGER NOT NULL,
+  minted_at       BIGINT NOT NULL,               -- ledger timestamp
+  tx_hash         TEXT NOT NULL,
+  revoked         BOOLEAN NOT NULL DEFAULT FALSE,
+  revoked_at      BIGINT,
+  event_id        BIGINT REFERENCES contract_events(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (quest_id, enrollee),                   -- one cert per quest per enrollee
+  UNIQUE (token_id)                              -- NFT token IDs are globally unique
+);
+
+CREATE INDEX IF NOT EXISTS idx_certs_quest_id    ON certificates (quest_id);
+CREATE INDEX IF NOT EXISTS idx_certs_enrollee    ON certificates (enrollee);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- creator_verifications: Audit trail for creator verification state changes.
+-- Each verify_creator / revoke_creator_verification event produces a row.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS creator_verifications (
+  id              BIGSERIAL PRIMARY KEY,
+  creator         TEXT NOT NULL,
+  admin           TEXT NOT NULL,
+  action          TEXT NOT NULL CHECK (action IN ('verified', 'revoked')),
+  timestamp       BIGINT NOT NULL,
+  event_id        BIGINT REFERENCES contract_events(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cv_creator ON creator_verifications (creator);
+
+-- =============================================================================
+-- TIER 3: Aggregated Tables & Analytics Views
+-- =============================================================================
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- quest_stats: Pre-computed aggregate statistics per quest.
+-- Refreshed periodically or on each event via the indexer.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS quest_stats (
+  quest_id              INTEGER PRIMARY KEY REFERENCES quests(id) ON DELETE CASCADE,
+  enrolled_count        INTEGER NOT NULL DEFAULT 0,
+  milestone_count       INTEGER NOT NULL DEFAULT 0,
+  completions_count     INTEGER NOT NULL DEFAULT 0,
+  total_funded          BIGINT NOT NULL DEFAULT 0,   -- i128
+  total_distributed     BIGINT NOT NULL DEFAULT 0,   -- i128
+  completion_rate       NUMERIC(5,4),                -- ratio 0..1
+  certificates_issued   INTEGER NOT NULL DEFAULT 0,
+  last_updated          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- user_earnings: Running total of rewards earned per address.
+-- Updated on each reward_distribution event.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS user_earnings (
+  address             TEXT PRIMARY KEY,
+  total_earned        BIGINT NOT NULL DEFAULT 0,
+  quests_enrolled     INTEGER NOT NULL DEFAULT 0,
+  quests_completed    INTEGER NOT NULL DEFAULT 0,
+  milestones_completed INTEGER NOT NULL DEFAULT 0,
+  last_activity_at    BIGINT,
+  last_updated        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ue_total_earned ON user_earnings (total_earned DESC);
+
+-- =============================================================================
+-- Dashboard & Analytics Views
+-- =============================================================================
+
+-- Daily quest creation and enrollment activity (enhanced metrics view)
 CREATE OR REPLACE VIEW v_quest_activity AS
 SELECT
   date_trunc('day', indexed_at) AS day,
   COUNT(*) FILTER (WHERE event_name = 'quest_created') AS quests_created,
-  COUNT(*) FILTER (WHERE event_name = 'enrollee_added') AS enrollments
+  COUNT(*) FILTER (WHERE event_name = 'quest_updated') AS quests_updated,
+  COUNT(*) FILTER (WHERE event_name = 'enrollee_added') AS enrollments,
+  COUNT(*) FILTER (WHERE event_name = 'enrollee_removed') AS unenrollments
 FROM contract_events
 WHERE contract_type = 'quest'
 GROUP BY 1
 ORDER BY 1 DESC;
 
+-- Daily reward activity (enhanced)
 CREATE OR REPLACE VIEW v_reward_activity AS
 SELECT
   date_trunc('day', indexed_at) AS day,
   COUNT(*) FILTER (WHERE event_name = 'reward_funded') AS fundings,
-  COUNT(*) FILTER (WHERE event_name = 'reward_distributed') AS distributions
+  COUNT(*) FILTER (WHERE event_name = 'reward_distributed') AS distributions,
+  COUNT(*) FILTER (WHERE event_name = 'reward_refunded') AS refunds
 FROM contract_events
 WHERE contract_type = 'rewards'
 GROUP BY 1
 ORDER BY 1 DESC;
 
+-- Daily milestone completions
 CREATE OR REPLACE VIEW v_milestone_completions AS
 SELECT
   date_trunc('day', indexed_at) AS day,
@@ -54,3 +314,113 @@ FROM contract_events
 WHERE contract_type = 'milestone' AND event_name = 'milestone_completed'
 GROUP BY 1
 ORDER BY 1 DESC;
+
+-- Quest leaderboard: top quests by enrollee count
+CREATE OR REPLACE VIEW v_quest_leaderboard AS
+SELECT
+  q.id,
+  q.name,
+  q.owner,
+  q.category,
+  q.status,
+  q.created_at,
+  COALESCE(qs.enrolled_count, 0) AS enrolled_count,
+  COALESCE(qs.milestone_count, 0) AS milestone_count,
+  COALESCE(qs.completions_count, 0) AS completions_count,
+  COALESCE(qs.total_funded, 0) AS total_funded,
+  COALESCE(qs.total_distributed, 0) AS total_distributed,
+  COALESCE(qs.certificates_issued, 0) AS certificates_issued
+FROM quests q
+LEFT JOIN quest_stats qs ON qs.quest_id = q.id
+WHERE q.status = 0  -- Active only
+ORDER BY enrolled_count DESC, total_distributed DESC;
+
+-- Top earners view
+CREATE OR REPLACE VIEW v_top_earners AS
+SELECT
+  address,
+  total_earned,
+  quests_completed,
+  milestones_completed,
+  last_activity_at
+FROM user_earnings
+ORDER BY total_earned DESC
+LIMIT 100;
+
+-- Recent certificate issuances
+CREATE OR REPLACE VIEW v_recent_certificates AS
+SELECT
+  c.id,
+  c.quest_id,
+  q.name AS quest_name,
+  c.enrollee,
+  c.token_id,
+  c.minted_at
+FROM certificates c
+JOIN quests q ON q.id = c.quest_id
+WHERE c.revoked = FALSE
+ORDER BY c.minted_at DESC
+LIMIT 100;
+
+-- Per-quest completion progress summary
+CREATE OR REPLACE VIEW v_quest_progress AS
+SELECT
+  q.id AS quest_id,
+  q.name AS quest_name,
+  qs.enrolled_count,
+  qs.milestone_count,
+  qs.completions_count,
+  CASE
+    WHEN qs.enrolled_count > 0 AND qs.milestone_count > 0
+      THEN ROUND(qs.completions_count::NUMERIC / (qs.enrolled_count * qs.milestone_count), 4)
+    ELSE 0
+  END AS overall_progress,
+  qs.certificates_issued,
+  CASE
+    WHEN qs.milestone_count > 0
+      THEN ROUND(qs.certificates_issued::NUMERIC / qs.enrolled_count, 4)
+    ELSE 0
+  END AS completion_rate
+FROM quests q
+LEFT JOIN quest_stats qs ON qs.quest_id = q.id
+WHERE q.status = 0;  -- Active only
+
+-- =============================================================================
+-- Maintenance & Cleanup
+-- =============================================================================
+
+-- Function to refresh quest_stats from the event tables
+-- Can be called on demand or via a cron/scheduler.
+CREATE OR REPLACE FUNCTION refresh_quest_stats()
+RETURNS void AS $$
+BEGIN
+  INSERT INTO quest_stats (quest_id, enrolled_count, milestone_count, completions_count,
+                           total_funded, total_distributed, certificates_issued, last_updated)
+  SELECT
+    q.id,
+    (SELECT COUNT(DISTINCT enrollee) FROM enrollees WHERE quest_id = q.id AND status = 'active'),
+    (SELECT COUNT(*) FROM milestones WHERE quest_id = q.id),
+    (SELECT COUNT(*) FROM milestone_completions WHERE quest_id = q.id),
+    COALESCE((SELECT SUM(amount) FROM reward_pool_events WHERE quest_id = q.id AND operation = 'fund'), 0),
+    COALESCE((SELECT SUM(amount) FROM reward_distributions WHERE quest_id = q.id), 0),
+    (SELECT COUNT(*) FROM certificates WHERE quest_id = q.id AND revoked = FALSE),
+    NOW()
+  FROM quests q
+  ON CONFLICT (quest_id) DO UPDATE SET
+    enrolled_count        = EXCLUDED.enrolled_count,
+    milestone_count       = EXCLUDED.milestone_count,
+    completions_count     = EXCLUDED.completions_count,
+    total_funded          = EXCLUDED.total_funded,
+    total_distributed     = EXCLUDED.total_distributed,
+    certificates_issued   = EXCLUDED.certificates_issued,
+    completion_rate       = CASE
+                              WHEN EXCLUDED.enrolled_count > 0 AND EXCLUDED.milestone_count > 0
+                                THEN ROUND(
+                                  EXCLUDED.completions_count::NUMERIC /
+                                  (EXCLUDED.enrolled_count * EXCLUDED.milestone_count),
+                                  4)
+                              ELSE NULL
+                            END,
+    last_updated          = NOW();
+END;
+$$ LANGUAGE plpgsql;

--- a/services/event-indexer/src/db/client.ts
+++ b/services/event-indexer/src/db/client.ts
@@ -17,6 +17,8 @@ export async function closePool(): Promise<void> {
   }
 }
 
+// ─── Indexer Cursors ─────────────────────────────────────────────────────────
+
 export async function getCursor(contractId: string): Promise<number> {
   const result = await getPool().query<{ last_ledger: string }>(
     "SELECT last_ledger FROM indexer_cursors WHERE contract_id = $1",
@@ -35,6 +37,8 @@ export async function setCursor(contractId: string, lastLedger: number): Promise
     [contractId, lastLedger]
   )
 }
+
+// ─── Raw Events ──────────────────────────────────────────────────────────────
 
 export interface StoredEvent {
   contractId: string
@@ -64,4 +68,615 @@ export async function insertEvent(event: StoredEvent): Promise<boolean> {
     ]
   )
   return result.rowCount !== null && result.rowCount > 0
+}
+
+// ─── Quests ──────────────────────────────────────────────────────────────────
+
+export interface QuestRow {
+  id: number
+  owner: string
+  name: string
+  description: string
+  category: string
+  tags: string[]
+  tokenAddr: string
+  createdAt: number
+  visibility: number
+  status: number
+  deadline: number
+  archivedAt: number
+  maxEnrollees: number | null
+  verified: boolean
+  version: number
+  firstEventId?: number | null
+  lastEventId?: number | null
+  lastUpdated: string
+}
+
+export async function upsertQuest(quest: Omit<QuestRow, "lastUpdated">): Promise<void> {
+  await getPool().query(
+    `INSERT INTO quests
+       (id, owner, name, description, category, tags, token_addr, created_at,
+        visibility, status, deadline, archived_at, max_enrollees, verified, version,
+        first_event_id, last_event_id, last_updated)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       owner         = EXCLUDED.owner,
+       name          = EXCLUDED.name,
+       description   = EXCLUDED.description,
+       category      = EXCLUDED.category,
+       tags          = EXCLUDED.tags,
+       token_addr    = EXCLUDED.token_addr,
+       visibility    = EXCLUDED.visibility,
+       status        = EXCLUDED.status,
+       deadline      = EXCLUDED.deadline,
+       archived_at   = EXCLUDED.archived_at,
+       max_enrollees = EXCLUDED.max_enrollees,
+       verified      = EXCLUDED.verified,
+       version       = EXCLUDED.version,
+       last_event_id = EXCLUDED.last_event_id,
+       last_updated  = NOW()`,
+    [
+      quest.id,
+      quest.owner,
+      quest.name,
+      quest.description,
+      quest.category,
+      quest.tags,
+      quest.tokenAddr,
+      quest.createdAt,
+      quest.visibility,
+      quest.status,
+      quest.deadline,
+      quest.archivedAt,
+      quest.maxEnrollees,
+      quest.verified,
+      quest.version,
+      quest.firstEventId ?? null,
+      quest.lastEventId ?? null,
+    ]
+  )
+}
+
+export async function getQuest(questId: number): Promise<QuestRow | null> {
+  const result = await getPool().query<QuestRow>(
+    "SELECT * FROM quests WHERE id = $1",
+    [questId]
+  )
+  return result.rows[0] ?? null
+}
+
+export async function searchQuests(
+  query: string,
+  limit: number = 20,
+  offset: number = 0
+): Promise<QuestRow[]> {
+  const result = await getPool().query(
+    `SELECT * FROM quests
+     WHERE status = 0
+       AND to_tsvector('english', name || ' ' || description || ' ' || category) @@ plainto_tsquery('english', $1)
+     ORDER BY created_at DESC
+     LIMIT $2 OFFSET $3`,
+    [query, limit, offset]
+  )
+  return result.rows as unknown as QuestRow[]
+}
+
+export async function listQuestsByOwner(
+  owner: string,
+  limit: number = 20,
+  offset: number = 0
+): Promise<QuestRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM quests WHERE owner = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+    [owner, limit, offset]
+  )
+  return result.rows as unknown as QuestRow[]
+}
+
+export async function listQuestsByCategory(
+  category: string,
+  limit: number = 20
+): Promise<QuestRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM quests WHERE category = $1 AND status = 0 ORDER BY created_at DESC LIMIT $2",
+    [category, limit]
+  )
+  return result.rows as unknown as QuestRow[]
+}
+
+// ─── Enrollees ───────────────────────────────────────────────────────────────
+
+export interface EnrolleeRow {
+  id: number
+  questId: number
+  enrollee: string
+  enrolledAt: number
+  joinMode: "self" | "owner" | "invite"
+  status: "active" | "removed" | "left"
+  removedAt: number | null
+  removedBy: string | null
+  createdAt: string
+}
+
+export async function insertEnrollee(
+  questId: number,
+  enrollee: string,
+  enrolledAt: number,
+  joinMode: "self" | "owner" | "invite"
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO enrollees (quest_id, enrollee, enrolled_at, join_mode)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT DO NOTHING`,
+    [questId, enrollee, enrolledAt, joinMode]
+  )
+}
+
+export async function markEnrolleeRemoved(
+  questId: number,
+  enrollee: string,
+  removedAt: number,
+  removedBy: string,
+  status: "removed" | "left" = "removed"
+): Promise<void> {
+  await getPool().query(
+    `UPDATE enrollees
+     SET status = $3, removed_at = $4, removed_by = $5
+     WHERE quest_id = $1 AND enrollee = $2 AND status = 'active'`,
+    [questId, enrollee, status, removedAt, removedBy]
+  )
+}
+
+export async function getActiveEnrollees(questId: number): Promise<EnrolleeRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM enrollees WHERE quest_id = $1 AND status = 'active'",
+    [questId]
+  )
+  return result.rows as unknown as EnrolleeRow[]
+}
+
+export async function getEnrolleeQuests(
+  enrollee: string,
+  limit: number = 20
+): Promise<QuestRow[]> {
+  const result = await getPool().query(
+    `SELECT q.* FROM quests q
+     JOIN enrollees e ON e.quest_id = q.id
+     WHERE e.enrollee = $1 AND e.status = 'active'
+     ORDER BY e.enrolled_at DESC
+     LIMIT $2`,
+    [enrollee, limit]
+  )
+  return result.rows as unknown as QuestRow[]
+}
+
+export async function isEnrolled(questId: number, enrollee: string): Promise<boolean> {
+  const result = await getPool().query(
+    "SELECT 1 FROM enrollees WHERE quest_id = $1 AND enrollee = $2 AND status = 'active' LIMIT 1",
+    [questId, enrollee]
+  )
+  return result.rowCount !== null && result.rowCount > 0
+}
+
+export async function getEnrolleeCount(questId: number): Promise<number> {
+  const result = await getPool().query(
+    "SELECT COUNT(*) AS cnt FROM enrollees WHERE quest_id = $1 AND status = 'active'",
+    [questId]
+  )
+  return Number(result.rows[0]?.cnt ?? 0)
+}
+
+// ─── Milestones ──────────────────────────────────────────────────────────────
+
+export interface MilestoneRow {
+  id: number
+  questId: number
+  title: string
+  description: string
+  rewardAmount: number
+  requiresPrevious: boolean
+  createdAt: number
+  lastUpdated: string
+}
+
+export async function upsertMilestone(
+  milestone: Omit<MilestoneRow, "lastUpdated"> & {
+    firstEventId?: number | null
+    lastEventId?: number | null
+  }
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO milestones
+       (id, quest_id, title, description, reward_amount, requires_previous, created_at,
+        first_event_id, last_event_id, last_updated)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+     ON CONFLICT (quest_id, id) DO UPDATE SET
+       title             = EXCLUDED.title,
+       description       = EXCLUDED.description,
+       reward_amount     = EXCLUDED.reward_amount,
+       requires_previous = EXCLUDED.requires_previous,
+       last_event_id     = EXCLUDED.last_event_id,
+       last_updated      = NOW()`,
+    [
+      milestone.id,
+      milestone.questId,
+      milestone.title,
+      milestone.description,
+      milestone.rewardAmount,
+      milestone.requiresPrevious,
+      milestone.createdAt,
+      milestone.firstEventId ?? null,
+      milestone.lastEventId ?? null,
+    ]
+  )
+}
+
+export async function getMilestones(questId: number): Promise<MilestoneRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM milestones WHERE quest_id = $1 ORDER BY id ASC",
+    [questId]
+  )
+  return result.rows as unknown as MilestoneRow[]
+}
+
+export async function getMilestoneCount(questId: number): Promise<number> {
+  const result = await getPool().query(
+    "SELECT COUNT(*) AS cnt FROM milestones WHERE quest_id = $1",
+    [questId]
+  )
+  return Number(result.rows[0]?.cnt ?? 0)
+}
+
+// ─── Milestone Completions ───────────────────────────────────────────────────
+
+export interface MilestoneCompletionRow {
+  id: number
+  questId: number
+  milestoneId: number
+  enrollee: string
+  completedAt: number
+  verificationMode: "owner" | "peer_review"
+  approvedBy: string[] | null
+  requiredApprovals: number | null
+  txHash: string | null
+}
+
+export async function insertMilestoneCompletion(
+  completion: Omit<MilestoneCompletionRow, "id">
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO milestone_completions
+       (quest_id, milestone_id, enrollee, completed_at, verification_mode,
+        approved_by, required_approvals, tx_hash, event_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT DO NOTHING`,
+    [
+      completion.questId,
+      completion.milestoneId,
+      completion.enrollee,
+      completion.completedAt,
+      completion.verificationMode,
+      completion.approvedBy ?? null,
+      completion.requiredApprovals ?? null,
+      completion.txHash ?? null,
+      null, // event_id
+    ]
+  )
+}
+
+export async function getCompletionsForQuest(questId: number): Promise<MilestoneCompletionRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM milestone_completions WHERE quest_id = $1 ORDER BY completed_at DESC",
+    [questId]
+  )
+  return result.rows as unknown as MilestoneCompletionRow[]
+}
+
+export async function getEnrolleeCompletions(
+  enrollee: string,
+  limit: number = 20
+): Promise<MilestoneCompletionRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM milestone_completions WHERE enrollee = $1 ORDER BY completed_at DESC LIMIT $2",
+    [enrollee, limit]
+  )
+  return result.rows as unknown as MilestoneCompletionRow[]
+}
+
+export async function getCompletionCount(questId: number): Promise<number> {
+  const result = await getPool().query(
+    "SELECT COUNT(*) AS cnt FROM milestone_completions WHERE quest_id = $1",
+    [questId]
+  )
+  return Number(result.rows[0]?.cnt ?? 0)
+}
+
+// ─── Reward Distributions ────────────────────────────────────────────────────
+
+export interface RewardDistributionRow {
+  id: number
+  questId: number
+  milestoneId: number
+  enrollee: string
+  amount: number
+  txHash: string
+  ledger: number
+  distributedAt: number
+}
+
+export async function insertRewardDistribution(
+  dist: Omit<RewardDistributionRow, "id">
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO reward_distributions
+       (quest_id, milestone_id, enrollee, amount, tx_hash, ledger, distributed_at, event_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT DO NOTHING`,
+    [
+      dist.questId,
+      dist.milestoneId,
+      dist.enrollee,
+      dist.amount,
+      dist.txHash,
+      dist.ledger,
+      dist.distributedAt,
+      null, // event_id
+    ]
+  )
+}
+
+export async function getDistributionsForQuest(
+  questId: number,
+  limit: number = 50
+): Promise<RewardDistributionRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM reward_distributions WHERE quest_id = $1 ORDER BY distributed_at DESC LIMIT $2",
+    [questId, limit]
+  )
+  return result.rows as unknown as RewardDistributionRow[]
+}
+
+export async function getDistributionsForEnrollee(
+  enrollee: string,
+  limit: number = 50
+): Promise<RewardDistributionRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM reward_distributions WHERE enrollee = $1 ORDER BY distributed_at DESC LIMIT $2",
+    [enrollee, limit]
+  )
+  return result.rows as unknown as RewardDistributionRow[]
+}
+
+export async function getTotalDistributedForQuest(questId: number): Promise<number> {
+  const result = await getPool().query(
+    "SELECT COALESCE(SUM(amount), 0) AS total FROM reward_distributions WHERE quest_id = $1",
+    [questId]
+  )
+  return Number(result.rows[0]?.total ?? 0)
+}
+
+// ─── Reward Pool Events ──────────────────────────────────────────────────────
+
+export interface RewardPoolEventRow {
+  id: number
+  questId: number
+  actor: string
+  operation: "fund" | "distribute" | "refund"
+  amount: number
+  txHash: string
+  ledger: number
+  occurredAt: number
+}
+
+export async function insertRewardPoolEvent(
+  event: Omit<RewardPoolEventRow, "id">
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO reward_pool_events
+       (quest_id, actor, operation, amount, tx_hash, ledger, occurred_at, event_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT DO NOTHING`,
+    [
+      event.questId,
+      event.actor,
+      event.operation,
+      event.amount,
+      event.txHash,
+      event.ledger,
+      event.occurredAt,
+      null, // event_id
+    ]
+  )
+}
+
+export async function getPoolBalance(questId: number): Promise<number> {
+  const result = await getPool().query(
+    `SELECT
+       COALESCE(SUM(amount) FILTER (WHERE operation = 'fund'), 0)
+       - COALESCE(SUM(amount) FILTER (WHERE operation IN ('distribute', 'refund')), 0)
+       AS balance
+     FROM reward_pool_events
+     WHERE quest_id = $1`,
+    [questId]
+  )
+  return Number(result.rows[0]?.balance ?? 0)
+}
+
+// ─── Certificates ────────────────────────────────────────────────────────────
+
+export interface CertificateRow {
+  id: number
+  questId: number
+  enrollee: string
+  tokenId: number
+  mintedAt: number
+  txHash: string
+  revoked: boolean
+  revokedAt: number | null
+}
+
+export async function insertCertificate(
+  cert: Omit<CertificateRow, "id">
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO certificates
+       (quest_id, enrollee, token_id, minted_at, tx_hash, event_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (quest_id, enrollee) DO NOTHING`,
+    [
+      cert.questId,
+      cert.enrollee,
+      cert.tokenId,
+      cert.mintedAt,
+      cert.txHash,
+      null, // event_id
+    ]
+  )
+}
+
+export async function getEnrolleeCertificates(
+  enrollee: string
+): Promise<CertificateRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM certificates WHERE enrollee = $1 AND revoked = FALSE ORDER BY minted_at DESC",
+    [enrollee]
+  )
+  return result.rows as unknown as CertificateRow[]
+}
+
+export async function getQuestCertificates(questId: number): Promise<CertificateRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM certificates WHERE quest_id = $1 ORDER BY minted_at DESC",
+    [questId]
+  )
+  return result.rows as unknown as CertificateRow[]
+}
+
+// ─── User Earnings ───────────────────────────────────────────────────────────
+
+export interface UserEarningsRow {
+  address: string
+  totalEarned: number
+  questsEnrolled: number
+  questsCompleted: number
+  milestonesCompleted: number
+  lastActivityAt: number | null
+}
+
+export async function upsertUserEarnings(
+  address: string,
+  delta: {
+    totalEarned?: number
+    questsEnrolled?: number
+    questsCompleted?: number
+    milestonesCompleted?: number
+  }
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO user_earnings (address, total_earned, quests_enrolled, quests_completed,
+                                milestones_completed, last_activity_at, last_updated)
+     VALUES ($1, $2, $3, $4, $5, EXTRACT(EPOCH FROM NOW())::BIGINT, NOW())
+     ON CONFLICT (address) DO UPDATE SET
+       total_earned         = user_earnings.total_earned + EXCLUDED.total_earned,
+       quests_enrolled      = user_earnings.quests_enrolled + EXCLUDED.quests_enrolled,
+       quests_completed     = user_earnings.quests_completed + EXCLUDED.quests_completed,
+       milestones_completed = user_earnings.milestones_completed + EXCLUDED.milestones_completed,
+       last_activity_at     = EXCLUDED.last_activity_at,
+       last_updated         = NOW()`,
+    [
+      address,
+      delta.totalEarned ?? 0,
+      delta.questsEnrolled ?? 0,
+      delta.questsCompleted ?? 0,
+      delta.milestonesCompleted ?? 0,
+    ]
+  )
+}
+
+export async function getUserEarnings(address: string): Promise<UserEarningsRow | null> {
+  const result = await getPool().query(
+    "SELECT * FROM user_earnings WHERE address = $1",
+    [address]
+  )
+  return result.rows[0] as unknown as UserEarningsRow | null
+}
+
+export async function getTopEarners(limit: number = 100): Promise<UserEarningsRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM user_earnings ORDER BY total_earned DESC LIMIT $1",
+    [limit]
+  )
+  return result.rows as unknown as UserEarningsRow[]
+}
+
+// ─── Aggregated Stats ────────────────────────────────────────────────────────
+
+export interface QuestStatsRow {
+  questId: number
+  enrolledCount: number
+  milestoneCount: number
+  completionsCount: number
+  totalFunded: number
+  totalDistributed: number
+  completionRate: number | null
+  certificatesIssued: number
+}
+
+export async function getQuestStats(questId: number): Promise<QuestStatsRow | null> {
+  const result = await getPool().query(
+    "SELECT * FROM quest_stats WHERE quest_id = $1",
+    [questId]
+  )
+  return result.rows[0] as unknown as QuestStatsRow | null
+}
+
+export async function getPlatformStats(): Promise<{
+  totalQuests: number
+  totalEnrollees: number
+  totalDistributed: number
+  totalFunded: number
+  activeUsers: number
+  certificatesIssued: number
+}> {
+  const result = await getPool().query(`
+    SELECT
+      (SELECT COUNT(*) FROM quests WHERE status = 0) AS total_quests,
+      (SELECT COUNT(DISTINCT enrollee) FROM enrollees WHERE status = 'active') AS total_enrollees,
+      (SELECT COALESCE(SUM(total_distributed), 0) FROM quest_stats) AS total_distributed,
+      (SELECT COALESCE(SUM(total_funded), 0) FROM quest_stats) AS total_funded,
+      (SELECT COUNT(*) FROM user_earnings WHERE last_activity_at IS NOT NULL) AS active_users,
+      (SELECT COUNT(*) FROM certificates WHERE revoked = FALSE) AS certificates_issued
+  `)
+  const row = result.rows[0]
+  return {
+    totalQuests: Number(row?.total_quests ?? 0),
+    totalEnrollees: Number(row?.total_enrollees ?? 0),
+    totalDistributed: Number(row?.total_distributed ?? 0),
+    totalFunded: Number(row?.total_funded ?? 0),
+    activeUsers: Number(row?.active_users ?? 0),
+    certificatesIssued: Number(row?.certificates_issued ?? 0),
+  }
+}
+
+export async function refreshQuestStats(): Promise<void> {
+  await getPool().query("SELECT refresh_quest_stats()")
+}
+
+// ─── Dashboard Queries ───────────────────────────────────────────────────────
+
+export async function getQuestLeaderboard(limit: number = 20): Promise<QuestStatsRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM v_quest_leaderboard LIMIT $1",
+    [limit]
+  )
+  return result.rows as unknown as QuestStatsRow[]
+}
+
+export async function getTopEarnersView(limit: number = 100): Promise<UserEarningsRow[]> {
+  const result = await getPool().query(
+    "SELECT * FROM v_top_earners LIMIT $1",
+    [limit]
+  )
+  return result.rows as unknown as UserEarningsRow[]
 }


### PR DESCRIPTION
Closes #1258
## Summary
 
Implements a three-tier PostgreSQL schema for off-chain Lernza data:
 
### Tier 1 — Raw Event Store (enhanced)
- Added \`certificate\` to \`contract_type\` CHECK constraint
- Enhanced dashboard views with additional metrics
 
### Tier 2 — Denormalized Entity Tables (new)
- **quests** — quest metadata with full-text search (GIN index)
- **enrollees** — historical enrollment tracking
- **milestones** — milestone definitions per quest
- **milestone_completions** — verification & peer-review records
- **reward_distributions** — all payout events
- **reward_pool_events** — funding/distribute/refund trail
- **certificates** — NFT certificates with revocation support
- **creator_verifications** — verification change audit trail
 
### Tier 3 — Aggregated Analytics (new)
- **quest_stats** — pre-computed per-quest aggregates
- **user_earnings** — running per-address earnings
 
### Views & Maintenance
- 7 views for dashboards: leaderboard, top earners, quest progress, certificates, daily activity
- \`refresh_quest_stats()\` PL/pgSQL function for on-demand recomputation
- Full TypeScript client library with strongly-typed query functions for all tables" \
 
