### PR TITLE
fix(contracts): validate recipient is active participant before reward distribution

### DIFF
--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -10,6 +10,7 @@ use soroban_sdk::{
 #[contractclient(name = "QuestClient")]
 pub trait QuestContractTrait {
     fn get_quest(env: Env, quest_id: u32) -> Result<QuestInfo, soroban_sdk::Val>;
+    fn is_enrollee(env: Env, quest_id: u32, user: Address) -> Result<bool, soroban_sdk::Val>;
 }
 
 #[contractclient(name = "MilestoneClient")]
@@ -93,6 +94,8 @@ pub enum Error {
     /// Contract is administratively paused (shared code 400).
     Paused = common::ERR_PAUSED as u32,
     BatchTooLarge = 17,
+    /// Reward recipient is no longer an active participant in the quest (issue #1325).
+    RecipientNotEnrolled = 18,
 }
 
 // TTL constants moved to common.
@@ -363,6 +366,23 @@ impl RewardsContract {
             return Err(Error::Unauthorized);
         }
 
+        // Issue #1325: Verify the recipient is still an active participant.
+        // A user who was removed or left the quest after completing a milestone
+        // must not receive a reward payout.
+        let quest_contract_addr = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::QuestContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client = QuestClient::new(&env, &quest_contract_addr);
+        let is_active = quest_client
+            .try_is_enrollee(&quest_id, &enrollee)
+            .unwrap_or(Ok(false))
+            .unwrap_or(false);
+        if !is_active {
+            return Err(Error::RecipientNotEnrolled);
+        }
+
         // Verify milestone completion before allowing reward distribution
         let milestone_contract_addr = env
             .storage()
@@ -509,6 +529,23 @@ impl RewardsContract {
             .persistent()
             .get::<DataKey, Address>(&auth_key)
             .ok_or(Error::QuestNotFunded)?;
+
+        // Issue #1325: Verify the claimant is still an active participant.
+        // A user who was removed or left the quest after completing milestones
+        // must not be able to self-claim rewards.
+        let quest_contract_addr_cb = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::QuestContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client_cb = QuestClient::new(&env, &quest_contract_addr_cb);
+        let claimant_active = quest_client_cb
+            .try_is_enrollee(&quest_id, &claimant)
+            .unwrap_or(Ok(false))
+            .unwrap_or(false);
+        if !claimant_active {
+            return Err(Error::RecipientNotEnrolled);
+        }
 
         let milestone_contract_addr = env
             .storage()

--- a/contracts/rewards/tests/integration_test.rs
+++ b/contracts/rewards/tests/integration_test.rs
@@ -550,3 +550,84 @@ fn test_broken_quest_linkage_propagates_error() {
     let result = rewards.try_fund_quest(&funder, &1, &500);
     assert_eq!(result, Err(Ok(RewardsError::QuestLookupFailed)));
 }
+
+/// 10. Issue #1325 — reward_user (distribute_reward) must reject recipients who
+///     are no longer active participants in the quest.
+///
+/// Scenario:
+///   1. Enrollee completes a milestone while still enrolled.
+///   2. Owner removes the enrollee before reward distribution (simulating suspension).
+///   3. `distribute_reward` must return `RecipientNotEnrolled` and transfer no tokens.
+///
+/// This guards against the window between milestone completion and reward
+/// payout where a user could be suspended or removed from the quest.
+#[test]
+fn test_distribute_reward_rejects_removed_enrollee() {
+    let ctx = QuestSystemTest::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+
+    ctx.mint_tokens(&owner, &5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.create_milestone(&owner, q_id, "Milestone", 500);
+
+    // Enrollee completes the milestone while still enrolled
+    ctx.milestone()
+        .verify_completion(&owner, &q_id, &ms_id, &enrollee);
+
+    // Simulate suspension: owner removes the enrollee before reward is distributed
+    ctx.quest().remove_enrollee(&q_id, &enrollee);
+    assert!(!ctx.quest().is_enrollee(&q_id, &enrollee));
+
+    // distribute_reward must now reject — recipient is no longer an active participant
+    let result = ctx
+        .rewards()
+        .try_distribute_reward(&owner, &q_id, &ms_id, &enrollee, &500);
+    assert_eq!(result, Err(Ok(RewardsError::RecipientNotEnrolled)));
+
+    // No tokens transferred, pool unchanged
+    assert_eq!(ctx.token_balance(&enrollee), 0);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 5_000);
+}
+
+/// 10b. Issue #1325 — claim_batch must also reject a claimant who is no longer
+///      an active participant.
+///
+/// Mirrors test 10 but exercises the self-service `claim_batch` path.
+#[test]
+fn test_claim_batch_rejects_removed_enrollee() {
+    let ctx = QuestSystemTest::setup();
+    let owner = Address::generate(&ctx.env);
+    let claimant = Address::generate(&ctx.env);
+
+    ctx.mint_tokens(&owner, &5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &claimant);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.create_milestone(&owner, q_id, "Batch Milestone", 500);
+
+    // Claimant completes the milestone while still enrolled
+    ctx.milestone()
+        .verify_completion(&owner, &q_id, &ms_id, &claimant);
+
+    // Simulate suspension: owner removes the claimant before they self-claim
+    ctx.quest().remove_enrollee(&q_id, &claimant);
+    assert!(!ctx.quest().is_enrollee(&q_id, &claimant));
+
+    // claim_batch must now reject — claimant is no longer an active participant
+    let milestone_ids = soroban_sdk::vec![&ctx.env, ms_id];
+    let result = ctx
+        .rewards()
+        .try_claim_batch(&claimant, &q_id, &milestone_ids);
+    assert_eq!(result, Err(Ok(RewardsError::RecipientNotEnrolled)));
+
+    // No tokens transferred, pool unchanged
+    assert_eq!(ctx.token_balance(&claimant), 0);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 5_000);
+}


### PR DESCRIPTION
## Summary

Closes #1325

The \distribute_reward\ function (the contract-level \eward_user\) and \claim_batch\ had no check that the recipient is still an active quest enrollee at the time of payout. A user who completed a milestone but was subsequently suspended or removed from the quest could still receive tokens.

## Changes

### \contracts/rewards/src/lib.rs\
- **\QuestContractTrait\**: Added \is_enrollee\ to the trait so the rewards contract can cross-call the quest contract to verify enrollment status.
- **\Error\ enum**: Added \RecipientNotEnrolled = 18\ for a clear, distinct error code.
- **\distribute_reward\**: Enrollment check via \quest.try_is_enrollee\ runs after the authority guard, before any token transfer. Returns \RecipientNotEnrolled\ if the recipient is no longer enrolled.
- **\claim_batch\**: Same check on the claimant before the Phase 1 validation loop — self-service claims are equally protected.

### \contracts/rewards/tests/integration_test.rs\
- **Test 10** (\	est_distribute_reward_rejects_removed_enrollee\): Enrollee completes milestone, owner removes them (simulating suspension), \distribute_reward\ returns \RecipientNotEnrolled\, no tokens transferred, pool unchanged.
- **Test 10b** (\	est_claim_batch_rejects_removed_enrollee\): Same scenario for the \claim_batch\ self-service path.

## Impact
- Tokens can no longer be sent to users who have been removed or suspended after milestone completion.
- Both authority-triggered (\distribute_reward\) and self-service (\claim_batch\) reward paths are covered.
- No breaking change to existing passing tests.