### PR TITLE
fix(contracts): emit verification_mode_set event in set_verification_…

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -492,6 +492,16 @@ impl MilestoneContract {
             .persistent()
             .extend_ttl(&mode_key, THRESHOLD, BUMP);
 
+        // Emit a verification-mode-set event so indexers and frontends can
+        // detect when a quest switches between owner-only and peer review,
+        // mirroring `set_distribution_mode`. See issue #1268.
+        // Topic: ("verification_mode_set",)
+        // Data: (quest_id, mode, actor, timestamp)
+        env.events().publish(
+            (Symbol::new(&env, "verification_mode_set"),),
+            (quest_id, mode, owner, env.ledger().timestamp()),
+        );
+
         Ok(())
     }
 

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -1,5 +1,7 @@
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String, Vec};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, vec, Address, Env, IntoVal, String, Val, Vec,
+};
 
 // Import the quest contract for testing
 extern crate certificate;
@@ -1699,6 +1701,65 @@ fn test_set_distribution_mode_emits_event() {
     assert!(
         after.len() > 0,
         "set_distribution_mode should publish a distribution_mode_set event"
+    );
+}
+
+// --- set_verification_mode emits event (issue #1268) ---
+
+/// The last event published, as a single-element Vec for comparison.
+fn last_event(env: &Env) -> Vec<(Address, Vec<Val>, Val)> {
+    let all = env.events().all();
+    assert!(all.len() > 0, "expected at least one published event");
+    all.slice(all.len() - 1..)
+}
+
+#[test]
+fn test_set_verification_mode_emits_event() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+
+    let mode = VerificationMode::PeerReview(2);
+    client.set_verification_mode(&owner, &q_id, &mode);
+
+    assert_eq!(
+        last_event(&env),
+        vec![
+            &env,
+            (
+                client.address.clone(),
+                (Symbol::new(&env, "verification_mode_set"),).into_val(&env),
+                (q_id, mode, owner.clone(), env.ledger().timestamp()).into_val(&env),
+            ),
+        ],
+        "set_verification_mode should publish a verification_mode_set event"
+    );
+}
+
+#[test]
+fn test_set_verification_mode_owner_only_emits_event() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+
+    // Switching back to owner-only must be visible to indexers too.
+    client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(2));
+    client.set_verification_mode(&owner, &q_id, &VerificationMode::OwnerOnly);
+
+    assert_eq!(
+        last_event(&env),
+        vec![
+            &env,
+            (
+                client.address.clone(),
+                (Symbol::new(&env, "verification_mode_set"),).into_val(&env),
+                (
+                    q_id,
+                    VerificationMode::OwnerOnly,
+                    owner.clone(),
+                    env.ledger().timestamp()
+                )
+                    .into_val(&env),
+            ),
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary

`set_verification_mode` in the milestone contract wrote the new `VerificationMode` to storage but emitted no event, so indexers and the frontend had no way to detect when a quest switched between owner-only and peer review without polling. The sibling setter `set_distribution_mode` already emits a detailed event — this brings the two in line.

## Changes

**`contracts/milestone/src/lib.rs`**

Added an event publish to `set_verification_mode`, after the storage write and TTL bump:

```rust
env.events().publish(
    (Symbol::new(&env, "verification_mode_set"),),
    (quest_id, mode, owner, env.ledger().timestamp()),
);
```

- Topic: `("verification_mode_set",)`
- Data: `(quest_id, mode, actor, timestamp)`

Shape intentionally mirrors `distribution_mode_set` so indexers can handle both setters with the same decoding path.

**`contracts/milestone/src/test.rs`**

- `test_set_verification_mode_emits_event` — asserts the full event (contract address, topic, data tuple) for `VerificationMode::PeerReview(2)`.
- `test_set_verification_mode_owner_only_emits_event` — asserts the event fires when switching back to `OwnerOnly`, so the "reverting to owner review" case isn't silently dropped.
- Added a `last_event` helper and the `vec`, `IntoVal`, `Val` imports it needs.

## Behaviour notes

- No storage layout, signature, or return-type change — purely additive on the event stream.
- Auth and pause checks are unchanged, and the event is emitted only after `require_auth`, `require_not_paused`, and the ownership check pass, so a rejected call publishes nothing.
- No migration needed; existing indexers ignore the new topic until they subscribe to it.


Closes #1268