### PR TITLE
fix: use checked_add for milestone counter increments

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -333,6 +333,8 @@ impl MilestoneContract {
             return Err(Error::InvalidInput);
         }
 
+        let next_id = id.checked_add(1).ok_or(Error::Overflow)?;
+
         let milestone = MilestoneInfo {
             id,
             quest_id,
@@ -344,14 +346,15 @@ impl MilestoneContract {
 
         let ms_key = DataKey::Milestone(quest_id, id);
         env.storage().persistent().set(&ms_key, &milestone);
-        env.storage().persistent().set(&next_key, &(id + 1));
+        env.storage().persistent().set(&next_key, &next_id);
 
         // Increment explicit milestone count
         let count_key = DataKey::MilestoneCount(quest_id);
         let current_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        let next_count = current_count.checked_add(1).ok_or(Error::Overflow)?;
         env.storage()
             .persistent()
-            .set(&count_key, &(current_count + 1));
+            .set(&count_key, &next_count);
         Self::bump_ms(&env, &count_key);
 
         // Emit milestone creation event


### PR DESCRIPTION
Replace bare arithmetic (id + 1, current_count + 1) with checked_add().ok_or(Error::Overflow)? in create_milestone.

Both NextMilestoneId and MilestoneCount counters now return Error::Overflow instead of wrapping silently if they ever exceed u32::MAX. Consistent with the rewards contract pattern.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->

closes #1276 
