### PR TITLE
fix(contracts): include creation_timestamp in quest_created event data

### DIFF
--- a/contracts/common/src/lib.rs
+++ b/contracts/common/src/lib.rs
@@ -232,11 +232,17 @@ pub fn log_cross_return(env: &Env, target: &Address, method: &str, success: bool
 
 /// Helper: emit a canonical quest_created event
 /// Topics: (quest_created,)
-/// Data: (quest_id, owner, name)
-pub fn emit_quest_created(env: &Env, quest_id: u32, owner: &Address, name: &String) {
+/// Data: (quest_id, owner, name, created_at)
+pub fn emit_quest_created(
+    env: &Env,
+    quest_id: u32,
+    owner: &Address,
+    name: &String,
+    created_at: u64,
+) {
     env.events().publish(
         (soroban_sdk::Symbol::new(&env, "quest_created"),),
-        (quest_id, owner.clone(), name.clone()),
+        (quest_id, owner.clone(), name.clone(), created_at),
     );
 }
 

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -413,9 +413,15 @@ impl QuestContract {
         }
         // Emit quest creation event
         // Event topics: (quest_created,)
-        // Event data: (quest_id, owner, name)
+        // Event data: (quest_id, owner, name, created_at)
         // Emit quest creation event via shared helper for consistent schema
-        common::emit_quest_created(&env, id, &quest.owner.clone(), &quest.name.clone());
+        common::emit_quest_created(
+            &env,
+            id,
+            &quest.owner.clone(),
+            &quest.name.clone(),
+            quest.created_at,
+        );
 
         Self::bump(&env, id);
         Ok(id)

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -78,6 +78,7 @@ fn create_quest_with_category_and_tags(
 #[test]
 fn test_create_quest() {
     let (env, client, owner, token) = setup();
+    let ts = env.ledger().timestamp();
     let id = create_quest_helper(&env, &client, &owner, &token);
     assert_eq!(id, 0);
     assert_eq!(client.get_quest_count(), 1);
@@ -85,6 +86,7 @@ fn test_create_quest() {
     assert_eq!(quest.owner, owner);
     assert_eq!(quest.name, String::from_str(&env, "My Quest"));
     assert_eq!(quest.token_addr, token);
+    assert_eq!(quest.created_at, ts);
 }
 
 #[test]
@@ -911,9 +913,11 @@ fn test_place_leave_hold_rejects_non_enrollee() {
 #[test]
 fn test_new_quest_is_active_by_default() {
     let (env, client, owner, token) = setup();
+    let ts = env.ledger().timestamp();
     create_quest_helper(&env, &client, &owner, &token);
     let quest = client.get_quest(&0);
     assert_eq!(quest.status, QuestStatus::Active);
+    assert_eq!(quest.created_at, ts);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #1342

### Problem
Quest metadata didn't include `creation_timestamp` in the on-chain event emitted when a quest is created. While the `QuestInfo` struct already had a `created_at` field that was set on creation, the `emit_quest_created` event only emitted `(quest_id, owner, name)` — omitting the creation timestamp. This meant the event indexer and analytics couldn't determine when quests were created from on-chain events alone.

### Changes

#### `contracts/common/src/lib.rs`
- Updated `emit_quest_created` helper to accept a `created_at: u64` parameter
- Now emits `(quest_id, owner, name, created_at)` in the event payload tuple

#### `contracts/quest/src/lib.rs`
- Updated the call site in `create_quest` to pass `quest.created_at` to `emit_quest_created`

#### `contracts/quest/src/test.rs`
- Added `created_at` assertion to `test_create_quest` using ledger timestamp comparison
- Added `created_at` assertion to `test_new_quest_is_active_by_default` using ledger timestamp comparison

### Compatibility
- **Event indexer**: No changes needed. The notification dispatcher reads `data[0]` for `questId` and `data[2]` for `questName` — `created_at` is appended at index 3, so existing indices are unchanged.
- **Frontend**: Already maps `createdAt: Number(r.created_at)` in `parseQuestInfo` — no changes needed.
- **ABI**: `emit_quest_created` is an internal helper, not a contract entry point — no ABI breakage.

### Testing
- [x] Added test assertions for `created_at` in quest creation tests
- [ ] Contract tests pass (`cargo test -p quest`)
