### PR TITLE
fix: re-sync countdown timers on tab resume

### DIFF
--- a/frontend/src/components/quest-progress-tracker.tsx
+++ b/frontend/src/components/quest-progress-tracker.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { CheckCircle2, Circle, Lock, Sparkles, Clock, Coins } from "lucide-react"
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
+import { useDeadlineCountdown } from "@/hooks/use-deadline-countdown"
 
 interface Milestone {
   id: number
@@ -27,8 +28,7 @@ function getMilestoneState(index: number, milestones: Milestone[]): MilestoneSta
   return "locked"
 }
 
-// Precompute at module load: Math.random() and Date.now() must not be called during render
-const MODULE_NOW = Date.now()
+// Precompute at module load: Math.random() must not be called during render
 const CONFETTI_COUNT = 20
 const confettiStyles = Array.from({ length: CONFETTI_COUNT }, () => ({
   left: `${Math.random() * 100}%`,
@@ -61,11 +61,8 @@ export function QuestProgressTracker({
     }
   }, [isComplete])
 
-  const timeRemaining = useMemo(
-    () => (deadline ? Math.max(0, deadline - MODULE_NOW / 1000) : null),
-    [deadline]
-  )
-  const daysRemaining = timeRemaining ? Math.ceil(timeRemaining / 86400) : null
+  const secondsLeft = useDeadlineCountdown(deadline)
+  const daysRemaining = secondsLeft !== null ? Math.ceil(secondsLeft / 86400) : null
 
   return (
     <div className={cn("relative", className)}>

--- a/frontend/src/hooks/use-deadline-countdown.test.ts
+++ b/frontend/src/hooks/use-deadline-countdown.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useDeadlineCountdown } from "./use-deadline-countdown"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a Unix-second timestamp that is `offsetSeconds` from Date.now(). */
+function deadlineFromNow(offsetSeconds: number): number {
+  return Math.floor(Date.now() / 1000) + offsetSeconds
+}
+
+/** Dispatch a synthetic visibilitychange event to simulate app resume. */
+function simulateVisibilityChange(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  })
+  document.dispatchEvent(new Event("visibilitychange"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Start in visible state
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useDeadlineCountdown – initial value", () => {
+  it("returns null when no deadline is provided", () => {
+    const { result } = renderHook(() => useDeadlineCountdown(undefined))
+    expect(result.current).toBeNull()
+  })
+
+  it("returns null for deadline = 0 (sentinel for no deadline)", () => {
+    const { result } = renderHook(() => useDeadlineCountdown(0))
+    expect(result.current).toBeNull()
+  })
+
+  it("returns correct seconds remaining on mount", () => {
+    const deadline = deadlineFromNow(300) // 5 minutes in the future
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+    // Should be within [298, 300] due to rounding
+    expect(result.current).toBeGreaterThanOrEqual(298)
+    expect(result.current).toBeLessThanOrEqual(300)
+  })
+
+  it("returns 0 (not negative) for an already-expired deadline", () => {
+    const deadline = deadlineFromNow(-60) // 1 minute in the past
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+    expect(result.current).toBe(0)
+  })
+})
+
+describe("useDeadlineCountdown – interval ticking", () => {
+  it("decrements by 1 each second", () => {
+    const deadline = deadlineFromNow(10)
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+
+    const initial = result.current!
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current).toBe(initial - 1)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current).toBe(initial - 2)
+  })
+
+  it("floors at 0 after the deadline passes", () => {
+    const deadline = deadlineFromNow(2)
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+
+    act(() => {
+      vi.advanceTimersByTime(5000) // advance past the deadline
+    })
+
+    expect(result.current).toBe(0)
+  })
+})
+
+describe("useDeadlineCountdown – visibilitychange re-sync", () => {
+  it("refreshes the countdown when the tab becomes visible again", () => {
+    // Deadline is 100 seconds from now
+    const deadline = deadlineFromNow(100)
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+
+    // Simulate 60 seconds elapsing while the browser throttled the interval
+    act(() => {
+      // Move the wall clock forward but don't advance intervals (simulates suspension)
+      vi.setSystemTime(Date.now() + 60_000)
+    })
+
+    // The interval hasn't fired yet — value may still be stale.
+    // Now the user brings the tab back to the foreground.
+    act(() => {
+      simulateVisibilityChange("visible")
+    })
+
+    // After re-sync, remaining time should be ~40 s (100 - 60)
+    expect(result.current).toBeGreaterThanOrEqual(38)
+    expect(result.current).toBeLessThanOrEqual(41)
+  })
+
+  it("does not update when the tab is hidden", () => {
+    const deadline = deadlineFromNow(100)
+    const { result } = renderHook(() => useDeadlineCountdown(deadline))
+    const before = result.current
+
+    act(() => {
+      simulateVisibilityChange("hidden")
+    })
+
+    // Value should not change on 'hidden' event
+    expect(result.current).toBe(before)
+  })
+})
+
+describe("useDeadlineCountdown – cleanup", () => {
+  it("removes the visibilitychange listener on unmount", () => {
+    const removeSpy = vi.spyOn(document, "removeEventListener")
+    const deadline = deadlineFromNow(60)
+    const { unmount } = renderHook(() => useDeadlineCountdown(deadline))
+
+    unmount()
+
+    expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function))
+    removeSpy.mockRestore()
+  })
+
+  it("clears the interval on unmount", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearInterval")
+    const deadline = deadlineFromNow(60)
+    const { unmount } = renderHook(() => useDeadlineCountdown(deadline))
+
+    unmount()
+
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+})

--- a/frontend/src/hooks/use-deadline-countdown.ts
+++ b/frontend/src/hooks/use-deadline-countdown.ts
@@ -1,0 +1,58 @@
+/**
+ * Hook for a live, resync-safe deadline countdown.
+ *
+ * The countdown ticks every second.  When the page returns from background /
+ * suspension (visibilitychange → visible) the reference time is immediately
+ * refreshed from Date.now() so the displayed value is always accurate, even
+ * after the browser throttled or paused the interval.
+ */
+
+import { useEffect, useState } from "react"
+import { getSecondsRemaining } from "@/lib/utils"
+
+/**
+ * Returns the number of whole seconds remaining until `deadline` (a Unix
+ * timestamp in seconds).  The value updates every second and is re-synced
+ * against the real wall clock whenever the page becomes visible again.
+ *
+ * Returns `null` when `deadline` is 0 / falsy (no deadline).
+ * Returns 0 once the deadline has passed.
+ */
+export function useDeadlineCountdown(deadline: number | undefined): number | null {
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(() => {
+    if (!deadline) return null
+    return getSecondsRemaining(deadline)
+  })
+
+  useEffect(() => {
+    if (!deadline) {
+      setSecondsLeft(null)
+      return
+    }
+
+    // Immediately set an accurate value in case the component mounts after
+    // a period of inactivity.
+    const refresh = () => setSecondsLeft(getSecondsRemaining(deadline))
+
+    refresh()
+
+    const interval = setInterval(refresh, 1000)
+
+    // Re-sync as soon as the tab becomes visible again so the countdown is
+    // never stale after the browser paused / throttled the interval.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refresh()
+      }
+    }
+
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
+  }, [deadline])
+
+  return secondsLeft
+}

--- a/frontend/src/hooks/use-transaction-timebounds.test.ts
+++ b/frontend/src/hooks/use-transaction-timebounds.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+
+// Mock the contracts client module to prevent it from instantiating a Soroban
+// RPC server at import time (which throws in a jsdom environment).
+vi.mock("@/lib/contracts/client", () => ({
+  isTransactionTimeboundsValid: (tb: { minTime: number; maxTime: number }) => {
+    const now = Math.floor(Date.now() / 1000)
+    if (now < tb.minTime) return false
+    if (tb.maxTime > 0 && now > tb.maxTime) return false
+    return true
+  },
+  getTransactionTimebounds: (tx: { timeBounds?: { minTime: string; maxTime: string } | null }) => {
+    if (!tx.timeBounds) return null
+    return {
+      minTime: parseInt(tx.timeBounds.minTime, 10),
+      maxTime: parseInt(tx.timeBounds.maxTime, 10),
+    }
+  },
+}))
+
+import { useTransactionTimebounds } from "./use-transaction-timebounds"
+import type { Transaction } from "@stellar/stellar-sdk"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNow(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+/** Build a minimal Transaction stub with controlled timebounds. */
+function makeTx(minTime: number, maxTime: number): Transaction {
+  return {
+    timeBounds: {
+      minTime: String(minTime),
+      maxTime: String(maxTime),
+    },
+  } as unknown as Transaction
+}
+
+/** Dispatch a visibilitychange event and update the visibilityState property. */
+function simulateVisibilityChange(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  })
+  document.dispatchEvent(new Event("visibilitychange"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useTransactionTimebounds – initial state", () => {
+  it("returns valid=true when no transaction is supplied", () => {
+    const { result } = renderHook(() => useTransactionTimebounds(null))
+    expect(result.current.isValid).toBe(true)
+  })
+
+  it("marks a future transaction as valid", () => {
+    const now = makeNow()
+    const tx = makeTx(0, now + 300) // expires in 5 min
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+    expect(result.current.isValid).toBe(true)
+    expect(result.current.timeRemaining).toBeGreaterThan(0)
+  })
+
+  it("marks an already-expired transaction as invalid", () => {
+    const now = makeNow()
+    const tx = makeTx(0, now - 60) // expired 1 min ago
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+    expect(result.current.isValid).toBe(false)
+    expect(result.current.reason).toMatch(/expired/i)
+  })
+
+  it("marks a too-early transaction as invalid", () => {
+    const now = makeNow()
+    const tx = makeTx(now + 120, now + 300) // not valid yet
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+    expect(result.current.isValid).toBe(false)
+    expect(result.current.reason).toMatch(/not yet valid/i)
+  })
+})
+
+describe("useTransactionTimebounds – periodic interval", () => {
+  it("detects expiry when the 10-second interval fires", () => {
+    const now = makeNow()
+    // Expires in 5 seconds; we'll advance 10 s to trigger the interval
+    const tx = makeTx(0, now + 5)
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+
+    expect(result.current.isValid).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+
+    expect(result.current.isValid).toBe(false)
+  })
+})
+
+describe("useTransactionTimebounds – visibilitychange re-sync", () => {
+  it("re-checks timebounds immediately when tab becomes visible", () => {
+    const now = makeNow()
+    // Transaction expires in 5 seconds
+    const tx = makeTx(0, now + 5)
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+
+    expect(result.current.isValid).toBe(true)
+
+    // Simulate 30 s passing during background (interval is throttled/paused)
+    act(() => {
+      vi.setSystemTime(Date.now() + 30_000)
+    })
+
+    // Tab comes back to foreground — should re-check immediately
+    act(() => {
+      simulateVisibilityChange("visible")
+    })
+
+    expect(result.current.isValid).toBe(false)
+    expect(result.current.reason).toMatch(/expired/i)
+  })
+
+  it("does not alter state on visibilitychange → hidden", () => {
+    const now = makeNow()
+    const tx = makeTx(0, now + 300)
+    const { result } = renderHook(() => useTransactionTimebounds(tx))
+
+    const before = result.current
+
+    act(() => {
+      simulateVisibilityChange("hidden")
+    })
+
+    // State should be unchanged
+    expect(result.current.isValid).toBe(before.isValid)
+  })
+})
+
+describe("useTransactionTimebounds – cleanup", () => {
+  it("removes visibilitychange listener and clears interval on unmount", () => {
+    const removeSpy = vi.spyOn(document, "removeEventListener")
+    const clearSpy = vi.spyOn(globalThis, "clearInterval")
+
+    const now = makeNow()
+    const tx = makeTx(0, now + 300)
+    const { unmount } = renderHook(() => useTransactionTimebounds(tx))
+
+    unmount()
+
+    expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function))
+    expect(clearSpy).toHaveBeenCalled()
+
+    removeSpy.mockRestore()
+    clearSpy.mockRestore()
+  })
+})

--- a/frontend/src/hooks/use-transaction-timebounds.ts
+++ b/frontend/src/hooks/use-transaction-timebounds.ts
@@ -62,7 +62,20 @@ export function useTransactionTimebounds(tx: Transaction | null) {
     // Check every 10 seconds to catch expiring transactions
     const interval = setInterval(checkTimebounds, 10000)
 
-    return () => clearInterval(interval)
+    // Re-sync immediately when the tab becomes visible again so the status is
+    // never stale after the browser throttled or paused the interval.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkTimebounds()
+      }
+    }
+
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
   }, [checkTimebounds])
 
   return status


### PR DESCRIPTION

  fix: re-sync countdown timers on tab resume
  
  Problem
  
  Countdown timers were stale after returning from background. Two separate root causes:
  
  1. QuestProgressTracker computed timeRemaining from MODULE_NOW — a Date.now() snapshot captured
  once at module load. It never updated, so the displayed time was always wrong by however long
  the page had been open.
  2. useTransactionTimebounds used setInterval with no visibility awareness. Browsers throttle or
  suspend intervals in backgrounded tabs, so the status could be off by the full background
  duration when the user returned.
  
  Changes
  
  use-deadline-countdown.ts (new hook)
  
  A general-purpose deadline countdown hook. Ticks every second via setInterval and registers a
  visibilitychange listener that immediately calls getSecondsRemaining(deadline) when the tab
  becomes visible again. Since Date.now() always reflects real wall-clock time, the first
  recalculation after resume is always accurate regardless of how long the browser was suspended.
  
  quest-progress-tracker.tsx
  
  Removed the MODULE_NOW constant and the useMemo that depended on it. Now uses
  useDeadlineCountdown(deadline) so daysRemaining updates live and re-syncs correctly on tab
  restore.
  
  use-transaction-timebounds.ts
  
  Added a visibilitychange event listener inside the existing useEffect. On visible, it calls
  checkTimebounds() immediately — snapping the validity status to real current time before the
  next 10-second interval tick.
  
  Tests
  
  - use-deadline-countdown.test.ts — 10 tests: initial value (no deadline, expired, future),
  interval ticking, floor at 0, visibilitychange re-sync, no update on hidden, cleanup (interval
  cleared, listener removed)
  - use-transaction-timebounds.test.ts — 8 tests: initial valid/invalid/too-early states,
  interval expiry detection, visibilitychange re-sync after simulated suspension, no state change
  on hidden, cleanup
  
  All 18 new tests pass. No existing tests broken.
  
  How to reproduce the fix
  
  1. Open a quest with a deadline
  2. Note the countdown
  3. Background the tab for 30s
  4. Return — timer now immediately shows the correct value instead of resuming from where it
  paused

closes #1335 