### PR TITLE
fix(contracts): cascade category index TTL with quest bump

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -99,10 +99,10 @@ fn is_blank_ascii(s: &String) -> bool {
     if len == 0 {
         return true;
     }
-    if len > MAX_QUEST_DESCRIPTION_LEN as usize {
+    if len > common::MAX_QUEST_DESCRIPTION_LEN as usize {
         return false;
     }
-    let mut buf = [0u8; MAX_QUEST_DESCRIPTION_LEN as usize];
+    let mut buf = [0u8; common::MAX_QUEST_DESCRIPTION_LEN as usize];
     s.copy_into_slice(&mut buf[..len]);
     for &b in buf[..len].iter() {
         if !matches!(b, b' ' | b'\n' | b'\r' | b'\t') {
@@ -1104,11 +1104,20 @@ impl QuestContract {
     }
 
     /// Get all public quests within a category.
+    ///
+    /// If the category index entry has expired (TTL lapsed) while child quests
+    /// still exist, rebuild the index from `PublicQuests` so quests are not
+    /// left undiscoverable / "orphaned" from category queries (#1328).
     pub fn get_quests_by_category(env: Env, category: String) -> Vec<QuestInfo> {
+        let category_key = DataKey::PublicCategoryQuests(category.clone());
+        if !env.storage().persistent().has(&category_key) {
+            Self::rebuild_category_index(&env, &category);
+        }
+
         let category_ids: Vec<u32> = env
             .storage()
             .persistent()
-            .get(&DataKey::PublicCategoryQuests(category.clone()))
+            .get(&category_key)
             .unwrap_or(Vec::new(&env));
         let mut matches = Vec::new(&env);
 
@@ -1120,7 +1129,6 @@ impl QuestContract {
             }
         }
 
-        let category_key = DataKey::PublicCategoryQuests(category);
         if env.storage().persistent().has(&category_key) {
             common::extend_persistent_ttl(&env, &category_key);
         }
@@ -1343,6 +1351,57 @@ impl QuestContract {
         common::extend_persistent_ttl(env, &DataKey::Quest(quest_id));
         common::extend_persistent_ttl(env, &DataKey::Enrollees(quest_id));
         common::extend_persistent_ttl(env, &DataKey::QuestVersionHistory(quest_id));
+
+        // Cascade TTL to discovery indexes so category/public indexes cannot
+        // expire while an active public quest still lives (#1328).
+        if let Ok(quest) = Self::load_quest(env, quest_id) {
+            if quest.visibility == Visibility::Public {
+                Self::bump_discovery_indexes(env, &quest.category, quest_id);
+            }
+        }
+    }
+
+    /// Extend (or recreate) the public + category indexes that reference a quest.
+    fn bump_discovery_indexes(env: &Env, category: &String, quest_id: u32) {
+        let public_key = DataKey::PublicQuests;
+        if env.storage().persistent().has(&public_key) {
+            common::extend_persistent_ttl(env, &public_key);
+        }
+
+        let category_key = DataKey::PublicCategoryQuests(category.clone());
+        if env.storage().persistent().has(&category_key) {
+            common::extend_persistent_ttl(env, &category_key);
+        } else {
+            // Index expired — re-attach this quest so it is not orphaned.
+            Self::add_id_to_index(env, category_key, quest_id);
+        }
+    }
+
+    /// Rebuild `PublicCategoryQuests(category)` from the public quest list.
+    /// Called when the category index is missing after TTL expiry.
+    fn rebuild_category_index(env: &Env, category: &String) {
+        let public_ids: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PublicQuests)
+            .unwrap_or(Vec::new(env));
+        let mut matching = Vec::new(env);
+
+        for i in 0..public_ids.len() {
+            if let Some(id) = public_ids.get(i) {
+                if let Ok(quest) = Self::load_quest(env, id) {
+                    if quest.visibility == Visibility::Public && quest.category == *category {
+                        matching.push_back(id);
+                    }
+                }
+            }
+        }
+
+        if !matching.is_empty() {
+            let category_key = DataKey::PublicCategoryQuests(category.clone());
+            env.storage().persistent().set(&category_key, &matching);
+            common::extend_persistent_ttl(env, &category_key);
+        }
     }
 }
 

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -492,6 +492,108 @@ fn test_get_quests_by_category_only_public() {
     assert_eq!(res.len(), 2);
 }
 
+/// #1328 — when the category index TTL expires (entry removed), child quests
+/// must still be discoverable: `get_quests_by_category` rebuilds the index
+/// from `PublicQuests` instead of returning an empty orphaned list.
+#[test]
+fn test_get_quests_by_category_rebuilds_after_index_expiry() {
+    let (env, client, owner, token) = setup();
+    let category = "Blockchain";
+    let id_a = create_quest_with_category_and_tags(
+        &env,
+        &client,
+        &owner,
+        &token,
+        category,
+        Vec::new(&env),
+        Visibility::Public,
+    );
+    let id_b = create_quest_with_category_and_tags(
+        &env,
+        &client,
+        &owner,
+        &token,
+        category,
+        Vec::new(&env),
+        Visibility::Public,
+    );
+
+    let category_key = DataKey::PublicCategoryQuests(String::from_str(&env, category));
+    // Simulate TTL expiry of the category index entry.
+    env.as_contract(&client.address, || {
+        env.storage().persistent().remove(&category_key);
+    });
+    assert!(
+        !env.as_contract(&client.address, || {
+            env.storage().persistent().has(&category_key)
+        }),
+        "category index should be gone after simulated expiry"
+    );
+
+    let res = client.get_quests_by_category(&String::from_str(&env, category));
+    assert_eq!(res.len(), 2);
+    let returned_ids: Vec<u32> = (0..res.len()).map(|i| res.get(i).unwrap().id).collect();
+    assert!(returned_ids.contains(&id_a));
+    assert!(returned_ids.contains(&id_b));
+
+    // Index should have been rewritten.
+    assert!(env.as_contract(&client.address, || {
+        env.storage().persistent().has(&category_key)
+    }));
+}
+
+/// #1328 — mutating a public quest (via bump) re-attaches it to the category
+/// index if that index has expired, so quests do not stay orphaned.
+#[test]
+fn test_bump_reindexes_quest_after_category_index_expiry() {
+    let (env, client, owner, token) = setup();
+    let category = "Design";
+    let quest_id = create_quest_with_category_and_tags(
+        &env,
+        &client,
+        &owner,
+        &token,
+        category,
+        Vec::new(&env),
+        Visibility::Public,
+    );
+
+    let category_key = DataKey::PublicCategoryQuests(String::from_str(&env, category));
+    env.as_contract(&client.address, || {
+        env.storage().persistent().remove(&category_key);
+    });
+
+    // Any mutating owner call ends in bump(); update_quest is a convenient one.
+    client.update_quest(
+        &quest_id,
+        &owner,
+        &None,
+        &Some(String::from_str(
+            &env,
+            "Updated description for TTL cascade",
+        )),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert!(env.as_contract(&client.address, || {
+        env.storage().persistent().has(&category_key)
+    }));
+    let indexed: Vec<u32> = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get(&category_key)
+            .unwrap_or(Vec::new(&env))
+    });
+    assert!(indexed.contains(quest_id));
+
+    let res = client.get_quests_by_category(&String::from_str(&env, category));
+    assert_eq!(res.len(), 1);
+    assert_eq!(res.get(0).unwrap().id, quest_id);
+}
+
 #[test]
 fn test_list_public_quests_empty() {
     let (_env, client, _owner, _token) = setup();

--- a/contracts/rewards/tests/integration_test.rs
+++ b/contracts/rewards/tests/integration_test.rs
@@ -162,7 +162,6 @@ fn test_happy_path_full_lifecycle() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -222,7 +221,6 @@ fn test_completing_all_milestones_mints_certificate() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -270,7 +268,6 @@ fn test_multiple_enrollees_share_single_milestone() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &e1);
     ctx.quest().add_enrollee(&q_id, &e2);
@@ -318,7 +315,6 @@ fn test_insufficient_pool_rejects_distribution() {
 
     ctx.mint_tokens(&owner, &1_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &100); // pool = 100
@@ -349,7 +345,6 @@ fn test_unenrolled_address_cannot_complete_milestone() {
     let owner = Address::generate(&ctx.env);
     let stranger = Address::generate(&ctx.env); // never enrolled
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     let ms_id = ctx.create_milestone(&owner, q_id, "Gated Milestone", 100);
 
@@ -383,7 +378,6 @@ fn test_non_authority_distribute_unauthorized() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -459,7 +453,6 @@ fn test_distribute_blocked_without_milestone_completion() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -489,7 +482,6 @@ fn test_distribute_reward_idempotent() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);

--- a/contracts/rewards/tests/panic_resilience_test.rs
+++ b/contracts/rewards/tests/panic_resilience_test.rs
@@ -108,7 +108,6 @@ fn quest_state_intact_after_milestone_panic() {
 
     ctx.mint(&owner, 5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -151,7 +150,6 @@ fn rewards_pool_intact_after_distribute_without_completion() {
 
     ctx.mint(&owner, 5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -193,7 +191,6 @@ fn quest_enrollment_intact_after_failed_fund() {
     let enrollee = Address::generate(&ctx.env);
 
     // owner has no tokens — fund_quest will fail
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
 


### PR DESCRIPTION
## Summary
- Fixes #1328: when `PublicCategoryQuests` TTL expires, public quests were still on-ledger but no longer discoverable by category ("orphaned" from the index)
- `bump()` now extends discovery-index TTLs for public quests and re-attaches a quest to its category index if the index entry is missing
- `get_quests_by_category` rebuilds the category index from `PublicQuests` when the index key is gone
- Adds regression tests that simulate index expiry via storage removal
- Also removes orphaned `&None,` leftovers in rewards tests that break `cargo fmt` on `main` after #1290

## Test plan
- [ ] `cargo test -p quest -- test_get_quests_by_category_rebuilds_after_index_expiry`
- [ ] `cargo test -p quest -- test_bump_reindexes_quest_after_category_index_expiry`
- [ ] Existing `test_get_quests_by_category_only_public` still passes
- [ ] After simulated category-index removal, `get_quests_by_category` returns the original public quests and rewrites the index