### PR TITLE
fix(frontend): show Not started for null/zero quest completion (#1331)

### DIFF
--- a/contracts/rewards/tests/integration_test.rs
+++ b/contracts/rewards/tests/integration_test.rs
@@ -162,7 +162,6 @@ fn test_happy_path_full_lifecycle() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -222,7 +221,6 @@ fn test_completing_all_milestones_mints_certificate() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -270,7 +268,6 @@ fn test_multiple_enrollees_share_single_milestone() {
 
     ctx.mint_tokens(&owner, &10_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &e1);
     ctx.quest().add_enrollee(&q_id, &e2);
@@ -318,7 +315,6 @@ fn test_insufficient_pool_rejects_distribution() {
 
     ctx.mint_tokens(&owner, &1_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &100); // pool = 100
@@ -349,7 +345,6 @@ fn test_unenrolled_address_cannot_complete_milestone() {
     let owner = Address::generate(&ctx.env);
     let stranger = Address::generate(&ctx.env); // never enrolled
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     let ms_id = ctx.create_milestone(&owner, q_id, "Gated Milestone", 100);
 
@@ -383,7 +378,6 @@ fn test_non_authority_distribute_unauthorized() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -459,7 +453,6 @@ fn test_distribute_blocked_without_milestone_completion() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -489,7 +482,6 @@ fn test_distribute_reward_idempotent() {
 
     ctx.mint_tokens(&owner, &5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);

--- a/contracts/rewards/tests/panic_resilience_test.rs
+++ b/contracts/rewards/tests/panic_resilience_test.rs
@@ -108,7 +108,6 @@ fn quest_state_intact_after_milestone_panic() {
 
     ctx.mint(&owner, 5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -151,7 +150,6 @@ fn rewards_pool_intact_after_distribute_without_completion() {
 
     ctx.mint(&owner, 5_000);
 
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
     ctx.rewards().fund_quest(&owner, &q_id, &5_000);
@@ -193,7 +191,6 @@ fn quest_enrollment_intact_after_failed_fund() {
     let enrollee = Address::generate(&ctx.env);
 
     // owner has no tokens — fund_quest will fail
-        &None,
     let q_id = ctx.create_quest(&owner);
     ctx.quest().add_enrollee(&q_id, &enrollee);
 

--- a/frontend/src/pages/dashboard-completion.test.tsx
+++ b/frontend/src/pages/dashboard-completion.test.tsx
@@ -1,0 +1,183 @@
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, within } from "@testing-library/react"
+
+vi.mock("./dashboard/earnings-chart", () => ({
+  default: () => null,
+}))
+
+vi.mock("@/lib/contracts/client", () => ({
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  RPC_TIMEOUT_MS: 15000,
+  server: {},
+  withTimeout: <T,>(promise: Promise<T>) => promise,
+}))
+
+vi.mock("@/hooks/use-token-metadata", () => ({
+  useTokenMetadata: () => ({ metadata: null, isLoading: false, error: null }),
+}))
+
+vi.mock("@/hooks/use-quest-stats", () => ({
+  useQuestStatsMap: () => ({
+    statsByQuestId: {
+      1: { enrolleeCount: 2, milestoneCount: 4, poolBalance: 100 },
+      2: { enrolleeCount: 1, milestoneCount: 3, poolBalance: 50 },
+      3: { enrolleeCount: 1, milestoneCount: 2, poolBalance: 25 },
+    },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+}))
+
+vi.mock("@/lib/contracts/quest", () => ({
+  questClient: {
+    listPublicQuests: vi.fn(),
+    listQuestsByOwner: vi.fn(),
+    listQuestsByEnrollee: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/contracts/milestone", () => ({
+  milestoneClient: {
+    getEnrolleeCompletions: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/contracts/rewards", () => ({
+  rewardsClient: {
+    getUserEarnings: vi.fn(),
+  },
+}))
+
+const QUESTS = [
+  {
+    id: 1,
+    owner: "GOWNER",
+    name: "Not Started Quest",
+    description: "Zero completions",
+    category: "Programming",
+    tags: ["rust"],
+    tokenAddr: "TOKEN",
+    createdAt: 100,
+    visibility: 0,
+    status: 0,
+    deadline: 0,
+    maxEnrollees: 10,
+  },
+  {
+    id: 2,
+    owner: "GOWNER",
+    name: "In Progress Quest",
+    description: "Some completions",
+    category: "Blockchain",
+    tags: ["soroban"],
+    tokenAddr: "TOKEN",
+    createdAt: 200,
+    visibility: 0,
+    status: 0,
+    deadline: 0,
+    maxEnrollees: 10,
+  },
+  {
+    id: 3,
+    owner: "GOWNER",
+    name: "Unknown Progress Quest",
+    description: "Missing completion data",
+    category: "Design",
+    tags: ["ui"],
+    tokenAddr: "TOKEN",
+    createdAt: 300,
+    visibility: 0,
+    status: 0,
+    deadline: 0,
+    maxEnrollees: 10,
+  },
+]
+
+vi.mock("@/hooks/use-async-data", () => ({
+  useContractData: () => ({
+    data: {
+      publicQuests: QUESTS,
+      ownedQuests: [],
+      enrolledQuests: [],
+      accessibleQuests: QUESTS,
+      previewQuestIds: QUESTS.map(q => q.id),
+      // Quest 1: explicit 0 (not started). Quest 2: in progress. Quest 3: absent/null.
+      questCompletions: { 1: 0, 2: 2 },
+      userEarnings: 0n,
+    },
+    isLoading: false,
+    error: null,
+    isEmpty: false,
+    refetch: async () => {},
+  }),
+}))
+
+vi.mock("@/hooks/use-wallet", () => ({
+  useWallet: vi.fn(),
+}))
+
+import { useWallet } from "@/hooks/use-wallet"
+import { Dashboard } from "./dashboard"
+const mockUseWallet = vi.mocked(useWallet)
+
+function getQuestGrid(container: HTMLElement): HTMLElement {
+  const grid = container.querySelector(".relative.grid.gap-5")
+  if (!grid) throw new Error("quest grid not found")
+  return grid as HTMLElement
+}
+
+function questCard(grid: HTMLElement, name: string): HTMLElement {
+  const title = within(grid).getByText(name)
+  const card = title.closest("button")
+  if (!card) throw new Error(`card for ${name} not found`)
+  return card
+}
+
+describe("Dashboard quest card completion progress (#1331)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState(null, "", "/dashboard")
+
+    mockUseWallet.mockReturnValue({
+      connected: true,
+      connect: vi.fn(),
+      shortAddress: "GABC…XYZ",
+      address: "GABC1234567890XYZ",
+    } as unknown as ReturnType<typeof useWallet>)
+  })
+
+  it("shows Not started instead of a 0% progress bar when completion is 0", async () => {
+    const { container } = render(<Dashboard />)
+    const grid = getQuestGrid(container)
+    await within(grid).findByText("Not Started Quest")
+    const card = questCard(grid, "Not Started Quest")
+
+    expect(within(card).getByTestId("quest-progress-not-started")).toHaveTextContent("Not started")
+    expect(within(card).queryByRole("progressbar")).not.toBeInTheDocument()
+    expect(within(card).queryByText("0/4")).not.toBeInTheDocument()
+  })
+
+  it("shows Not started when completion_percentage is missing/null", async () => {
+    const { container } = render(<Dashboard />)
+    const grid = getQuestGrid(container)
+    await within(grid).findByText("Unknown Progress Quest")
+    const card = questCard(grid, "Unknown Progress Quest")
+
+    expect(within(card).getByTestId("quest-progress-not-started")).toHaveTextContent("Not started")
+    expect(within(card).queryByRole("progressbar")).not.toBeInTheDocument()
+  })
+
+  it("still shows a progress bar when the user has completed milestones", async () => {
+    const { container } = render(<Dashboard />)
+    const grid = getQuestGrid(container)
+    await within(grid).findByText("In Progress Quest")
+    const card = questCard(grid, "In Progress Quest")
+
+    expect(within(card).queryByTestId("quest-progress-not-started")).not.toBeInTheDocument()
+    expect(within(card).getByRole("progressbar")).toBeInTheDocument()
+    expect(within(card).getByText("2/3")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -553,10 +553,18 @@ export function Dashboard({ onSelectQuest, onCreateQuest, onLaunchTutorial }: Da
                     poolBalance: 0,
                   }
                   const totalMilestones = stats.milestoneCount
-                  const completedCount = questCompletions[ws.id] || 0
+                  // Treat missing/null completion as unknown — never coerce to 0% which
+                  // looks like "started but empty". See #1331.
+                  const completedCount = questCompletions[ws.id]
+                  const hasCompletion =
+                    typeof completedCount === "number" && Number.isFinite(completedCount)
+                  const startedCount = hasCompletion ? completedCount : 0
+                  const notStarted = !hasCompletion || startedCount === 0
                   const totalReward = stats.poolBalance
                   const earnedReward =
-                    totalMilestones > 0 ? (totalReward * completedCount) / totalMilestones : 0
+                    totalMilestones > 0 && hasCompletion
+                      ? (totalReward * startedCount) / totalMilestones
+                      : 0
                   const isOwned = !!address && ws.owner === address
 
                   return (
@@ -575,7 +583,9 @@ export function Dashboard({ onSelectQuest, onCreateQuest, onLaunchTutorial }: Da
                                 <CardTitle className="group-hover:text-accent text-base transition-colors">
                                   {ws.name}
                                 </CardTitle>
-                                {completedCount === totalMilestones && totalMilestones > 0 && (
+                                {hasCompletion &&
+                                  startedCount === totalMilestones &&
+                                  totalMilestones > 0 && (
                                   <Badge variant="success" className="gap-1">
                                     <Sparkles className="h-3 w-3" />
                                     Complete
@@ -622,16 +632,25 @@ export function Dashboard({ onSelectQuest, onCreateQuest, onLaunchTutorial }: Da
 
                           {totalMilestones > 0 && (
                             <div className="space-y-2">
-                              <div className="flex items-center gap-3">
-                                <Progress
-                                  value={completedCount}
-                                  max={totalMilestones}
-                                  className="flex-1"
-                                />
-                                <span className="text-muted-foreground text-xs font-bold whitespace-nowrap">
-                                  {completedCount}/{totalMilestones}
-                                </span>
-                              </div>
+                              {notStarted ? (
+                                <p
+                                  className="text-muted-foreground text-xs font-bold"
+                                  data-testid="quest-progress-not-started"
+                                >
+                                  Not started
+                                </p>
+                              ) : (
+                                <div className="flex items-center gap-3">
+                                  <Progress
+                                    value={startedCount}
+                                    max={totalMilestones}
+                                    className="flex-1"
+                                  />
+                                  <span className="text-muted-foreground text-xs font-bold whitespace-nowrap">
+                                    {startedCount}/{totalMilestones}
+                                  </span>
+                                </div>
+                              )}
                               {earnedReward > 0 && (
                                 <div className="flex items-center justify-between">
                                   <span className="text-muted-foreground text-xs font-bold">


### PR DESCRIPTION
## Overview

This PR fixes dashboard quest cards that treated missing or zero completion as a started quest at **0%**. Quests with `null` / `undefined` / `0` completion now show a clear **Not started** empty state instead of a misleading progress bar.

## Related Issue

Closes #1331

## Changes

### Dashboard quest card progress

* **[MODIFY]** `frontend/src/pages/dashboard.tsx`
  * Stop coercing missing completion into `0` for progress UI.
  * Render **Not started** when completion is null/undefined/0.
  * Keep the progress bar only when the learner has completed at least one milestone.

* **[ADD]** `frontend/src/pages/dashboard-completion.test.tsx`
  * Coverage for zero completion, missing completion, and in-progress progress-bar rendering.

* **[MODIFY]** `contracts/rewards/tests/integration_test.rs`, `contracts/rewards/tests/panic_resilience_test.rs`
  * Remove orphaned `&None,` leftovers that break `cargo fmt` on `main` after #1290.

## Verification Results

```
pnpm exec vitest run --config vitest.unit.config.ts src/pages/dashboard-completion.test.tsx
✅ 3/3 passed
  - shows Not started instead of a 0% progress bar when completion is 0
  - shows Not started when completion_percentage is missing/null
  - still shows a progress bar when the user has completed milestones
```

| Acceptance Criteria | Status |
| --- | --- |
| Null/undefined completion does not render as 0% | ✅ Shows "Not started", no progressbar |
| Zero completion shows empty/unknown state | ✅ "Not started" label via `data-testid="quest-progress-not-started"` |
| In-progress quests still show progress | ✅ Progress bar + `completed/total` retained |

## Test plan

- [x] Unit tests for zero / missing / in-progress completion states
- [ ] Open dashboard with a quest that has milestones but 0 completions → see "Not started"
- [ ] Open dashboard with a mid-progress quest → progress bar still shows `completed/total`