### PR TITLE
feat: add pre-built quest templates for courses, bootcamps, and chall…

### DIFF
--- a/frontend/src/pages/create-quest/context.tsx
+++ b/frontend/src/pages/create-quest/context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, type ReactNode, useCallback } from "react"
 import type { Step1Values, Step2Values, FormStep } from "./types"
+import type { QuestTemplate } from "./quest-templates"
 
 interface QuestCreationContextType {
   step1Data: Step1Values
@@ -10,6 +11,13 @@ interface QuestCreationContextType {
   goToNext: () => void
   goToBack: () => void
   setCurrentStep: (step: FormStep) => void
+  /** ID of the template that was last applied, or null if none. */
+  appliedTemplateId: string | null
+  /**
+   * Apply a template: populate step1 and step2 data, record the template id,
+   * and navigate to step 1 so the user can review and edit.
+   */
+  applyTemplate: (template: QuestTemplate) => void
 }
 
 const QuestCreationContext = createContext<QuestCreationContextType | undefined>(undefined)
@@ -25,6 +33,7 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
     milestones: [{ title: "", description: "", rewardAmount: 0 }],
   })
   const [currentStep, setCurrentStep] = useState<FormStep>(1)
+  const [appliedTemplateId, setAppliedTemplateId] = useState<string | null>(null)
 
   const goToNext = useCallback(() => {
     setCurrentStep(prev => (prev + 1) as FormStep)
@@ -33,6 +42,14 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
 
   const goToBack = useCallback(() => {
     setCurrentStep(prev => (prev - 1) as FormStep)
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }, [])
+
+  const applyTemplate = useCallback((template: QuestTemplate) => {
+    setStep1Data(template.step1)
+    setStep2Data(template.step2)
+    setAppliedTemplateId(template.id)
+    setCurrentStep(1)
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [])
 
@@ -45,6 +62,8 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
     goToNext,
     goToBack,
     setCurrentStep,
+    appliedTemplateId,
+    applyTemplate,
   }
 
   return <QuestCreationContext.Provider value={value}>{children}</QuestCreationContext.Provider>

--- a/frontend/src/pages/create-quest/quest-templates.test.tsx
+++ b/frontend/src/pages/create-quest/quest-templates.test.tsx
@@ -1,0 +1,248 @@
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { step1Schema, step2Schema } from "./types"
+import {
+  QUEST_TEMPLATES,
+  TEMPLATES_BY_CATEGORY,
+  CATEGORY_META,
+  getTemplateById,
+  type TemplateCategory,
+} from "./quest-templates"
+import { TemplatePicker } from "./template-picker"
+
+// ─── Template data integrity ──────────────────────────────────────────────────
+
+describe("Quest templates — data integrity", () => {
+  it("has exactly 9 templates", () => {
+    expect(QUEST_TEMPLATES).toHaveLength(9)
+  })
+
+  it("has 3 templates per category", () => {
+    const cats: TemplateCategory[] = ["course", "bootcamp", "challenge"]
+    for (const cat of cats) {
+      expect(TEMPLATES_BY_CATEGORY[cat]).toHaveLength(3)
+    }
+  })
+
+  it("all template ids are unique", () => {
+    const ids = QUEST_TEMPLATES.map(t => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("all templates belong to a valid category", () => {
+    const validCategories: TemplateCategory[] = ["course", "bootcamp", "challenge"]
+    for (const t of QUEST_TEMPLATES) {
+      expect(validCategories).toContain(t.category)
+    }
+  })
+
+  it("all templates have non-empty name, tagline, icon, and duration", () => {
+    for (const t of QUEST_TEMPLATES) {
+      expect(t.name.trim().length).toBeGreaterThan(0)
+      expect(t.tagline.trim().length).toBeGreaterThan(0)
+      expect(t.icon.trim().length).toBeGreaterThan(0)
+      expect(t.duration.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it("getTemplateById returns the right template", () => {
+    const first = QUEST_TEMPLATES[0]
+    expect(getTemplateById(first.id)).toEqual(first)
+  })
+
+  it("getTemplateById returns undefined for unknown id", () => {
+    expect(getTemplateById("does-not-exist")).toBeUndefined()
+  })
+
+  it("CATEGORY_META has entries for all three categories", () => {
+    const cats: TemplateCategory[] = ["course", "bootcamp", "challenge"]
+    for (const cat of cats) {
+      const meta = CATEGORY_META[cat]
+      expect(meta.label.trim().length).toBeGreaterThan(0)
+      expect(meta.description.trim().length).toBeGreaterThan(0)
+      expect(meta.icon.trim().length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ─── Schema compliance ────────────────────────────────────────────────────────
+
+describe("Quest templates — step1 schema compliance", () => {
+  it.each(QUEST_TEMPLATES)("$name: step1 data passes the step1 schema", template => {
+    const result = step1Schema.safeParse(template.step1)
+    expect(result.success).toBe(true)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: name ≤ 64 chars and non-blank", template => {
+    expect(template.step1.name.length).toBeLessThanOrEqual(64)
+    expect(template.step1.name.trim().length).toBeGreaterThan(0)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: description ≤ 2000 chars and non-blank", template => {
+    expect(template.step1.description.length).toBeLessThanOrEqual(2000)
+    expect(template.step1.description.trim().length).toBeGreaterThan(0)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: category ≤ 32 chars and non-blank", template => {
+    expect(template.step1.category.length).toBeLessThanOrEqual(32)
+    expect(template.step1.category.trim().length).toBeGreaterThan(0)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: tags count ≤ 5, each ≤ 32 chars", template => {
+    expect(template.step1.tags.length).toBeLessThanOrEqual(5)
+    for (const tag of template.step1.tags) {
+      expect(tag.length).toBeLessThanOrEqual(32)
+      expect(tag.trim().length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("Quest templates — step2 schema compliance", () => {
+  it.each(QUEST_TEMPLATES)("$name: step2 data passes the step2 schema", template => {
+    const result = step2Schema.safeParse(template.step2)
+    expect(result.success).toBe(true)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: has at least 1 milestone, at most 50", template => {
+    const count = template.step2.milestones.length
+    expect(count).toBeGreaterThanOrEqual(1)
+    expect(count).toBeLessThanOrEqual(50)
+  })
+
+  it.each(QUEST_TEMPLATES)("$name: all milestone titles ≤ 128 chars and non-blank", template => {
+    for (const m of template.step2.milestones) {
+      expect(m.title.length).toBeLessThanOrEqual(128)
+      expect(m.title.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(QUEST_TEMPLATES)(
+    "$name: all milestone descriptions ≤ 1000 chars and non-blank",
+    template => {
+      for (const m of template.step2.milestones) {
+        expect(m.description.length).toBeLessThanOrEqual(1000)
+        expect(m.description.trim().length).toBeGreaterThan(0)
+      }
+    }
+  )
+
+  it.each(QUEST_TEMPLATES)("$name: all reward amounts are positive numbers", template => {
+    for (const m of template.step2.milestones) {
+      expect(m.rewardAmount).toBeGreaterThan(0)
+      expect(Number.isFinite(m.rewardAmount)).toBe(true)
+    }
+  })
+})
+
+// ─── TemplatePicker component ─────────────────────────────────────────────────
+
+describe("TemplatePicker component", () => {
+  const onClose = vi.fn()
+  const onApply = vi.fn()
+
+  beforeEach(() => {
+    onClose.mockClear()
+    onApply.mockClear()
+  })
+
+  it("does not render when isOpen is false", () => {
+    const { container } = render(
+      <TemplatePicker isOpen={false} onClose={onClose} onApply={onApply} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders the modal when isOpen is true", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    expect(screen.getByRole("dialog")).toBeDefined()
+    expect(screen.getByText("Choose a Quest Template")).toBeDefined()
+  })
+
+  it("renders three category tabs", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    expect(screen.getByRole("tab", { name: /courses/i })).toBeDefined()
+    expect(screen.getByRole("tab", { name: /bootcamps/i })).toBeDefined()
+    expect(screen.getByRole("tab", { name: /challenges/i })).toBeDefined()
+  })
+
+  it("shows courses tab selected by default", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    const coursesTab = screen.getByRole("tab", { name: /courses/i })
+    expect(coursesTab.getAttribute("aria-selected")).toBe("true")
+  })
+
+  it("shows course template names in the list", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    for (const t of TEMPLATES_BY_CATEGORY.course) {
+      // Template name appears in both the card list and the desktop preview panel
+      expect(screen.getAllByText(t.name).length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it("switches to bootcamp category when tab is clicked", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    const bootcampTab = screen.getByRole("tab", { name: /bootcamps/i })
+    fireEvent.click(bootcampTab)
+
+    // Bootcamp template names should now be visible
+    for (const t of TEMPLATES_BY_CATEGORY.bootcamp) {
+      expect(screen.getAllByText(t.name).length).toBeGreaterThanOrEqual(1)
+    }
+    // Course template names should NOT be visible
+    for (const t of TEMPLATES_BY_CATEGORY.course) {
+      expect(screen.queryByText(t.name)).toBeNull()
+    }
+  })
+
+  it("switches to challenge category when tab is clicked", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    const challengeTab = screen.getByRole("tab", { name: /challenges/i })
+    fireEvent.click(challengeTab)
+    for (const t of TEMPLATES_BY_CATEGORY.challenge) {
+      expect(screen.getAllByText(t.name).length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it("calls onClose when the close button is clicked", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    const closeBtn = screen.getByRole("button", { name: /close template picker/i })
+    fireEvent.click(closeBtn)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onClose when Escape is pressed", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    fireEvent.keyDown(window, { key: "Escape" })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onApply with the selected template when the CTA is clicked", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    // At least one "Apply Template" button is rendered on desktop layout
+    const applyBtns = screen.getAllByText(/apply template/i)
+    fireEvent.click(applyBtns[0])
+    expect(onApply).toHaveBeenCalledTimes(1)
+    // The first argument should be a valid QuestTemplate
+    const applied = onApply.mock.calls[0][0]
+    expect(applied).toHaveProperty("id")
+    expect(applied).toHaveProperty("step1")
+    expect(applied).toHaveProperty("step2")
+  })
+
+  it("marks the clicked template card as selected (aria-pressed)", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    const secondTemplate = TEMPLATES_BY_CATEGORY.course[1]
+    const card = screen.getByRole("button", { name: new RegExp(secondTemplate.name, "i") })
+    fireEvent.click(card)
+    expect(card.getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("has correct role attributes for accessibility", () => {
+    render(<TemplatePicker isOpen={true} onClose={onClose} onApply={onApply} />)
+    expect(screen.getByRole("dialog")).toBeDefined()
+    expect(screen.getByRole("tablist")).toBeDefined()
+    const tabs = screen.getAllByRole("tab")
+    expect(tabs.length).toBe(3)
+  })
+})

--- a/frontend/src/pages/create-quest/quest-templates.ts
+++ b/frontend/src/pages/create-quest/quest-templates.ts
@@ -1,0 +1,552 @@
+/**
+ * Pre-built quest templates for common learning use cases.
+ *
+ * Three categories:
+ *   "course"    — self-paced learning paths, typically 4–6 milestones
+ *   "bootcamp"  — intensive structured programs, typically 6–10 milestones
+ *   "challenge" — focused skill sprints, typically 3–5 milestones
+ *
+ * All string lengths satisfy contract constraints (validated by schema in tests):
+ *   name        ≤ 64 chars
+ *   description ≤ 2000 chars
+ *   category    ≤ 32 chars
+ *   tag         ≤ 32 chars, max 5 tags
+ *   milestone.title       ≤ 128 chars
+ *   milestone.description ≤ 1000 chars
+ *   milestone.rewardAmount > 0
+ */
+
+import type { Step1Values, Step2Values } from "./types"
+
+export type TemplateCategory = "course" | "bootcamp" | "challenge"
+
+export interface QuestTemplate {
+  id: string
+  category: TemplateCategory
+  /** Short, human-readable display name */
+  name: string
+  /** One-sentence pitch shown in the template card */
+  tagline: string
+  /** Emoji icon used in the card header */
+  icon: string
+  /** Approximate duration shown as a badge */
+  duration: string
+  /** Filled into the quest "Basics" form on apply */
+  step1: Step1Values
+  /** Filled into the quest "Milestones" form on apply */
+  step2: Step2Values
+}
+
+// ─── Courses ─────────────────────────────────────────────────────────────────
+
+const WEB_DEV_FUNDAMENTALS: QuestTemplate = {
+  id: "course-web-dev-fundamentals",
+  category: "course",
+  name: "Web Dev Fundamentals",
+  tagline: "Take a learner from zero to their first deployed web app.",
+  icon: "🌐",
+  duration: "4–6 weeks",
+  step1: {
+    name: "Web Development Fundamentals",
+    description:
+      "A structured introduction to web development. Learners will master HTML, CSS, and JavaScript, then build and deploy a real-world project. Perfect for absolute beginners.",
+    category: "Programming",
+    tags: ["javascript", "web-dev", "beginner", "html", "css"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Build a Static HTML Page",
+        description:
+          "Create a multi-section HTML page with semantic markup, headings, paragraphs, images, and links. No styling required yet — focus on valid structure.",
+        rewardAmount: 25,
+      },
+      {
+        title: "Style with CSS",
+        description:
+          "Apply a stylesheet to your HTML page. Use flexbox or grid for layout, add colour, typography, and at least one responsive breakpoint.",
+        rewardAmount: 50,
+      },
+      {
+        title: "Add Interactivity with JavaScript",
+        description:
+          "Write a JS file that responds to at least two DOM events (e.g. button click, form submit). Manipulate the DOM and show feedback to the user.",
+        rewardAmount: 75,
+      },
+      {
+        title: "Build a Mini Project",
+        description:
+          "Combine HTML, CSS, and JS to build a small interactive app — a to-do list, quiz, or calculator. The project must be runnable in a browser with no build step.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Deploy to Production",
+        description:
+          "Deploy your project to a public URL using Vercel, Netlify, or GitHub Pages. Share the live link as proof of completion.",
+        rewardAmount: 150,
+      },
+    ],
+  },
+}
+
+const UI_UX_DESIGN_COURSE: QuestTemplate = {
+  id: "course-ui-ux-design",
+  category: "course",
+  name: "UI/UX Design Essentials",
+  tagline: "Learn design thinking, Figma, and ship a real design system.",
+  icon: "🎨",
+  duration: "3–5 weeks",
+  step1: {
+    name: "UI/UX Design Essentials",
+    description:
+      "Learn the core principles of user interface and experience design. From wireframes and user flows to high-fidelity mockups and a component library — all in Figma.",
+    category: "Design",
+    tags: ["ui/ux", "figma", "design-systems", "beginner"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Create a User Persona",
+        description:
+          "Research a target user group and document a detailed persona — goals, pain points, demographics, and a quote. Deliver a Figma frame or PDF.",
+        rewardAmount: 30,
+      },
+      {
+        title: "Map a User Flow",
+        description:
+          "Draw a flow diagram for one core user journey (sign-up, checkout, or onboarding) with at least 6 decision points. Use FigJam or any diagramming tool.",
+        rewardAmount: 50,
+      },
+      {
+        title: "Design Low-Fidelity Wireframes",
+        description:
+          "Wireframe three screens of a mobile or web app using only greyscale shapes and placeholder text. Include navigation and at least one form.",
+        rewardAmount: 75,
+      },
+      {
+        title: "Build a Component Library",
+        description:
+          "Create a Figma component library with a colour palette, typography scale, spacing system, and at least 10 reusable components (button, input, card, etc.).",
+        rewardAmount: 125,
+      },
+      {
+        title: "Deliver a High-Fidelity Prototype",
+        description:
+          "Polish your wireframes into a complete high-fidelity, interactive prototype using your component library. Include at least one prototype flow users can click through.",
+        rewardAmount: 200,
+      },
+    ],
+  },
+}
+
+const DATA_SCIENCE_INTRO: QuestTemplate = {
+  id: "course-data-science-intro",
+  category: "course",
+  name: "Intro to Data Science",
+  tagline: "Python, pandas, and your first end-to-end ML model.",
+  icon: "📊",
+  duration: "5–7 weeks",
+  step1: {
+    name: "Intro to Data Science with Python",
+    description:
+      "A hands-on introduction to data science. Learn Python, data manipulation with pandas, data visualisation, and train your first machine-learning model on a real dataset.",
+    category: "Data Science",
+    tags: ["python", "pandas", "ml", "beginner", "data"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Python Foundations",
+        description:
+          "Complete exercises covering Python basics: variables, loops, functions, list comprehensions, and file I/O. Submit a .py file or Jupyter notebook.",
+        rewardAmount: 40,
+      },
+      {
+        title: "Data Wrangling with Pandas",
+        description:
+          "Load a CSV dataset, clean missing values, filter rows, group by categories, and compute summary statistics. Document your steps in a notebook.",
+        rewardAmount: 75,
+      },
+      {
+        title: "Exploratory Data Analysis",
+        description:
+          "Produce at least five charts (histogram, scatter, bar, heatmap, box plot) exploring a dataset of your choice. Write interpretations under each chart.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Train a Classification Model",
+        description:
+          "Using scikit-learn, train a classifier (logistic regression or random forest) on a labelled dataset. Report accuracy, precision, recall, and confusion matrix.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Present Your Findings",
+        description:
+          "Record a 5-minute video or write a 500-word report explaining your dataset, methodology, results, and at least two actionable insights.",
+        rewardAmount: 200,
+      },
+    ],
+  },
+}
+
+// ─── Bootcamps ───────────────────────────────────────────────────────────────
+
+const STELLAR_DEV_BOOTCAMP: QuestTemplate = {
+  id: "bootcamp-stellar-dev",
+  category: "bootcamp",
+  name: "Stellar Dev Bootcamp",
+  tagline: "Intensive path from Stellar basics to a live Soroban dApp.",
+  icon: "⭐",
+  duration: "6–8 weeks",
+  step1: {
+    name: "Stellar Development Bootcamp",
+    description:
+      "An intensive, structured bootcamp for developers entering the Stellar/Soroban ecosystem. Covers accounts, transactions, smart contracts in Rust, and deploying a production dApp.",
+    category: "Blockchain",
+    tags: ["stellar", "soroban", "rust", "smart-contracts"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Set Up the Stellar Dev Environment",
+        description:
+          "Install Rust, the WASM target, and Stellar CLI. Fund a testnet account via Friendbot and confirm the balance using the Stellar SDK.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Write Your First Soroban Contract",
+        description:
+          "Create, test, and deploy a 'Hello World' Soroban contract that accepts a name and returns a greeting. All unit tests must pass.",
+        rewardAmount: 200,
+      },
+      {
+        title: "Implement a Token Counter Contract",
+        description:
+          "Build a contract that increments a persistent counter and exposes get/set functions. Demonstrate TTL bumping and storage tier selection.",
+        rewardAmount: 300,
+      },
+      {
+        title: "Build an Asset Transfer Flow",
+        description:
+          "Write a contract that interacts with a Stellar Asset Contract (SAC). Implement deposit, withdraw, and balance-check functions with auth guards.",
+        rewardAmount: 400,
+      },
+      {
+        title: "Deploy a Frontend Integration",
+        description:
+          "Build a minimal React or vanilla JS frontend that connects Freighter, calls your contract's read functions, and signs a write transaction.",
+        rewardAmount: 500,
+      },
+      {
+        title: "Security Review & Audit Checklist",
+        description:
+          "Run clippy with deny(warnings), address all lint issues, and complete the standard Soroban security checklist: auth, integer overflow, reentrancy, event emission.",
+        rewardAmount: 500,
+      },
+    ],
+  },
+}
+
+const FULLSTACK_JS_BOOTCAMP: QuestTemplate = {
+  id: "bootcamp-fullstack-js",
+  category: "bootcamp",
+  name: "Full-Stack JavaScript Bootcamp",
+  tagline: "React, Node.js, databases, auth, and a shipped product.",
+  icon: "🚀",
+  duration: "8–10 weeks",
+  step1: {
+    name: "Full-Stack JavaScript Bootcamp",
+    description:
+      "A comprehensive bootcamp covering the modern JavaScript stack. Build and deploy a full-stack web application with React, Node/Express, PostgreSQL, authentication, and CI/CD.",
+    category: "Programming",
+    tags: ["javascript", "react", "node", "fullstack"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "React Fundamentals",
+        description:
+          "Build a multi-page React SPA with at least 5 components, client-side routing, and state managed with hooks. No external state library required.",
+        rewardAmount: 100,
+      },
+      {
+        title: "REST API with Node & Express",
+        description:
+          "Create a REST API with at least 4 resource endpoints (CRUD). Include input validation, error handling middleware, and an OpenAPI or Postman collection.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Database Design & Integration",
+        description:
+          "Design a normalised PostgreSQL schema, implement migrations, and wire up your API endpoints to the database using an ORM or query builder.",
+        rewardAmount: 200,
+      },
+      {
+        title: "Authentication & Authorisation",
+        description:
+          "Implement JWT-based auth: register, login, and at least one protected route. Passwords must be hashed (bcrypt). Include refresh-token logic.",
+        rewardAmount: 250,
+      },
+      {
+        title: "Testing Suite",
+        description:
+          "Achieve ≥ 70% test coverage on your API with integration tests. Include at least one happy path and one error path per endpoint. Use Jest or Vitest.",
+        rewardAmount: 200,
+      },
+      {
+        title: "Deploy to Production with CI/CD",
+        description:
+          "Deploy frontend and backend to separate hosting services. Set up a GitHub Actions pipeline that runs tests and deploys on push to main.",
+        rewardAmount: 300,
+      },
+    ],
+  },
+}
+
+const DEVOPS_BOOTCAMP: QuestTemplate = {
+  id: "bootcamp-devops",
+  category: "bootcamp",
+  name: "DevOps Bootcamp",
+  tagline: "Docker, Kubernetes, CI/CD, and cloud infrastructure in 8 weeks.",
+  icon: "⚙️",
+  duration: "7–9 weeks",
+  step1: {
+    name: "DevOps Engineering Bootcamp",
+    description:
+      "Master modern DevOps practices: containerisation with Docker, orchestration with Kubernetes, infrastructure as code, CI/CD pipelines, monitoring, and cloud deployment on AWS or GCP.",
+    category: "DevOps",
+    tags: ["docker", "kubernetes", "cicd", "cloud"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Containerise an Application",
+        description:
+          "Write a production-quality Dockerfile for an existing app. Use multi-stage builds, non-root user, and a .dockerignore. The image must build and run correctly.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Docker Compose Multi-Service Setup",
+        description:
+          "Define a docker-compose.yml that runs at least three services (app, database, cache). Include named volumes, health checks, and an env-file.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Kubernetes Deployment",
+        description:
+          "Write Kubernetes manifests (Deployment, Service, ConfigMap, Secret) for your app. Deploy to a local cluster (minikube or kind) and demonstrate rolling updates.",
+        rewardAmount: 250,
+      },
+      {
+        title: "CI/CD Pipeline",
+        description:
+          "Build a GitHub Actions workflow with lint, test, build, and deploy stages. The pipeline must fail fast and push a Docker image to a registry on success.",
+        rewardAmount: 200,
+      },
+      {
+        title: "Infrastructure as Code",
+        description:
+          "Provision a cloud environment using Terraform or Pulumi: VPC, compute instance, and managed database. All resources defined as code, no manual console steps.",
+        rewardAmount: 300,
+      },
+      {
+        title: "Observability Setup",
+        description:
+          "Instrument your app with structured logging and metrics. Set up Prometheus + Grafana (or cloud-native equivalents) with at least two alerting rules.",
+        rewardAmount: 250,
+      },
+    ],
+  },
+}
+
+// ─── Skill Challenges ────────────────────────────────────────────────────────
+
+const RUST_SKILL_CHALLENGE: QuestTemplate = {
+  id: "challenge-rust",
+  category: "challenge",
+  name: "Rust 30-Day Challenge",
+  tagline: "Level up Rust skills with focused, verifiable code exercises.",
+  icon: "🦀",
+  duration: "4 weeks",
+  step1: {
+    name: "Rust 30-Day Skill Challenge",
+    description:
+      "A focused Rust skill challenge. Complete a series of progressively harder exercises covering ownership, traits, generics, async, and systems programming. Each milestone requires a working, idiomatic Rust implementation.",
+    category: "Programming",
+    tags: ["rust", "systems", "challenge", "intermediate"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Ownership & Borrowing Exercises",
+        description:
+          "Solve 10 exercises demonstrating ownership rules, borrowing, and lifetimes. All exercises must compile without warnings and pass the provided test suite.",
+        rewardAmount: 75,
+      },
+      {
+        title: "Implement a CLI Tool",
+        description:
+          "Build a CLI application using clap or argh. The tool should read from stdin or a file, process data, and output results. Include error handling with anyhow or thiserror.",
+        rewardAmount: 125,
+      },
+      {
+        title: "Generics, Traits & Iterators",
+        description:
+          "Implement a generic data structure (stack, queue, or sorted set) using traits. Write iterator implementations and demonstrate use in at least one practical example.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Async Rust with Tokio",
+        description:
+          "Build an async HTTP client that fetches data from a public API, retries on failure (with exponential back-off), and writes results to a file. Use tokio and reqwest.",
+        rewardAmount: 200,
+      },
+    ],
+  },
+}
+
+const ALGO_CHALLENGE: QuestTemplate = {
+  id: "challenge-algorithms",
+  category: "challenge",
+  name: "Algorithms & DSA Sprint",
+  tagline: "Master 40 must-know patterns across arrays, trees, and graphs.",
+  icon: "🧠",
+  duration: "3–4 weeks",
+  step1: {
+    name: "Algorithms & Data Structures Sprint",
+    description:
+      "A targeted challenge covering the most important DSA patterns for technical interviews and competitive programming. Solve problems in your language of choice, document your reasoning, and hit complexity targets.",
+    category: "Computer Science",
+    tags: ["algorithms", "dsa", "interviews", "challenge"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "Arrays, Strings & Sliding Window",
+        description:
+          "Solve 10 problems using two-pointer and sliding-window techniques. For each problem, state the time and space complexity and explain why your approach is optimal.",
+        rewardAmount: 75,
+      },
+      {
+        title: "Linked Lists & Stacks",
+        description:
+          "Implement singly and doubly linked lists from scratch. Solve 8 classic problems (reverse, detect cycle, merge sorted lists, LRU cache). All implementations must pass unit tests.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Trees & Binary Search",
+        description:
+          "Solve 10 tree problems covering DFS, BFS, BST properties, lowest common ancestor, and serialisation/deserialisation. At least 3 problems must use iterative solutions.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Graphs & Dynamic Programming",
+        description:
+          "Implement BFS and DFS for directed and undirected graphs. Solve 12 problems covering shortest paths, topological sort, DP tabulation, and DP memoisation.",
+        rewardAmount: 200,
+      },
+    ],
+  },
+}
+
+const OPEN_SOURCE_CHALLENGE: QuestTemplate = {
+  id: "challenge-open-source",
+  category: "challenge",
+  name: "Open Source Contributor Sprint",
+  tagline: "Make meaningful contributions to 3 real open-source projects.",
+  icon: "🔓",
+  duration: "4–6 weeks",
+  step1: {
+    name: "Open Source Contributor Sprint",
+    description:
+      "Stop lurking and start shipping. This challenge pushes you to make genuine, merged contributions to active open-source projects — bug fixes, features, docs, and tests all count.",
+    category: "Open Source",
+    tags: ["open-source", "github", "contribution", "community"],
+  },
+  step2: {
+    milestones: [
+      {
+        title: "First Merged Pull Request",
+        description:
+          "Get your first PR merged into any active open-source project with ≥ 100 stars. The change must be non-trivial (not just a typo fix). Share the PR link.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Bug Fix with Regression Test",
+        description:
+          "Find and fix a confirmed bug in an open-source project. Your PR must include a regression test that would have caught the bug. Link to the issue and merged PR.",
+        rewardAmount: 150,
+      },
+      {
+        title: "Feature Addition",
+        description:
+          "Implement a requested feature from an open-source project's issue tracker. The feature must be accepted and merged by the maintainers.",
+        rewardAmount: 250,
+      },
+      {
+        title: "Documentation Overhaul",
+        description:
+          "Significantly improve documentation for a library or tool: add a getting-started guide, API reference, or migration guide. Must be merged and publicly accessible.",
+        rewardAmount: 100,
+      },
+      {
+        title: "Maintainer Recognition",
+        description:
+          "Be recognised as a contributor (added to CONTRIBUTORS file, mentioned in release notes, or invited to the organisation) by at least one open-source project maintainer.",
+        rewardAmount: 200,
+      },
+    ],
+  },
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+/** All templates in display order. */
+export const QUEST_TEMPLATES: QuestTemplate[] = [
+  // Courses
+  WEB_DEV_FUNDAMENTALS,
+  UI_UX_DESIGN_COURSE,
+  DATA_SCIENCE_INTRO,
+  // Bootcamps
+  STELLAR_DEV_BOOTCAMP,
+  FULLSTACK_JS_BOOTCAMP,
+  DEVOPS_BOOTCAMP,
+  // Challenges
+  RUST_SKILL_CHALLENGE,
+  ALGO_CHALLENGE,
+  OPEN_SOURCE_CHALLENGE,
+]
+
+/** Templates grouped by category for tabbed browsing. */
+export const TEMPLATES_BY_CATEGORY: Record<TemplateCategory, QuestTemplate[]> = {
+  course: QUEST_TEMPLATES.filter(t => t.category === "course"),
+  bootcamp: QUEST_TEMPLATES.filter(t => t.category === "bootcamp"),
+  challenge: QUEST_TEMPLATES.filter(t => t.category === "challenge"),
+}
+
+/** Human-readable labels and metadata for each category tab. */
+export const CATEGORY_META: Record<
+  TemplateCategory,
+  { label: string; description: string; icon: string }
+> = {
+  course: {
+    label: "Courses",
+    icon: "📚",
+    description: "Self-paced learning paths with progressive milestones.",
+  },
+  bootcamp: {
+    label: "Bootcamps",
+    icon: "🏕️",
+    description: "Intensive, structured programs with high-stakes rewards.",
+  },
+  challenge: {
+    label: "Challenges",
+    icon: "⚡",
+    description: "Focused skill sprints to prove mastery fast.",
+  },
+}
+
+/** Lookup a template by its unique id. Returns undefined if not found. */
+export function getTemplateById(id: string): QuestTemplate | undefined {
+  return QUEST_TEMPLATES.find(t => t.id === id)
+}

--- a/frontend/src/pages/create-quest/step1.tsx
+++ b/frontend/src/pages/create-quest/step1.tsx
@@ -1,22 +1,26 @@
-import { useState, type KeyboardEvent } from "react"
+import { useState, useEffect, type KeyboardEvent } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { ArrowRight, FileText, Plus, X } from "lucide-react"
+import { ArrowRight, FileText, LayoutTemplate, Plus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { step1Schema, type Step1Values, FieldError, FormLabel } from "./types"
 import { useQuestCreation } from "./context"
+import { TemplatePicker } from "./template-picker"
+import type { QuestTemplate } from "./quest-templates"
 
 export function Step1Form() {
-  const { step1Data, setStep1Data, goToNext } = useQuestCreation()
+  const { step1Data, setStep1Data, goToNext, applyTemplate, appliedTemplateId } = useQuestCreation()
   const [tagInput, setTagInput] = useState("")
   const [tagError, setTagError] = useState<string | null>(null)
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
 
   const {
     register,
     handleSubmit,
     watch,
     setValue,
+    reset,
     formState: { errors, isValid },
   } = useForm<Step1Values>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,6 +33,22 @@ export function Step1Form() {
     },
     mode: "onChange",
   })
+
+  // When a template is applied the context updates step1Data; sync the form.
+  useEffect(() => {
+    reset({
+      name: step1Data.name || "",
+      description: step1Data.description || "",
+      category: step1Data.category || "",
+      tags: step1Data.tags || [],
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appliedTemplateId])
+
+  const handleApplyTemplate = (template: QuestTemplate) => {
+    applyTemplate(template)
+    setIsPickerOpen(false)
+  }
 
   const nameValue = watch("name", "")
   const descValue = watch("description", "")
@@ -82,11 +102,27 @@ export function Step1Form() {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       <div>
         <div className="bg-accent border-border border-b px-6 py-3">
-          <div className="flex items-center gap-2">
-            <FileText className="h-4 w-4" />
-            <span className="text-sm font-semibold tracking-wider uppercase">
-              Step 1 — Quest Basics
-            </span>
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <FileText className="h-4 w-4" />
+              <span className="text-sm font-semibold tracking-wider uppercase">
+                Step 1 — Quest Basics
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsPickerOpen(true)}
+              aria-label="Open template picker"
+              className={cn(
+                "border-border neo-press flex cursor-pointer items-center gap-1.5 border px-3 py-1.5 text-xs font-semibold transition-colors",
+                appliedTemplateId
+                  ? "bg-success/20 border-success/40 hover:bg-success/30"
+                  : "bg-background hover:bg-secondary"
+              )}
+            >
+              <LayoutTemplate className="h-3.5 w-3.5" />
+              {appliedTemplateId ? "Template applied ✓" : "Use a Template"}
+            </button>
           </div>
         </div>
         <div className="border-border bg-background space-y-5 border border-t-0 p-6 shadow-md">
@@ -103,7 +139,7 @@ export function Step1Form() {
               placeholder="e.g. Learn to Code with Alex"
               className={cn(
                 "border-border bg-background w-full border px-4 py-2.5 text-sm font-medium transition-shadow focus:shadow-md focus:outline-none",
-                errors.name && "border-destructive focus:ring-1 focus:ring-destructive"
+                errors.name && "border-destructive focus:ring-destructive focus:ring-1"
               )}
               maxLength={64}
             />
@@ -134,7 +170,7 @@ export function Step1Form() {
               placeholder="Describe what learners will accomplish..."
               className={cn(
                 "border-border bg-background w-full resize-none border px-4 py-2.5 text-sm font-medium transition-shadow focus:shadow-md focus:outline-none",
-                errors.description && "border-destructive focus:ring-1 focus:ring-destructive"
+                errors.description && "border-destructive focus:ring-destructive focus:ring-1"
               )}
               maxLength={2000}
             />
@@ -164,7 +200,7 @@ export function Step1Form() {
               placeholder="e.g. Programming, Web3, Design"
               className={cn(
                 "border-border bg-background w-full border px-4 py-2.5 text-sm font-medium transition-shadow focus:shadow-md focus:outline-none",
-                errors.category && "border-destructive focus:ring-1 focus:ring-destructive"
+                errors.category && "border-destructive focus:ring-destructive focus:ring-1"
               )}
               maxLength={32}
             />
@@ -253,6 +289,12 @@ export function Step1Form() {
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
+
+      <TemplatePicker
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        onApply={handleApplyTemplate}
+      />
     </form>
   )
 }

--- a/frontend/src/pages/create-quest/template-picker.tsx
+++ b/frontend/src/pages/create-quest/template-picker.tsx
@@ -1,0 +1,425 @@
+/**
+ * TemplatePicker — full-screen modal to browse and preview quest templates.
+ *
+ * Layout:
+ *   ┌─────────────────────────────────────────────────┐
+ *   │  Header: title + close button                   │
+ *   ├──────────────┬──────────────────────────────────┤
+ *   │  Left panel  │  Right panel                     │
+ *   │  Category    │  Preview: name, tagline, milest. │
+ *   │  tabs +      │  + "Use this template" CTA       │
+ *   │  template    │                                  │
+ *   │  cards       │  (or empty state when nothing    │
+ *   │              │   is selected)                   │
+ *   └──────────────┴──────────────────────────────────┘
+ *
+ * On mobile the layout collapses to a single-column flow:
+ *   category tabs → cards → tapping a card expands inline preview.
+ */
+
+import { useState, useEffect, useCallback } from "react"
+import { X, ArrowRight, Coins, Check, ChevronDown, ChevronUp } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import {
+  QUEST_TEMPLATES,
+  TEMPLATES_BY_CATEGORY,
+  CATEGORY_META,
+  type QuestTemplate,
+  type TemplateCategory,
+} from "./quest-templates"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface TemplatePickerProps {
+  /** Whether the modal is open */
+  isOpen: boolean
+  /** Called when the user closes without selecting */
+  onClose: () => void
+  /** Called when the user confirms a template selection */
+  onApply: (template: QuestTemplate) => void
+}
+
+// ─── TemplateCard (left panel item) ──────────────────────────────────────────
+
+interface TemplateCardProps {
+  template: QuestTemplate
+  isSelected: boolean
+  onSelect: () => void
+}
+
+function TemplateCard({ template, isSelected, onSelect }: TemplateCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      aria-label={`Select template: ${template.name}`}
+      className={cn(
+        "border-border bg-background w-full cursor-pointer border p-4 text-left transition-all",
+        "hover:bg-secondary focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none",
+        isSelected
+          ? "border-foreground bg-accent shadow-[2px_2px_0px_0px_hsl(var(--foreground))]"
+          : "hover:shadow-[2px_2px_0px_0px_hsl(var(--border))]"
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex-shrink-0 text-xl" aria-hidden>
+          {template.icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <p className="truncate text-sm font-semibold">{template.name}</p>
+            {isSelected && <Check className="h-3.5 w-3.5 flex-shrink-0" aria-label="Selected" />}
+          </div>
+          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">{template.tagline}</p>
+          <div className="mt-2 flex items-center gap-1.5">
+            <span className="bg-secondary border-border border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+              {template.duration}
+            </span>
+            <span className="text-muted-foreground text-[10px] font-semibold">
+              {template.step2.milestones.length} milestones
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+// ─── MobilePreviewPanel (collapsible, shown below selected card on mobile) ───
+
+interface MobilePreviewPanelProps {
+  template: QuestTemplate
+  onApply: () => void
+}
+
+function MobilePreviewPanel({ template, onApply }: MobilePreviewPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const totalReward = template.step2.milestones.reduce((s, m) => s + m.rewardAmount, 0)
+
+  return (
+    <div className="border-border bg-accent border-t">
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold"
+        aria-expanded={expanded}
+      >
+        <span>Preview: {template.name}</span>
+        {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </button>
+
+      {expanded && (
+        <div className="space-y-4 px-4 pb-4">
+          <PreviewContent template={template} totalReward={totalReward} />
+          <Button onClick={onApply} className="shimmer-on-hover w-full">
+            Start with this template
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── PreviewContent (shared by desktop panel and mobile panel) ───────────────
+
+interface PreviewContentProps {
+  template: QuestTemplate
+  totalReward: number
+}
+
+function PreviewContent({ template, totalReward }: PreviewContentProps) {
+  return (
+    <>
+      {/* Category + duration badges */}
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="outline" className="text-xs">
+          {CATEGORY_META[template.category].icon} {CATEGORY_META[template.category].label}
+        </Badge>
+        <Badge variant="secondary" className="text-xs">
+          {template.duration}
+        </Badge>
+        <Badge variant="secondary" className="text-xs">
+          <Coins className="mr-1 h-3 w-3" />
+          {totalReward} USDC suggested
+        </Badge>
+      </div>
+
+      {/* Quest basics */}
+      <div>
+        <p className="text-muted-foreground mb-1 text-[10px] font-semibold tracking-wider uppercase">
+          Quest Basics
+        </p>
+        <h3 className="text-base font-semibold">{template.step1.name}</h3>
+        <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+          {template.step1.description}
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          <span className="bg-secondary border-border border px-2 py-0.5 text-[10px] font-semibold">
+            {template.step1.category}
+          </span>
+          {template.step1.tags.map(tag => (
+            <span
+              key={tag}
+              className="bg-secondary border-border border px-2 py-0.5 text-[10px] font-semibold"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Milestones */}
+      <div>
+        <p className="text-muted-foreground mb-2 text-[10px] font-semibold tracking-wider uppercase">
+          Milestones ({template.step2.milestones.length})
+        </p>
+        <ol className="space-y-2">
+          {template.step2.milestones.map((m, i) => (
+            <li key={i} className="bg-background border-border flex items-start gap-3 border p-3">
+              <div className="bg-accent border-border mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center border text-[10px] font-semibold">
+                {i + 1}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <p className="text-sm font-semibold">{m.title}</p>
+                  <span className="flex-shrink-0 text-xs font-semibold tabular-nums">
+                    {m.rewardAmount} USDC
+                  </span>
+                </div>
+                <p className="text-muted-foreground mt-0.5 text-xs leading-relaxed">
+                  {m.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      {/* Total */}
+      <div className="bg-secondary border-border flex items-center justify-between border px-4 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <Coins className="h-3.5 w-3.5" />
+          <span className="text-xs font-semibold">Suggested total reward</span>
+        </div>
+        <span className="text-sm font-semibold tabular-nums">{totalReward} USDC</span>
+      </div>
+    </>
+  )
+}
+
+// ─── TemplatePicker (main) ────────────────────────────────────────────────────
+
+const CATEGORIES: TemplateCategory[] = ["course", "bootcamp", "challenge"]
+
+export function TemplatePicker({ isOpen, onClose, onApply }: TemplatePickerProps) {
+  const [activeCategory, setActiveCategory] = useState<TemplateCategory>("course")
+  const [selectedId, setSelectedId] = useState<string | null>(QUEST_TEMPLATES[0]?.id ?? null)
+
+  // Reset to first template in the newly selected category
+  const handleCategoryChange = useCallback((cat: TemplateCategory) => {
+    setActiveCategory(cat)
+    setSelectedId(TEMPLATES_BY_CATEGORY[cat][0]?.id ?? null)
+  }, [])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [isOpen, onClose])
+
+  // Lock body scroll while open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const visibleTemplates = TEMPLATES_BY_CATEGORY[activeCategory]
+  const selectedTemplate = selectedId
+    ? (QUEST_TEMPLATES.find(t => t.id === selectedId) ?? null)
+    : null
+  const totalReward = selectedTemplate
+    ? selectedTemplate.step2.milestones.reduce((s, m) => s + m.rewardAmount, 0)
+    : 0
+
+  const handleApply = () => {
+    if (selectedTemplate) {
+      onApply(selectedTemplate)
+    }
+  }
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-stretch justify-stretch bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Choose a quest template"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      {/* Modal container */}
+      <div className="bg-background border-border relative mx-auto flex w-full max-w-5xl flex-col overflow-hidden border shadow-2xl sm:my-4 sm:rounded-none">
+        {/* ── Header ────────────────────────────────────── */}
+        <div className="bg-accent border-border flex flex-shrink-0 items-center justify-between border-b px-5 py-3">
+          <div>
+            <h2 className="text-sm font-semibold tracking-wider uppercase">
+              Choose a Quest Template
+            </h2>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              Start with a pre-built structure. You can edit every field before creating.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close template picker"
+            className="border-border bg-background neo-press hover:bg-secondary flex h-8 w-8 cursor-pointer items-center justify-center border transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* ── Category Tabs ──────────────────────────────── */}
+        <div
+          className="border-border flex flex-shrink-0 gap-0 border-b"
+          role="tablist"
+          aria-label="Template categories"
+        >
+          {CATEGORIES.map(cat => {
+            const meta = CATEGORY_META[cat]
+            const isActive = activeCategory === cat
+            return (
+              <button
+                key={cat}
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`tabpanel-${cat}`}
+                id={`tab-${cat}`}
+                type="button"
+                onClick={() => handleCategoryChange(cat)}
+                className={cn(
+                  "border-border flex flex-1 cursor-pointer items-center justify-center gap-1.5 border-r px-3 py-3 text-xs font-semibold transition-colors last:border-r-0 sm:gap-2 sm:px-5 sm:text-sm",
+                  isActive
+                    ? "bg-background text-foreground border-b-foreground border-b-2"
+                    : "bg-secondary text-muted-foreground hover:bg-accent hover:text-foreground"
+                )}
+              >
+                <span aria-hidden>{meta.icon}</span>
+                <span className="hidden sm:inline">{meta.label}</span>
+                <span className="sm:hidden">{meta.label}</span>
+                <span className="bg-accent border-border hidden border px-1 text-[10px] font-semibold sm:inline">
+                  {TEMPLATES_BY_CATEGORY[cat].length}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+
+        {/* ── Body: two-panel layout on md+, single column on mobile ── */}
+        <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+          {/* ── Left: Template List ─────────────────────── */}
+          <div
+            id={`tabpanel-${activeCategory}`}
+            role="tabpanel"
+            aria-labelledby={`tab-${activeCategory}`}
+            className="border-border flex w-full flex-col overflow-y-auto border-r md:w-72 md:flex-shrink-0 lg:w-80"
+          >
+            <div className="flex-shrink-0 px-4 pt-3 pb-1">
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                {CATEGORY_META[activeCategory].description}
+              </p>
+            </div>
+            <div className="flex-1 space-y-2 overflow-y-auto p-3">
+              {visibleTemplates.map(template => (
+                <div key={template.id}>
+                  <TemplateCard
+                    template={template}
+                    isSelected={selectedId === template.id}
+                    onSelect={() => setSelectedId(template.id)}
+                  />
+                  {/* Mobile-only inline preview */}
+                  {selectedId === template.id && (
+                    <div className="md:hidden">
+                      <MobilePreviewPanel template={template} onApply={handleApply} />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Right: Preview Panel (desktop only) ─────── */}
+          <div className="hidden min-h-0 flex-1 flex-col overflow-hidden md:flex">
+            {selectedTemplate ? (
+              <>
+                {/* Scrollable preview content */}
+                <div className="flex-1 space-y-4 overflow-y-auto p-5">
+                  <div className="flex items-start gap-3">
+                    <span className="text-3xl" aria-hidden>
+                      {selectedTemplate.icon}
+                    </span>
+                    <div>
+                      <h3 className="text-lg font-semibold">{selectedTemplate.name}</h3>
+                      <p className="text-muted-foreground text-sm">{selectedTemplate.tagline}</p>
+                    </div>
+                  </div>
+                  <PreviewContent template={selectedTemplate} totalReward={totalReward} />
+                </div>
+
+                {/* Sticky footer CTA */}
+                <div className="border-border flex-shrink-0 border-t p-4">
+                  <Button onClick={handleApply} className="shimmer-on-hover w-full" size="lg">
+                    Start with this template
+                    <ArrowRight className="h-4 w-4" />
+                  </Button>
+                  <p className="text-muted-foreground mt-2 text-center text-xs">
+                    All fields are editable before you create the quest.
+                  </p>
+                </div>
+              </>
+            ) : (
+              /* Empty state */
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+                <span className="text-4xl" aria-hidden>
+                  👈
+                </span>
+                <p className="text-sm font-semibold">Select a template to preview it here</p>
+                <p className="text-muted-foreground max-w-xs text-xs">
+                  Browse the templates on the left and click one to see its full milestone
+                  structure.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ── Mobile footer: apply button when something is selected ── */}
+        {selectedTemplate && (
+          <div className="border-border flex-shrink-0 border-t p-4 md:hidden">
+            <Button onClick={handleApply} className="shimmer-on-hover w-full">
+              Start with "{selectedTemplate.name}"
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
…enges

- Add 9 pre-built templates across 3 categories (course, bootcamp, challenge)
- Templates: Web Dev, UI/UX, Data Science, Stellar Dev Bootcamp, Full-Stack JS, DevOps, Rust Challenge, Algorithms & DSA, Open Source Contributor Sprint
- Add TemplatePicker modal with category tabs, card list, and preview panel
- Integrate template picker into Step 1 of the create-quest wizard
- Wire applyTemplate action through QuestCreationContext
- Add 110 unit tests covering data integrity, schema compliance, and UI behavior

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->

#1228 
