### PR TITLE
fix(contracts): validate certificate metadata URI and expire stale quest invites

### DIFF
--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -256,7 +256,11 @@ impl CertificateContract {
 
     #[only_owner]
     pub fn set_metadata_base(env: Env, uri: String) -> Result<(), Error> {
+        if !common::is_valid_url(&uri) {
+            return Err(Error::InvalidInput);
+        }
         env.storage().instance().set(&DataKey::MetadataBase, &uri);
+        extend_instance_ttl(&env);
         env.events()
             .publish((Symbol::new(&env, "metadata_base_updated"),), uri);
         Ok(())

--- a/contracts/certificate/src/test.rs
+++ b/contracts/certificate/src/test.rs
@@ -148,6 +148,55 @@ fn test_get_metadata_base_not_set_returns_error() {
     assert_eq!(result, Err(Ok(Error::MetadataBaseNotSet)));
 }
 
+#[test]
+fn test_set_metadata_base_rejects_empty_string() {
+    // Issue #1273 — empty URI must be rejected.
+    let (env, client, _owner) = setup();
+    let uri = String::from_str(&env, "");
+    let result = client.try_set_metadata_base(&uri);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_set_metadata_base_rejects_malformed_uri() {
+    // Issue #1273 — arbitrary non-URI strings must be rejected.
+    let (env, client, _owner) = setup();
+    let uri = String::from_str(&env, "not-a-valid-uri");
+    let result = client.try_set_metadata_base(&uri);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_set_metadata_base_rejects_whitespace() {
+    // Issue #1273 — URIs containing whitespace must be rejected.
+    let (env, client, _owner) = setup();
+    let uri = String::from_str(&env, "https://lernza.io/ certs");
+    let result = client.try_set_metadata_base(&uri);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_set_metadata_base_accepts_ipfs_uri() {
+    // Issue #1273 — ipfs:// URIs remain a valid metadata base scheme.
+    let (env, client, _owner) = setup();
+    let uri = String::from_str(&env, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/");
+    client.set_metadata_base(&uri);
+    assert_eq!(client.get_metadata_base(), uri);
+}
+
+#[test]
+fn test_set_metadata_base_rejected_uri_does_not_overwrite_stored_value() {
+    // Issue #1273 — a rejected update must leave the previously stored URI intact.
+    let (env, client, _owner) = setup();
+    let good_uri = String::from_str(&env, "https://lernza.io/certificates/");
+    client.set_metadata_base(&good_uri);
+
+    let bad_uri = String::from_str(&env, "garbage");
+    let result = client.try_set_metadata_base(&bad_uri);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+    assert_eq!(client.get_metadata_base(), good_uri);
+}
+
 // --- Additional edge-case coverage — issue #1184 ---
 
 #[test]

--- a/contracts/common/src/lib.rs
+++ b/contracts/common/src/lib.rs
@@ -191,7 +191,8 @@ pub fn extend_persistent_ttl(env: &Env, key: &impl IsDataKey) {
 }
 
 /// Basic URL format checker used by contract metadata validation.
-/// Lightweight acceptance of http/https and rejects whitespace.
+/// Lightweight acceptance of http/https/ipfs schemes and rejects whitespace
+/// and empty strings.
 pub fn is_valid_url(s: &String) -> bool {
     if s.len() == 0 || s.len() > 2048 {
         return false;
@@ -209,10 +210,14 @@ pub fn is_valid_url(s: &String) -> bool {
     }
     let prefix_http = b"http://";
     let prefix_https = b"https://";
+    let prefix_ipfs = b"ipfs://";
     if len >= 7 && &buf[..7] == prefix_http {
         return true;
     }
     if len >= 8 && &buf[..8] == prefix_https {
+        return true;
+    }
+    if len >= 7 && &buf[..7] == prefix_ipfs {
         return true;
     }
     false
@@ -302,3 +307,25 @@ pub fn get_persistent<K: IsDataKey, T: soroban_sdk::TryFromVal<Env, soroban_sdk:
 ) -> Option<T> {
     env.storage().persistent().get(key)
 }
+
+/// Planning-only heuristic for rent-cost estimates: stroops charged per
+/// 1,024 bytes of persistent-entry payload for a single `BUMP` (~30 day) TTL
+/// extension window. This mirrors the order of magnitude of Soroban's
+/// published write-fee / rent schedule but is **not** read from the network,
+/// so callers must still confirm exact costs via `simulateTransaction`
+/// before submitting a transaction. See `docs/GAS_COSTS.md` for the full
+/// storage cost model this constant supports.
+pub const RENT_STROOPS_PER_KB_PER_BUMP: i128 = 150;
+
+/// Estimate the rent (in stroops) needed to keep a persistent entry of
+/// `entry_size_bytes` alive for one `BUMP` TTL-extension cycle.
+///
+/// This is a rough, contract-side planning aid so frontends can show users
+/// an approximate storage cost *before* they sign a transaction — it is not
+/// a substitute for simulating the actual transaction.
+pub fn estimate_persistent_rent(entry_size_bytes: u32) -> i128 {
+    let bytes = entry_size_bytes as i128;
+    // Ceil-divide so partial kilobytes still round up to a whole unit of rent.
+    ((bytes * RENT_STROOPS_PER_KB_PER_BUMP) + 1023) / 1024
+}
+

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -760,6 +760,9 @@ impl QuestContract {
         if quest.status == QuestStatus::Archived || quest.status == QuestStatus::Cancelled {
             return Err(Error::EnrollmentClosed);
         }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return Err(Error::DeadlineExpired);
+        }
         let key = DataKey::InviteCommitment(quest_id, commitment.clone());
         env.storage().persistent().set(&key, &true);
         common::extend_persistent_ttl(&env, &key);
@@ -790,8 +793,22 @@ impl QuestContract {
         Ok(())
     }
 
-    /// Check whether an invite commitment is registered and not yet consumed.
+    /// Check whether an invite commitment is registered, not yet consumed,
+    /// and still redeemable (the quest is neither closed nor past its
+    /// deadline). A commitment that would be rejected by
+    /// `join_quest_with_invite` for any of these reasons reports as invalid
+    /// here too, so callers never see a stale invite reported as valid.
     pub fn is_invite_valid(env: Env, quest_id: u32, commitment: BytesN<32>) -> bool {
+        let quest = match Self::load_quest(&env, quest_id) {
+            Ok(q) => q,
+            Err(_) => return false,
+        };
+        if quest.status == QuestStatus::Archived || quest.status == QuestStatus::Cancelled {
+            return false;
+        }
+        if quest.deadline > 0 && env.ledger().timestamp() > quest.deadline {
+            return false;
+        }
         let registered = env
             .storage()
             .persistent()
@@ -1106,6 +1123,53 @@ impl QuestContract {
             return Ok(false);
         }
         Ok(env.ledger().timestamp() > quest.deadline)
+    }
+
+    /// Estimate the rent (in stroops) `create_quest` will need to keep the
+    /// resulting `QuestInfo` entry alive for one TTL cycle (~30 days), based
+    /// on the sizes of the variable-length fields the caller intends to
+    /// submit. This is a planning aid only — see `docs/GAS_COSTS.md` for the
+    /// full storage cost model and its accuracy caveats. Always confirm the
+    /// exact fee with `simulateTransaction` before signing.
+    pub fn estimate_quest_creation_rent(
+        _env: Env,
+        name_len: u32,
+        description_len: u32,
+        category_len: u32,
+        tag_count: u32,
+    ) -> i128 {
+        // Fixed overhead accounts for the non-string QuestInfo fields
+        // (addresses, numeric fields, enums, and struct/XDR framing).
+        const FIXED_OVERHEAD_BYTES: u32 = 256;
+        const AVG_TAG_BYTES: u32 = MAX_TAG_LEN;
+
+        let entry_size = FIXED_OVERHEAD_BYTES
+            + name_len
+            + description_len
+            + category_len
+            + (tag_count.min(MAX_TAGS) * AVG_TAG_BYTES);
+
+        common::estimate_persistent_rent(entry_size)
+    }
+
+    /// Explicitly refresh the TTL for a quest, its enrollee list, and its
+    /// version history. Owner only.
+    ///
+    /// Quest data is normally kept alive as a side effect of other mutating
+    /// calls (see `bump`), but a quest that receives no updates for a long
+    /// stretch can approach expiry. This lets an owner top up the TTL
+    /// directly — e.g. from a scheduled job — without making an unrelated
+    /// state change.
+    pub fn extend_quest_ttl(env: Env, quest_id: u32, owner: Address) -> Result<(), Error> {
+        let quest = Self::load_quest(&env, quest_id)?;
+        if quest.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        owner.require_auth();
+        Self::bump(&env, quest_id);
+        env.events()
+            .publish((Symbol::new(&env, "quest_ttl_extended"),), quest_id);
+        Ok(())
     }
 
     /// Get total quest count.

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -1809,6 +1809,56 @@ fn test_invite_past_deadline_rejected() {
 }
 
 #[test]
+fn test_is_invite_valid_false_after_deadline() {
+    // Issue #1326 — is_invite_valid must not report a stale invite as valid
+    // once the quest deadline has passed, even though the commitment itself
+    // is still registered and unused.
+    let (env, client, owner, token) = setup();
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"secret";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+    assert!(client.is_invite_valid(&quest_id, &commitment));
+
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&quest_id, &999);
+
+    assert!(!client.is_invite_valid(&quest_id, &commitment));
+}
+
+#[test]
+fn test_register_invite_past_deadline_rejected() {
+    // Issue #1326 — an owner cannot register new invites for a quest whose
+    // deadline has already passed.
+    let (env, client, owner, token) = setup();
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    env.ledger().set_timestamp(1000);
+    client.set_deadline(&quest_id, &999);
+
+    let commitment = sha256_commitment(&env, b"secret");
+    let result = client.try_register_invite(&owner, &quest_id, &commitment);
+    assert_eq!(result, Err(Ok(Error::DeadlineExpired)));
+}
+
+#[test]
+fn test_is_invite_valid_false_for_archived_quest() {
+    // Issue #1326 — closing a quest (archive) must also invalidate its
+    // outstanding invites from the query surface.
+    let (env, client, owner, token) = setup();
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Private);
+
+    let preimage = b"secret";
+    let commitment = sha256_commitment(&env, preimage);
+    client.register_invite(&owner, &quest_id, &commitment);
+    assert!(client.is_invite_valid(&quest_id, &commitment));
+
+    client.archive_quest(&quest_id);
+    assert!(!client.is_invite_valid(&quest_id, &commitment));
+}
+
+#[test]
 fn test_invite_respects_enrollment_cap() {
     let (env, client, owner, token) = setup();
     // Cap of 1 enrollee.
@@ -2017,4 +2067,42 @@ fn test_signature_and_preimage_validation_rejects_forgery() {
         &Bytes::from_slice(&env, authentic_preimage),
     );
     assert!(client.is_enrollee(&quest_id, &victim));
+}
+
+// --- Storage cost estimation & TTL management — issue #1416 ---
+
+#[test]
+fn test_estimate_quest_creation_rent_scales_with_input_size() {
+    let (env, client, _owner, _token) = setup();
+
+    let small = client.estimate_quest_creation_rent(&4, &10, &4, &0);
+    let large = client.estimate_quest_creation_rent(&64, &2000, &32, &5);
+
+    assert!(small > 0);
+    assert!(large > small);
+}
+
+#[test]
+fn test_estimate_quest_creation_rent_caps_tag_count() {
+    // Tags beyond MAX_TAGS (5) must not inflate the estimate further, since
+    // create_quest itself rejects more than MAX_TAGS tags.
+    let (env, client, _owner, _token) = setup();
+
+    let at_cap = client.estimate_quest_creation_rent(&10, &10, &10, &5);
+    let above_cap = client.estimate_quest_creation_rent(&10, &10, &10, &50);
+    assert_eq!(at_cap, above_cap);
+}
+
+#[test]
+fn test_extend_quest_ttl_owner_only() {
+    let (env, client, owner, token) = setup();
+    let quest_id = create_quest_with_visibility(&env, &client, &owner, &token, Visibility::Public);
+
+    // Non-owner cannot extend TTL.
+    let impostor = Address::generate(&env);
+    let result = client.try_extend_quest_ttl(&quest_id, &impostor);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+    // Owner can extend TTL successfully.
+    client.extend_quest_ttl(&quest_id, &owner);
 }

--- a/docs/deploy-testnet.md
+++ b/docs/deploy-testnet.md
@@ -3,11 +3,14 @@
 This guide is a step-by-step runbook for deploying Lernza Soroban contracts to Stellar **testnet**.
 
 Contracts in this repo:
-- `contracts/rewards` (reward pools and payout)
 - `contracts/quest` (quest creation and enrollment)
 - `contracts/milestone` (milestone definition and completion verification)
+- `contracts/rewards` (reward pools and payout)
+- `contracts/certificate` (quest-completion certificate NFTs)
 
 `quest` is the contract name for quests.
+
+For a guided, end-to-end walkthrough that also exercises the contracts (create a quest, fund it, enroll a learner, submit and verify a milestone) see [testnet-tutorial.md](testnet-tutorial.md). This document focuses on the deployment mechanics; the tutorial focuses on interacting with contracts once deployed.
 
 ## Automated Deployment (Recommended)
 
@@ -42,6 +45,28 @@ cargo --version
 rustup target list | grep wasm32
 ```
 
+### 1.1 Testnet Account & Faucet Setup
+
+Testnet accounts need testnet XLM (Lumens) to pay transaction fees. The Stellar CLI can create and fund a key in one step:
+
+```bash
+# Generate a new local key named "lernza-deployer" and fund it via the
+# Friendbot faucet in a single command
+stellar keys generate lernza-deployer --network testnet --fund
+
+# Check the account exists and has a balance
+stellar keys address lernza-deployer
+stellar account fund lernza-deployer --network testnet   # re-fund if needed
+```
+
+If you already have a key and just need more testnet XLM, use Friendbot directly:
+
+```bash
+curl "https://friendbot.stellar.org/?addr=$(stellar keys address lernza-deployer)"
+```
+
+Each Friendbot request funds the account with a fixed amount of testnet XLM (enough for many contract calls). Testnet state is reset periodically by SDF — if your account or contracts disappear, re-run this setup and redeploy.
+
 ## 2. Build Contracts
 
 From repo root:
@@ -52,9 +77,10 @@ stellar contract build
 ```
 
 Expected wasm outputs:
-- `target/wasm32v1-none/release/rewards.wasm`
 - `target/wasm32v1-none/release/quest.wasm`
 - `target/wasm32v1-none/release/milestone.wasm`
+- `target/wasm32v1-none/release/rewards.wasm`
+- `target/wasm32v1-none/release/certificate.wasm`
 
 ## 3. Configure Network + Deployer Identity
 
@@ -97,21 +123,9 @@ TOKEN_ID=<output_from_command_above>
 
 ## 5. Deploy Contracts
 
-Deploy each contract and copy the returned contract ID.
+Deploy each contract and copy the returned contract ID. Contracts can be deployed in any order since deployment itself does not create cross-contract references — only the *initialization/usage* sequence in Section 6 is order-dependent.
 
-### 5.1 Deploy rewards
-
-```bash
-stellar contract deploy \
-  --wasm target/wasm32v1-none/release/rewards.wasm \
-  --source-account lernza-deployer \
-  --network testnet \
-  --alias lernza-rewards-testnet
-```
-
-Save output as `REWARDS_ID`.
-
-### 5.2 Deploy quest contract
+### 5.1 Deploy quest contract
 
 ```bash
 stellar contract deploy \
@@ -123,7 +137,7 @@ stellar contract deploy \
 
 Save output as `QUEST_ID`.
 
-### 5.3 Deploy milestone
+### 5.2 Deploy milestone
 
 ```bash
 stellar contract deploy \
@@ -135,22 +149,56 @@ stellar contract deploy \
 
 Save output as `MILESTONE_ID`.
 
+### 5.3 Deploy rewards
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/rewards.wasm \
+  --source-account lernza-deployer \
+  --network testnet \
+  --alias lernza-rewards-testnet
+```
+
+Save output as `REWARDS_ID`.
+
+### 5.4 Deploy certificate
+
+The certificate contract's constructor takes the owner/admin address directly, so it is initialized as part of deployment (no separate `initialize` call):
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/certificate.wasm \
+  --source-account lernza-deployer \
+  --network testnet \
+  --alias lernza-certificate-testnet \
+  -- \
+  --owner lernza-deployer
+```
+
+Save output as `CERTIFICATE_ID`.
+
 ## 6. Initialization Sequence (Required Order)
 
-Required order for first setup:
-1. Initialize `rewards`
-2. Create quest in `quest`
-3. Create milestone in `milestone`
+Contracts reference each other by address at initialization time (there are
+no cross-contract calls at runtime beyond read-only lookups — see
+[ARCHITECTURE.md](ARCHITECTURE.md) — but `milestone` and `rewards` both store
+peer contract addresses set once during `initialize`). Deploy all four
+contracts first (Section 5), then initialize/use them in this order:
 
-### 6.1 Initialize rewards first
+1. **`quest`** — initialize the contract admin, then create the quest
+2. **`milestone`** — initialize with the `quest` and `certificate` addresses, then define milestones for the quest
+3. **`rewards`** — initialize with the token, `quest`, and `milestone` addresses, then fund the quest's reward pool
+4. **`certificate`** — mint a completion certificate once a learner finishes the quest
+
+### 6.1 Initialize the quest contract admin (one-time)
 
 ```bash
 stellar contract invoke \
-  --id <REWARDS_ID> \
+  --id <QUEST_ID> \
   --source-account lernza-deployer \
   --network testnet \
   -- initialize \
-  --token_addr <TOKEN_ID>
+  --admin lernza-deployer
 ```
 
 ### 6.2 Create quest
@@ -164,14 +212,30 @@ stellar contract invoke \
   --owner lernza-deployer \
   --name "Lernza Test Quest" \
   --description "Deployment check quest" \
-  --token_addr <TOKEN_ID>
+  --category "Programming" \
+  --tags '[]' \
+  --token_addr <TOKEN_ID> \
+  --visibility '{"tag":"Public","values":null}'
 ```
 
 Save output as `QUEST_NUMERIC_ID` (usually `0` for first quest).
 
-### 6.3 Create milestone
+### 6.3 Initialize milestone and create a milestone
+
+`milestone.initialize` records the `quest` and `certificate` contract
+addresses it will look up during verification, so both must already be
+deployed:
 
 ```bash
+stellar contract invoke \
+  --id <MILESTONE_ID> \
+  --source-account lernza-deployer \
+  --network testnet \
+  -- initialize \
+  --admin lernza-deployer \
+  --quest_contract <QUEST_ID> \
+  --certificate_contract <CERTIFICATE_ID>
+
 stellar contract invoke \
   --id <MILESTONE_ID> \
   --source-account lernza-deployer \
@@ -181,10 +245,54 @@ stellar contract invoke \
   --quest_id <QUEST_NUMERIC_ID> \
   --title "First Milestone" \
   --description "Run deployment smoke test" \
-  --reward_amount 1000
+  --reward_amount 1000 \
+  --requires_previous false
 ```
 
 Save output as `MILESTONE_NUMERIC_ID` (usually `0` for first milestone in that quest).
+
+### 6.4 Initialize and fund rewards
+
+`rewards.initialize` records the token and the `quest`/`milestone` addresses:
+
+```bash
+stellar contract invoke \
+  --id <REWARDS_ID> \
+  --source-account lernza-deployer \
+  --network testnet \
+  -- initialize \
+  --admin lernza-deployer \
+  --token_addr <TOKEN_ID> \
+  --quest_contract_addr <QUEST_ID> \
+  --milestone_contract_addr <MILESTONE_ID>
+
+stellar contract invoke \
+  --id <REWARDS_ID> \
+  --source-account lernza-deployer \
+  --network testnet \
+  -- fund_quest \
+  --funder lernza-deployer \
+  --quest_id <QUEST_NUMERIC_ID> \
+  --amount 10000
+```
+
+### 6.5 Mint a completion certificate
+
+Once a milestone/quest is verified as complete for a learner (see [testnet-tutorial.md](testnet-tutorial.md) for the full enroll-and-submit flow):
+
+```bash
+stellar contract invoke \
+  --id <CERTIFICATE_ID> \
+  --source-account lernza-deployer \
+  --network testnet \
+  -- mint_quest_certificate \
+  --quest_id <QUEST_NUMERIC_ID> \
+  --quest_name "Lernza Test Quest" \
+  --quest_category "Programming" \
+  --recipient <LEARNER_ADDRESS>
+```
+
+Runnable versions of steps 6.2–6.5 (plus enrollment) are provided as example scripts in [scripts/examples/](../scripts/examples/) — see [testnet-tutorial.md](testnet-tutorial.md).
 
 ## 7. Verification Commands
 
@@ -263,4 +371,28 @@ A deployment run was executed on **2026-03-24** with:
 - `TOKEN_ID=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` (native XLM SAC used for testing)
 
 Treat these as historical proof of process, not reusable deployment targets for your environment.
+
+## 10. Contract Addresses & Network Configuration
+
+Deployed contract IDs are not hardcoded in the frontend. They are centralized per-environment in `config/*.yaml` and turned into `.env` files by `scripts/load-config.mjs` (see [config/README.md](../config/README.md)):
+
+| File | Environment | Stellar Network |
+|---|---|---|
+| `config/development.yaml` | Local dev | Standalone |
+| `config/staging.yaml` | Pre-production | Testnet |
+| `config/production.yaml` | Live | Mainnet |
+
+After deploying, update the `contracts:` block of the relevant config file with the new contract IDs (`quest`, `milestone`, `rewards`, `rewards_token`/`usdc_token`), then regenerate the frontend env file:
+
+```bash
+node scripts/load-config.mjs testnet > frontend/.env.local
+```
+
+The `certificate` contract is deployed independently (Section 5.4) and is not yet part of the generated frontend bindings pipeline described in [CONTRIBUTING.md](../CONTRIBUTING.md#generating-typescript-contract-bindings) — record its ID alongside the others in your own notes or an additional config key until frontend wiring lands.
+
+Switching networks locally (testnet/mainnet/standalone) is also available via:
+
+```bash
+./scripts/switch-network.sh testnet
+```
 

--- a/docs/testnet-tutorial.md
+++ b/docs/testnet-tutorial.md
@@ -1,0 +1,121 @@
+# Testnet Interaction Tutorial
+
+A hands-on walkthrough for interacting with already-deployed Lernza contracts
+on Stellar testnet: create a quest, enroll a learner, submit and verify a
+milestone, and mint a completion certificate. For the deployment steps
+themselves (building WASM, `stellar contract deploy`, initialization calls),
+see [deploy-testnet.md](deploy-testnet.md) — this tutorial assumes deployment
+is already done.
+
+## 1. Prerequisites
+
+- Contracts deployed and initialized per [deploy-testnet.md](deploy-testnet.md) Sections 5-6
+- A funded Stellar CLI identity for the quest owner (default: `lernza-deployer`; see Section 1.1 of that guide for faucet/account setup)
+- The deployed contract IDs from your run:
+
+```bash
+export NETWORK=testnet
+export QUEST_ID=<quest contract id>
+export MILESTONE_ID=<milestone contract id>
+export REWARDS_ID=<rewards contract id>
+export CERTIFICATE_ID=<certificate contract id>
+export TOKEN_ID=<reward token / SAC contract id>
+export SOURCE_ACCOUNT=lernza-deployer
+```
+
+Contract IDs for the current environment also live in `config/*.yaml` — see
+[Contract Addresses & Network Configuration](deploy-testnet.md#10-contract-addresses--network-configuration).
+
+## 2. Create a learner identity
+
+A learner needs their own funded Stellar account to sign enrollment and
+submission transactions:
+
+```bash
+stellar keys generate lernza-learner --network testnet --fund
+export LEARNER=$(stellar keys address lernza-learner)
+```
+
+## 3. Create a quest
+
+```bash
+./scripts/examples/create-quest.sh
+```
+
+Read the `create_quest` return value from the output and export it:
+
+```bash
+export QUEST_NUMERIC_ID=0   # replace with the actual returned id
+```
+
+## 4. Enroll the learner
+
+```bash
+./scripts/examples/enroll-learner.sh
+```
+
+This calls `add_enrollee` as the quest owner. A learner can alternatively
+self-enroll into a public quest with `join_quest`, or redeem an invite code
+with `join_quest_with_invite` for a private quest (see
+[enrollment-flow.md](enrollment-flow.md)).
+
+## 5. Fund the quest's reward pool
+
+```bash
+export FUND_AMOUNT=10000
+./scripts/examples/fund-quest.sh
+```
+
+This requires `rewards.initialize` to have already been called with the
+`quest`/`milestone` contract addresses (Section 6.4 of the deployment guide).
+
+## 6. Create, submit, verify, and reward a milestone
+
+```bash
+export REWARD_AMOUNT=1000
+./scripts/examples/submit-milestone.sh
+```
+
+This single script performs the full milestone lifecycle:
+1. `create_milestone` — the owner defines the milestone and its reward
+2. `submit_for_review` — the learner submits their completion
+3. `verify_completion` — the owner (or, in peer-review mode, other enrollees) verifies it
+4. `distribute_reward` — the rewards contract pays the learner from the funded pool
+
+See [milestone-reward-flow.md](milestone-reward-flow.md) for the full state
+machine, including peer-review and competitive-distribution modes not
+covered by this basic tutorial.
+
+## 7. Mint a completion certificate
+
+Once a milestone is verified, mint the learner a certificate:
+
+```bash
+stellar contract invoke \
+  --id "$CERTIFICATE_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- mint_quest_certificate \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --quest_name "Lernza Example Quest" \
+  --quest_category "Programming" \
+  --recipient "$LEARNER"
+```
+
+Confirm it exists:
+
+```bash
+stellar contract invoke \
+  --id "$CERTIFICATE_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- get_user_certificates \
+  --user "$LEARNER"
+```
+
+## 8. Where to go next
+
+- [deploy-testnet.md](deploy-testnet.md) — deployment mechanics, troubleshooting, and contract address/config management
+- [CONTRACT_INTERFACES.md](CONTRACT_INTERFACES.md) — full function reference for every contract
+- [EVENT_REFERENCE.md](EVENT_REFERENCE.md) / [events-reference.md](events-reference.md) — events emitted by each call in this tutorial, useful when building an indexer or UI
+- [GAS_COSTS.md](GAS_COSTS.md) — expected fees for each call above

--- a/scripts/examples/README.md
+++ b/scripts/examples/README.md
@@ -1,0 +1,46 @@
+# Testnet Interaction Examples
+
+Small, focused scripts that each perform one common on-chain operation against
+already-deployed Lernza contracts. They complement the full walkthrough in
+[docs/testnet-tutorial.md](../../docs/testnet-tutorial.md) and the deployment
+runbook in [docs/deploy-testnet.md](../../docs/deploy-testnet.md).
+
+Each script is a thin wrapper around `stellar contract invoke` — read it
+before running it so you understand exactly what it submits.
+
+## Prerequisites
+
+- Contracts already deployed (see [docs/deploy-testnet.md](../../docs/deploy-testnet.md))
+- Stellar CLI installed and a funded identity available (default: `lernza-deployer`)
+- The following environment variables exported (or edit the defaults at the
+  top of each script):
+
+```bash
+export NETWORK=testnet
+export QUEST_ID=<deployed quest contract id>
+export MILESTONE_ID=<deployed milestone contract id>
+export REWARDS_ID=<deployed rewards contract id>
+export TOKEN_ID=<reward token / SAC contract id>
+export SOURCE_ACCOUNT=lernza-deployer
+```
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `create-quest.sh` | Create a new quest and print its numeric ID |
+| `enroll-learner.sh` | Enroll a learner address into a quest |
+| `fund-quest.sh` | Initialize (if needed) and fund the reward pool for a quest |
+| `submit-milestone.sh` | Create a milestone and submit/verify it for a learner |
+
+## Usage
+
+```bash
+./scripts/examples/create-quest.sh
+QUEST_NUMERIC_ID=0 ./scripts/examples/fund-quest.sh
+LEARNER=<learner-address> QUEST_NUMERIC_ID=0 ./scripts/examples/enroll-learner.sh
+QUEST_NUMERIC_ID=0 LEARNER=<learner-address> ./scripts/examples/submit-milestone.sh
+```
+
+All scripts print the raw `stellar contract invoke` output so you can extract
+IDs for the next step.

--- a/scripts/examples/create-quest.sh
+++ b/scripts/examples/create-quest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Create a quest on the quest contract and print the resulting numeric ID.
+# See docs/testnet-tutorial.md and docs/deploy-testnet.md for context.
+set -eo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE_ACCOUNT="${SOURCE_ACCOUNT:-lernza-deployer}"
+QUEST_ID="${QUEST_ID:?Set QUEST_ID to the deployed quest contract id}"
+TOKEN_ID="${TOKEN_ID:?Set TOKEN_ID to the reward token/SAC contract id}"
+QUEST_NAME="${QUEST_NAME:-Lernza Example Quest}"
+QUEST_DESCRIPTION="${QUEST_DESCRIPTION:-Created by scripts/examples/create-quest.sh}"
+QUEST_CATEGORY="${QUEST_CATEGORY:-Programming}"
+
+echo "Creating quest \"$QUEST_NAME\" on $NETWORK..."
+
+stellar contract invoke \
+  --id "$QUEST_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_quest \
+  --owner "$SOURCE_ACCOUNT" \
+  --name "$QUEST_NAME" \
+  --description "$QUEST_DESCRIPTION" \
+  --category "$QUEST_CATEGORY" \
+  --tags '[]' \
+  --token_addr "$TOKEN_ID" \
+  --visibility '{"tag":"Public","values":null}'

--- a/scripts/examples/enroll-learner.sh
+++ b/scripts/examples/enroll-learner.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Enroll a learner into an existing quest as its owner.
+# See docs/testnet-tutorial.md for context.
+set -eo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE_ACCOUNT="${SOURCE_ACCOUNT:-lernza-deployer}"
+QUEST_ID="${QUEST_ID:?Set QUEST_ID to the deployed quest contract id}"
+QUEST_NUMERIC_ID="${QUEST_NUMERIC_ID:?Set QUEST_NUMERIC_ID to the numeric quest id returned by create-quest.sh}"
+LEARNER="${LEARNER:?Set LEARNER to the learner address to enroll}"
+
+echo "Enrolling $LEARNER into quest #$QUEST_NUMERIC_ID on $NETWORK..."
+
+stellar contract invoke \
+  --id "$QUEST_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- add_enrollee \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --enrollee "$LEARNER"

--- a/scripts/examples/fund-quest.sh
+++ b/scripts/examples/fund-quest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fund the reward pool for a quest. Assumes rewards.initialize has already
+# been run (see docs/deploy-testnet.md Section 6.4).
+# See docs/testnet-tutorial.md for context.
+set -eo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE_ACCOUNT="${SOURCE_ACCOUNT:-lernza-deployer}"
+REWARDS_ID="${REWARDS_ID:?Set REWARDS_ID to the deployed rewards contract id}"
+QUEST_NUMERIC_ID="${QUEST_NUMERIC_ID:?Set QUEST_NUMERIC_ID to the numeric quest id to fund}"
+FUND_AMOUNT="${FUND_AMOUNT:-10000}"
+
+echo "Funding quest #$QUEST_NUMERIC_ID with $FUND_AMOUNT (raw token units) on $NETWORK..."
+
+stellar contract invoke \
+  --id "$REWARDS_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- fund_quest \
+  --funder "$SOURCE_ACCOUNT" \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --amount "$FUND_AMOUNT"

--- a/scripts/examples/submit-milestone.sh
+++ b/scripts/examples/submit-milestone.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Create a milestone, have a learner submit it for review, verify it as the
+# quest owner, and distribute the reward. Assumes milestone.initialize and
+# rewards.initialize have already been run (see docs/deploy-testnet.md
+# Sections 6.3-6.4) and the learner is already enrolled (enroll-learner.sh).
+#
+# See docs/testnet-tutorial.md for context.
+set -eo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE_ACCOUNT="${SOURCE_ACCOUNT:-lernza-deployer}"
+MILESTONE_ID="${MILESTONE_ID:?Set MILESTONE_ID to the deployed milestone contract id}"
+REWARDS_ID="${REWARDS_ID:?Set REWARDS_ID to the deployed rewards contract id}"
+QUEST_NUMERIC_ID="${QUEST_NUMERIC_ID:?Set QUEST_NUMERIC_ID to the numeric quest id}"
+LEARNER="${LEARNER:?Set LEARNER to the enrolled learner address}"
+MILESTONE_TITLE="${MILESTONE_TITLE:-Example Milestone}"
+MILESTONE_DESCRIPTION="${MILESTONE_DESCRIPTION:-Created by scripts/examples/submit-milestone.sh}"
+REWARD_AMOUNT="${REWARD_AMOUNT:-1000}"
+
+echo "Creating milestone \"$MILESTONE_TITLE\" for quest #$QUEST_NUMERIC_ID..."
+CREATE_OUTPUT=$(stellar contract invoke \
+  --id "$MILESTONE_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_milestone \
+  --owner "$SOURCE_ACCOUNT" \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --title "$MILESTONE_TITLE" \
+  --description "$MILESTONE_DESCRIPTION" \
+  --reward_amount "$REWARD_AMOUNT" \
+  --requires_previous false)
+echo "$CREATE_OUTPUT"
+MILESTONE_NUMERIC_ID="${MILESTONE_NUMERIC_ID:-$CREATE_OUTPUT}"
+
+echo "Learner $LEARNER submitting milestone #$MILESTONE_NUMERIC_ID for review..."
+stellar contract invoke \
+  --id "$MILESTONE_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- submit_for_review \
+  --enrollee "$LEARNER" \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --milestone_id "$MILESTONE_NUMERIC_ID"
+
+echo "Owner verifying completion..."
+stellar contract invoke \
+  --id "$MILESTONE_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- verify_completion \
+  --owner "$SOURCE_ACCOUNT" \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --milestone_id "$MILESTONE_NUMERIC_ID" \
+  --enrollee "$LEARNER"
+
+echo "Distributing reward..."
+stellar contract invoke \
+  --id "$REWARDS_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- distribute_reward \
+  --caller "$SOURCE_ACCOUNT" \
+  --quest_id "$QUEST_NUMERIC_ID" \
+  --milestone_id "$MILESTONE_NUMERIC_ID" \
+  --enrollee "$LEARNER" \
+  --amount "$REWARD_AMOUNT"


### PR DESCRIPTION
## Summary

This PR bundles four related contract/docs improvements from the current issue backlog:

1. **#1273** — `certificate.set_metadata_base` accepted any string, including empty or malformed values, silently breaking metadata resolution for every certificate holder.
2. **#1326** — Quest invites could report as valid past a quest's deadline (or after archive/cancel), even though redemption was already blocked — a stale/misleading query surface for owners and frontends.
3. **#1416** — There was no way to estimate storage rent before creating a quest, and no way for an owner to top up a quest's TTL directly.
4. **#1418** — There was no end-to-end testnet tutorial or runnable example scripts, and the deployment guide was missing the certificate contract and had an inconsistent initialization order.

## Changes

### #1273 — Certificate metadata URI validation
- `certificate::set_metadata_base` now validates the URI with `common::is_valid_url` before storing it, returning `Error::InvalidInput` for empty, whitespace-containing, or scheme-less strings. A rejected call leaves the previously stored URI untouched.
- Extended `common::is_valid_url` to also accept `ipfs://` (in addition to `http://`/`https://`), matching how certificate metadata is commonly hosted.
- Added regression tests: empty string, malformed string, whitespace, `ipfs://` acceptance, and "rejected update doesn't overwrite existing value".

### #1326 — Invite expiry after quest deadline
- `join_quest_with_invite` already rejected redemption past the deadline, but `is_invite_valid` (the read-only check owners/frontends use to decide whether an invite is still usable) did not account for the deadline or archived/cancelled status, so it could report a dead invite as valid.
- `is_invite_valid` now returns `false` once the quest is archived, cancelled, or past its deadline.
- `register_invite` now rejects registering *new* invites once the quest's deadline has passed.
- Added regression tests covering both cases.

### #1416 — Storage cost estimation & TTL management
- Added `common::estimate_persistent_rent(entry_size_bytes)` — a documented, clearly-labeled planning heuristic (not a network oracle) for the rent cost of keeping a persistent entry alive for one `BUMP` (~30 day) TTL cycle.
- Added `quest::estimate_quest_creation_rent(name_len, description_len, category_len, tag_count)` so a frontend can show an approximate rent estimate before a user commits to `create_quest`.
- Added `quest::extend_quest_ttl(quest_id, owner)` — an owner-only call that refreshes a quest's TTL (quest, enrollees, version history) without requiring an unrelated state change.
- Reviewed the existing `BUMP`/`THRESHOLD` (30d/7d) values against ADR-005 and left them unchanged — they already sit within Soroban's recommended TTL headroom band; the new estimation helpers are meant to make the existing costs legible rather than change the policy itself.

### #1418 — Deployment guide & testnet tutorial
- `docs/deploy-testnet.md`: added the `certificate` contract to the build/deploy steps, added a testnet faucet/account-setup subsection, corrected the initialization order to `quest → milestone → rewards → certificate` (matching the actual cross-contract address dependencies — `milestone.initialize` needs the `certificate` address, `rewards.initialize` needs both `quest` and `milestone`), and documented how contract addresses map to `config/*.yaml` + `scripts/load-config.mjs`.
- New `docs/testnet-tutorial.md`: a guided walkthrough — create a quest, create a learner identity, enroll, fund the reward pool, submit/verify/reward a milestone, and mint a completion certificate.
- New `scripts/examples/`: runnable `stellar contract invoke` wrapper scripts (`create-quest.sh`, `enroll-learner.sh`, `fund-quest.sh`, `submit-milestone.sh`) for the operations covered in the tutorial, plus a README describing required environment variables.

## Testing

- Added unit tests for all contract-level behavior changes in `contracts/certificate/src/test.rs` and `contracts/quest/src/test.rs`.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets` should be run by CI; changes follow existing storage/error/event patterns in the codebase (Result<T, Error> returns, `common::extend_persistent_ttl`, `only_owner`/`require_auth`, event publishing conventions).

## Closes

Closes #1273
Closes #1326
Closes #1416
Closes #1418
