### PR TITLE
feat: add creator quest workflow

### DIFF
--- a/frontend/src/lib/contracts/quest.interaction.test.ts
+++ b/frontend/src/lib/contracts/quest.interaction.test.ts
@@ -158,6 +158,7 @@ describe("QuestClient contract interactions (#1216)", () => {
           TOKEN,
           0,
           25,
+          null,
         ],
       })
       expect(mocks.prepareTransaction).toHaveBeenCalledTimes(1)
@@ -172,6 +173,7 @@ describe("QuestClient contract interactions (#1216)", () => {
       expect(method).toBe("create_quest")
       expect(args[6]).toBe(1) // Visibility.Private
       expect(args[7]).toBeNull()
+      expect(args[8]).toBeNull()
     })
 
     it("updateQuest sends null for every omitted optional field", async () => {

--- a/frontend/src/lib/contracts/quest.ts
+++ b/frontend/src/lib/contracts/quest.ts
@@ -197,7 +197,8 @@ export class QuestClient {
     tags: string[],
     tokenAddr: string,
     visibility: Visibility,
-    maxEnrollees?: number
+    maxEnrollees?: number,
+    deadline?: number
   ) {
     return safeContractCall(async () => {
       const tx = await this.buildTx(owner, "create_quest", [
@@ -211,6 +212,7 @@ export class QuestClient {
         maxEnrollees !== undefined
           ? nativeToScVal(maxEnrollees, { type: "u32" })
           : nativeToScVal(null),
+        deadline !== undefined ? nativeToScVal(deadline, { type: "u64" }) : nativeToScVal(null),
       ])
       return signAndSubmit(tx)
     })

--- a/frontend/src/pages/create-quest/context.tsx
+++ b/frontend/src/pages/create-quest/context.tsx
@@ -10,6 +10,7 @@ interface QuestCreationContextType {
   goToNext: () => void
   goToBack: () => void
   setCurrentStep: (step: FormStep) => void
+  loadDraft: (step1: Step1Values, step2: Step2Values, currentStep: FormStep) => void
 }
 
 const QuestCreationContext = createContext<QuestCreationContextType | undefined>(undefined)
@@ -22,7 +23,7 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
     tags: [],
   })
   const [step2Data, setStep2Data] = useState<Step2Values>({
-    milestones: [{ title: "", description: "", rewardAmount: 0 }],
+    milestones: [{ title: "", description: "", rewardAmount: 0, prerequisiteIds: [] }],
   })
   const [currentStep, setCurrentStep] = useState<FormStep>(1)
 
@@ -35,6 +36,11 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
     setCurrentStep(prev => (prev - 1) as FormStep)
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [])
+  const loadDraft = useCallback((step1: Step1Values, step2: Step2Values, step: FormStep) => {
+    setStep1Data(step1)
+    setStep2Data(step2)
+    setCurrentStep(step)
+  }, [])
 
   const value = {
     step1Data,
@@ -45,6 +51,7 @@ export function QuestCreationProvider({ children }: { children: ReactNode }) {
     goToNext,
     goToBack,
     setCurrentStep,
+    loadDraft,
   }
 
   return <QuestCreationContext.Provider value={value}>{children}</QuestCreationContext.Provider>

--- a/frontend/src/pages/create-quest/drafts.ts
+++ b/frontend/src/pages/create-quest/drafts.ts
@@ -1,0 +1,18 @@
+import type { Step1Values, Step2Values, FormStep } from "./types"
+
+const STORAGE_KEY = "lernza.quest-drafts.v1"
+export interface QuestDraft { id: string; updatedAt: number; step1: Step1Values; step2: Step2Values; currentStep: FormStep }
+
+function read(): QuestDraft[] {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]") as QuestDraft[] } catch { return [] }
+}
+function write(drafts: QuestDraft[]) { localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts)) }
+export const questDrafts = {
+  list: () => read().sort((a, b) => b.updatedAt - a.updatedAt),
+  save: (draft: Omit<QuestDraft, "updatedAt">) => {
+    const next = { ...draft, updatedAt: Date.now() }
+    write([next, ...read().filter(item => item.id !== draft.id)])
+    return next
+  },
+  remove: (id: string) => write(read().filter(draft => draft.id !== id)),
+}

--- a/frontend/src/pages/create-quest/index.tsx
+++ b/frontend/src/pages/create-quest/index.tsx
@@ -1,9 +1,11 @@
-import { Suspense, lazy } from "react"
-import { ArrowLeft, Wallet } from "lucide-react"
+import { Suspense, lazy, useState } from "react"
+import { ArrowLeft, Wallet, Bookmark, LayoutTemplate, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useWallet } from "@/hooks/use-wallet"
 import { QuestCreationProvider, useQuestCreation } from "./context"
 import { StepIndicator } from "./types"
+import { QUEST_TEMPLATES } from "./templates"
+import { questDrafts } from "./drafts"
 
 const Step1Form = lazy(() => import("./step1").then(m => ({ default: m.Step1Form })))
 const Step2Form = lazy(() => import("./step2").then(m => ({ default: m.Step2Form })))
@@ -18,7 +20,15 @@ interface CreateQuestProps {
 }
 
 function CreateQuestContent({ onBack }: CreateQuestProps) {
-  const { currentStep } = useQuestCreation()
+  const { currentStep, step1Data, step2Data, loadDraft } = useQuestCreation()
+  const [showLibrary, setShowLibrary] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const saveDraft = () => {
+    const id = `${Date.now()}`
+    questDrafts.save({ id, step1: step1Data, step2: step2Data, currentStep })
+    setNotice("Draft saved on this device. You can reopen it from Drafts.")
+  }
 
   return (
     <div className="relative mx-auto max-w-2xl px-4 py-8 sm:px-6">
@@ -42,6 +52,30 @@ function CreateQuestContent({ onBack }: CreateQuestProps) {
           Set up milestones and fund the reward pool to incentivize learners.
         </p>
       </div>
+
+      <div className="relative mb-6 flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" onClick={() => setShowLibrary(value => !value)}>
+          <LayoutTemplate className="h-4 w-4" /> Templates
+        </Button>
+        <Button variant="outline" size="sm" onClick={saveDraft}>
+          <Bookmark className="h-4 w-4" /> Save draft
+        </Button>
+        {notice && <span className="text-muted-foreground self-center text-xs font-semibold">{notice}</span>}
+      </div>
+
+      {showLibrary && (
+        <div className="border-border bg-background relative mb-6 border p-4 shadow-md">
+          <button aria-label="Close template and draft library" onClick={() => setShowLibrary(false)} className="absolute right-3 top-3"><X className="h-4 w-4" /></button>
+          <p className="mb-3 text-xs font-bold uppercase text-muted-foreground">Start from a template</p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {QUEST_TEMPLATES.map(template => <button key={template.id} type="button" onClick={() => { loadDraft(template.step1, template.step2, 1); setShowLibrary(false); setNotice(`${template.name} loaded — customize it before publishing.`) }} className="border-border hover:bg-secondary border p-3 text-left">
+              <span className="block text-sm font-semibold">{template.name}</span><span className="text-muted-foreground text-xs">{template.description}</span>
+            </button>)}
+          </div>
+          <p className="mb-2 mt-5 text-xs font-bold uppercase text-muted-foreground">Saved drafts</p>
+          {questDrafts.list().length ? <div className="space-y-2">{questDrafts.list().map(draft => <div key={draft.id} className="border-border flex items-center justify-between border p-2"><span className="text-sm font-semibold">{draft.step1.name || "Untitled quest"}</span><div className="flex gap-2"><button className="text-xs font-bold underline" onClick={() => { loadDraft(draft.step1, draft.step2, draft.currentStep); setShowLibrary(false) }}>Open</button><button className="text-destructive text-xs font-bold underline" onClick={() => { questDrafts.remove(draft.id); setShowLibrary(false); setShowLibrary(true) }}>Delete</button></div></div>)}</div> : <p className="text-muted-foreground text-sm">No saved drafts yet.</p>}
+        </div>
+      )}
 
       {/* Step indicator */}
       <div className="animate-fade-in-up stagger-1 relative">

--- a/frontend/src/pages/create-quest/step1.tsx
+++ b/frontend/src/pages/create-quest/step1.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from "react"
+import { useEffect, useState, type KeyboardEvent } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ArrowRight, FileText, Plus, X } from "lucide-react"
@@ -34,6 +34,14 @@ export function Step1Form() {
   const descValue = watch("description", "")
   const categoryValue = watch("category", "")
   const tagsValue = watch("tags", [])
+
+  // Keep incomplete input in the creation context so "Save draft" works before a step is valid.
+  useEffect(() => {
+    const subscription = watch(value => setStep1Data({
+      name: value.name ?? "", description: value.description ?? "", category: value.category ?? "", tags: value.tags ?? [],
+    }))
+    return () => subscription.unsubscribe()
+  }, [setStep1Data, watch])
 
   const handleAddTag = () => {
     setTagError(null)

--- a/frontend/src/pages/create-quest/step2.tsx
+++ b/frontend/src/pages/create-quest/step2.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useForm, useFieldArray } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
@@ -30,6 +30,7 @@ export function Step2Form() {
     control,
     handleSubmit,
     watch,
+    setValue,
     formState: { errors, isValid },
   } = useForm<Step2Values>({
     resolver: zodResolver(step2Schema),
@@ -44,13 +45,19 @@ export function Step2Form() {
 
   const handleBatchImport = (imported: ParsedMilestone[], mode: "append" | "replace") => {
     if (mode === "replace") {
-      replace(imported)
+      replace(imported.map(item => ({ ...item, prerequisiteIds: [] })))
     } else {
-      append(imported)
+      append(imported.map(item => ({ ...item, prerequisiteIds: [] })))
     }
   }
 
   const milestones = watch("milestones")
+  useEffect(() => {
+    const subscription = watch(value => setStep2Data({
+      milestones: (value.milestones ?? []).map(milestone => ({ ...milestone, prerequisiteIds: milestone.prerequisiteIds ?? [] })),
+    }))
+    return () => subscription.unsubscribe()
+  }, [setStep2Data, watch])
   const totalReward = milestones.reduce((sum: number, m: z.infer<typeof milestoneSchema>) => {
     const n = Number(m.rewardAmount)
     return sum + (isNaN(n) ? 0 : n)
@@ -90,6 +97,7 @@ export function Step2Form() {
             {fields.map((field, index) => {
               const titleVal = milestones?.[index]?.title || ""
               const descVal = milestones?.[index]?.description || ""
+              const prerequisiteIds = milestones?.[index]?.prerequisiteIds || []
 
               return (
                 <div key={field.id} className="space-y-4 p-5">
@@ -247,6 +255,23 @@ export function Step2Form() {
                       message={errors.milestones?.[index]?.rewardAmount?.message}
                     />
                   </div>
+
+                  <div>
+                    <FormLabel>Prerequisites</FormLabel>
+                    <p className="text-muted-foreground mb-2 text-xs">Require the immediately preceding milestone to be verified before this work unlocks.</p>
+                    <div className="flex flex-wrap gap-2">
+                      {fields.slice(Math.max(index - 1, 0), index).map((_, offset) => {
+                        const prerequisiteIndex = index - 1 + offset
+                        return <label key={prerequisiteIndex} className="border-border flex cursor-pointer items-center gap-1.5 border px-2 py-1 text-xs font-semibold">
+                          <input type="checkbox" checked={prerequisiteIds.includes(prerequisiteIndex)} onChange={() => {
+                            const next = prerequisiteIds.includes(prerequisiteIndex) ? [] : [prerequisiteIndex]
+                            setValue(`milestones.${index}.prerequisiteIds`, next, { shouldDirty: true, shouldValidate: true })
+                          }} /> Step {prerequisiteIndex + 1}
+                        </label>
+                      })}
+                      {index === 0 && <span className="text-muted-foreground text-xs">First milestone is immediately available.</span>}
+                    </div>
+                  </div>
                 </div>
               )
             })}
@@ -256,7 +281,7 @@ export function Step2Form() {
           <div className="border-border border-t p-5 grid grid-cols-1 sm:grid-cols-2 gap-3">
             <button
               type="button"
-              onClick={() => append({ title: "", description: "", rewardAmount: 0 })}
+              onClick={() => append({ title: "", description: "", rewardAmount: 0, prerequisiteIds: [] })}
               className="border-border hover:bg-secondary flex w-full cursor-pointer items-center justify-center gap-2 border border-dashed py-3 text-sm font-semibold transition-colors"
             >
               <Plus className="h-4 w-4" />

--- a/frontend/src/pages/create-quest/step3.tsx
+++ b/frontend/src/pages/create-quest/step3.tsx
@@ -67,7 +67,7 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
         step1Data.category,
         step1Data.tags || [],
         tokenAddr,
-        Visibility.Public
+        Visibility.Unlisted
       )
 
       if (result.status === "FAILED") {
@@ -101,7 +101,7 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
           m.title,
           m.description,
           rewardAmount,
-          i > 0 // requiresPrevious for all except the first milestone
+          m.prerequisiteIds.length > 0
         )
       }
 
@@ -119,6 +119,20 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
 
   const handleFinalize = () => {
     onComplete()
+  }
+
+  const handlePublish = async () => {
+    if (!address || createdQuestId === null) return
+    setTxPhase("creating")
+    setTxError(null)
+    try {
+      const result = await questClient.updateQuest(address, createdQuestId, undefined, undefined, undefined, undefined, Visibility.Public)
+      if (result.status === "FAILED") throw new Error(result.error || "Publishing failed")
+      setTxPhase("done")
+    } catch (err: unknown) {
+      setTxError(err instanceof Error ? err.message : "Publishing failed")
+      setTxPhase("funded")
+    }
   }
 
   const isBusy = txPhase === "creating" || txPhase === "funding"
@@ -178,6 +192,7 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
                     <div>
                       <p className="text-sm font-semibold">{m.title}</p>
                       <p className="text-muted-foreground mt-0.5 text-xs">{m.description}</p>
+                      {m.prerequisiteIds.length > 0 && <p className="text-muted-foreground mt-1 text-xs font-semibold">Requires: {m.prerequisiteIds.map(id => `Step ${id + 1}`).join(", ")}</p>}
                     </div>
                   </div>
                   <Badge variant="default" className="flex-shrink-0 tabular-nums">
@@ -233,7 +248,7 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
               ) : txPhase === "created" || txPhase === "funded" || txPhase === "done" ? (
                 <>
                   <Check className="h-4 w-4" />
-                  Quest created
+                  Quest saved as private setup
                 </>
               ) : (
                 <>
@@ -275,16 +290,18 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
               )}
             </Button>
 
-            {/* Finalize button */}
+            {/* Publish button */}
             {txPhase === "funded" && (
               <Button
-                onClick={handleFinalize}
+                onClick={handlePublish}
                 className="shimmer-on-hover w-full"
               >
                 <Sparkles className="h-4 w-4" />
-                Finalize & Return to Dashboard
+                Publish Quest
               </Button>
             )}
+
+            {txPhase === "done" && <Button onClick={handleFinalize} className="shimmer-on-hover w-full"><Check className="h-4 w-4" />Return to Dashboard</Button>}
 
             {txPhase === "idle" && !txError && (
               <p className="text-muted-foreground mt-2 text-center text-xs font-bold">
@@ -298,9 +315,10 @@ export function Step3Review({ onComplete }: Step3ReviewProps) {
             )}
             {txPhase === "funded" && (
               <p className="text-muted-foreground mt-2 text-center text-xs font-bold">
-                Pool funded! Your quest is live with on-chain rewards.
+                Pool funded. Publish when you are ready to make the quest discoverable.
               </p>
             )}
+            {txPhase === "done" && <p className="text-muted-foreground mt-2 text-center text-xs font-bold">Quest published with a funded reward pool.</p>}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/create-quest/templates.ts
+++ b/frontend/src/pages/create-quest/templates.ts
@@ -1,0 +1,64 @@
+import type { Step1Values, Step2Values } from "./types"
+
+export interface QuestTemplate {
+  id: "onboarding" | "api-development" | "smart-contract-development" | "frontend-fundamentals"
+  name: string
+  description: string
+  step1: Step1Values
+  step2: Step2Values
+}
+
+const milestone = (title: string, description: string, rewardAmount: number, prerequisiteIds: number[] = []) => ({
+  title,
+  description,
+  rewardAmount,
+  prerequisiteIds,
+})
+
+/** Starter paths are deliberately ordinary form data: creators can edit every field before publishing. */
+export const QUEST_TEMPLATES: QuestTemplate[] = [
+  {
+    id: "onboarding",
+    name: "Team onboarding",
+    description: "A welcoming, structured path for new contributors.",
+    step1: { name: "Contributor Onboarding", description: "Help new contributors become confident and productive.", category: "Onboarding", tags: ["team", "getting-started"] },
+    step2: { milestones: [
+      milestone("Meet the team", "Review the team guide and introduce yourself.", 25),
+      milestone("Set up your workspace", "Install the required tools and verify your access.", 50, [0]),
+      milestone("Ship a first contribution", "Complete a small, reviewed contribution.", 100, [1]),
+    ] },
+  },
+  {
+    id: "api-development",
+    name: "API development",
+    description: "From endpoint design through testing and documentation.",
+    step1: { name: "Build a Production API", description: "Design, implement, test, and document a useful API.", category: "Programming", tags: ["api", "backend"] },
+    step2: { milestones: [
+      milestone("Design the API", "Define resources, request and response shapes, and error handling.", 50),
+      milestone("Implement endpoints", "Build the API with validation and authentication.", 100, [0]),
+      milestone("Test and document", "Add integration tests and clear API documentation.", 75, [1]),
+    ] },
+  },
+  {
+    id: "smart-contract-development",
+    name: "Smart-contract development",
+    description: "A safe path from contract design to testnet deployment.",
+    step1: { name: "Smart Contract Fundamentals", description: "Build and validate a secure smart contract.", category: "Web3", tags: ["smart-contracts", "stellar"] },
+    step2: { milestones: [
+      milestone("Model contract state", "Write the contract specification and identify access controls.", 75),
+      milestone("Implement the contract", "Build core methods with defensive validation.", 150, [0]),
+      milestone("Test and deploy", "Add tests and deploy the verified contract to testnet.", 125, [1]),
+    ] },
+  },
+  {
+    id: "frontend-fundamentals",
+    name: "Frontend fundamentals",
+    description: "Build accessible, responsive interfaces step by step.",
+    step1: { name: "Frontend Fundamentals", description: "Turn a design into an accessible, responsive web experience.", category: "Frontend", tags: ["frontend", "web"] },
+    step2: { milestones: [
+      milestone("Build the layout", "Create semantic page structure and responsive layout.", 50),
+      milestone("Add interactions", "Implement the essential user flows and state handling.", 100, [0]),
+      milestone("Polish accessibility", "Test keyboard navigation, labels, and mobile presentation.", 75, [1]),
+    ] },
+  },
+]

--- a/frontend/src/pages/create-quest/types.tsx
+++ b/frontend/src/pages/create-quest/types.tsx
@@ -71,6 +71,7 @@ export const milestoneSchema = z.object({
     .number({ message: "Reward amount is required" })
     .positive("Reward must be greater than 0")
     .max(MAX_REWARD_AMOUNT, `Reward max ${formatTokens(MAX_REWARD_AMOUNT)} tokens`),
+  prerequisiteIds: z.array(z.number().int().nonnegative()).default([]),
 })
 
 export const step2Schema = z.object({

--- a/frontend/src/pages/creator-dashboard.tsx
+++ b/frontend/src/pages/creator-dashboard.tsx
@@ -40,20 +40,24 @@ export function CreatorDashboard() {
             enrollees.map(enrollee => milestoneClient.getEnrolleeCompletions(quest.id, enrollee))
           )
           const totalCompletions = completionCounts.reduce((sum, count) => sum + count, 0)
+          const stalledLearners = completionCounts.filter(count => count === 0).length
+          const pendingReviews = enrollees.reduce(
+            (sum, _, index) => sum + Math.max(milestones.length - completionCounts[index], 0),
+            0
+          )
 
           // Estimate distributed amount based on milestone rewards
-          const totalMilestoneRewards = milestones.reduce(
-            (sum, m) => sum + BigInt(m.rewardAmount || 0),
-            0n
-          )
-          const estimatedDistributed =
-            totalMilestoneRewards > poolBalance ? totalMilestoneRewards - poolBalance : 0n
+          const estimatedDistributed = completionCounts.reduce((sum, completions) =>
+            sum + milestones.slice(0, completions).reduce((earned, milestone) => earned + milestone.rewardAmount, 0n), 0n)
 
           return {
             id: quest.id,
             name: quest.name,
             enrolleeCount: enrollees.length,
             completionCount: totalCompletions,
+            pendingReviews,
+            stalledLearners,
+            milestoneCount: milestones.length,
             poolBalance,
             totalDistributed: estimatedDistributed,
           }

--- a/frontend/src/pages/dashboard/creator-analytics.tsx
+++ b/frontend/src/pages/dashboard/creator-analytics.tsx
@@ -1,4 +1,4 @@
-import { Users, TrendingUp, Award, DollarSign } from "lucide-react"
+import { Users, TrendingUp, Award, DollarSign, ClipboardCheck, CircleAlert } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { formatTokens } from "@/lib/utils"
@@ -9,6 +9,9 @@ interface CreatorAnalyticsProps {
     name: string
     enrolleeCount: number
     completionCount: number
+    pendingReviews: number
+    stalledLearners: number
+    milestoneCount: number
     poolBalance: bigint
     totalDistributed: bigint
   }>
@@ -19,6 +22,8 @@ export function CreatorAnalytics({ quests }: CreatorAnalyticsProps) {
   const totalCompletions = quests.reduce((sum, q) => sum + q.completionCount, 0)
   const totalDistributed = quests.reduce((sum, q) => sum + q.totalDistributed, 0n)
   const totalPoolBalance = quests.reduce((sum, q) => sum + q.poolBalance, 0n)
+  const pendingReviews = quests.reduce((sum, q) => sum + q.pendingReviews, 0)
+  const stalledLearners = quests.reduce((sum, q) => sum + q.stalledLearners, 0)
 
   const avgCompletionRate =
     totalEnrollees > 0 ? ((totalCompletions / totalEnrollees) * 100).toFixed(1) : "0"
@@ -26,7 +31,7 @@ export function CreatorAnalytics({ quests }: CreatorAnalyticsProps) {
   return (
     <div className="space-y-6">
       {/* Stats Grid */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
         <Card className="animate-fade-in-up stagger-1">
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
@@ -82,6 +87,12 @@ export function CreatorAnalytics({ quests }: CreatorAnalyticsProps) {
             </div>
           </CardContent>
         </Card>
+        <Card>
+          <CardContent className="pt-6"><div className="flex items-center gap-3"><div className="bg-secondary border-border flex h-10 w-10 items-center justify-center border"><ClipboardCheck className="h-5 w-5" /></div><div><p className="text-muted-foreground text-xs font-bold uppercase">To review</p><p className="text-2xl font-semibold">{pendingReviews}</p></div></div></CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6"><div className="flex items-center gap-3"><div className="bg-secondary border-border flex h-10 w-10 items-center justify-center border"><CircleAlert className="h-5 w-5" /></div><div><p className="text-muted-foreground text-xs font-bold uppercase">Stalled learners</p><p className="text-2xl font-semibold">{stalledLearners}</p></div></div></CardContent>
+        </Card>
       </div>
 
       {/* Quest List */}
@@ -109,8 +120,10 @@ export function CreatorAnalytics({ quests }: CreatorAnalyticsProps) {
                         </Badge>
                         <Badge variant="secondary" className="text-xs">
                           <Award className="mr-1 h-3 w-3" />
-                          {quest.completionCount} completed
+                          {quest.completionCount}/{quest.enrolleeCount * quest.milestoneCount} verified
                         </Badge>
+                        <Badge variant={quest.pendingReviews ? "default" : "secondary"} className="text-xs"><ClipboardCheck className="mr-1 h-3 w-3" />{quest.pendingReviews} remaining</Badge>
+                        {quest.stalledLearners > 0 && <Badge variant="destructive" className="text-xs"><CircleAlert className="mr-1 h-3 w-3" />{quest.stalledLearners} stalled</Badge>}
                         <Badge
                           variant={Number(completionRate) >= 50 ? "default" : "secondary"}
                           className="text-xs"


### PR DESCRIPTION
## Summary
- add owner-focused progress metrics for enrollment, verified milestones, payouts, outstanding work, and stalled learners
- support local quest drafts and editable learning-path templates
- add milestone ordering and prerequisite configuration
- keep new quests unlisted until funded and explicitly published

## Validation
- git diff --check
- frontend lint/build could not run because npm ci currently fails on an existing peer-dependency resolution conflict involving @vitejs/plugin-react and Babel 8.

Closes #1457
Closes #1458
Closes #1459
Closes #1460