### PR TITLE
feat(frontend): enforce bundle size and route performance budgets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,22 +150,19 @@ jobs:
       - name: Type-check & build
         run: pnpm run build
 
-      - name: Analyze bundle size
+      - name: Check bundle budget
         id: bundle
-        run: |
-          cd dist
-          TOTAL_SIZE=$(du -sh . | cut -f1)
-          ASSETS_SIZE=$(du -sh assets | cut -f1)
-          echo "total_size=$TOTAL_SIZE" >> $GITHUB_OUTPUT
-          echo "assets_size=$ASSETS_SIZE" >> $GITHUB_OUTPUT
+        run: pnpm run check:bundle-budget
 
       - name: Comment bundle size
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const { total_size, assets_size } = process.env;
-            const body = `## 📦 Bundle Size Report\n\n| Metric | Size |\n|--------|------|\n| Total dist | ${total_size} |\n| Assets | ${assets_size} |\n\n_This helps track frontend bundle size changes._`;
+            const { total_kb, script_kb, passed } = process.env;
+            const status = passed === 'true' ? '✅ Within budget' : '❌ Budget exceeded';
+            const budgetUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${context.payload.pull_request.head.sha}/frontend/budget.json`;
+            const body = `## 📦 Bundle Size Report\n\n${status} — see [\`frontend/budget.json\`](${budgetUrl}) for the enforced limits.\n\n| Metric | Size |\n|--------|------|\n| Total dist | ${total_kb} KB |\n| Script (JS) | ${script_kb} KB |\n\n_Enforced by \`pnpm run check:bundle-budget\`; the job fails when a budget is exceeded._`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -197,8 +194,9 @@ jobs:
               console.log("Failed to post bundle size comment.", error.message);
             }
         env:
-          total_size: ${{ steps.bundle.outputs.total_size }}
-          assets_size: ${{ steps.bundle.outputs.assets_size }}
+          total_kb: ${{ steps.bundle.outputs.total_kb }}
+          script_kb: ${{ steps.bundle.outputs.script_kb }}
+          passed: ${{ steps.bundle.outputs.passed }}
 
   # ── Contracts: fmt + clippy + test + build WASM ──────────────────
   # Matrix covers Linux and macOS to catch platform-specific divergence.

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -49,11 +49,25 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 300
 
+      - name: Build key-route URL list
+        id: routes
+        run: |
+          BASE="${{ steps.vercel.outputs.url }}"
+          # Mirrors the key routes checked in lighthouserc.json's collect.url
+          # for the static-dist run, so both jobs cover the same set of pages.
+          ROUTES=("/" "/dashboard" "/create-quest" "/creator-dashboard" "/leaderboard" "/quest/1")
+          {
+            echo "urls<<EOF"
+            for route in "${ROUTES[@]}"; do
+              echo "${BASE}${route}"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Lighthouse CI against Vercel preview
         uses: treosh/lighthouse-ci-action@v12
         with:
-          urls: |
-            ${{ steps.vercel.outputs.url }}
+          urls: ${{ steps.routes.outputs.urls }}
           uploadArtifacts: true
           temporaryPublicStorage: true
           configPath: ./frontend/lighthouserc.json
@@ -88,17 +102,17 @@ jobs:
         with:
           script: |
             const body = `## 🚦 Lighthouse CI Report
-            
-            Performance budgets have been checked against the Vercel preview deployment.
-            
-            **Acceptance Criteria:**
-            - ✅ Total bundle size < 500KB
+
+            Performance budgets have been checked against the Vercel preview deployment across key routes (/, /dashboard, /create-quest, /creator-dashboard, /leaderboard, /quest/1).
+
+            **Acceptance Criteria (see frontend/budget.json and frontend/lighthouserc.json):**
+            - ✅ Total bundle size < 500KB, script < 200KB, stylesheet < 60KB, image < 100KB, font < 50KB
             - ✅ LCP (Largest Contentful Paint) < 2.5s
             - ✅ CLS (Cumulative Layout Shift) < 0.1
             - ✅ No regressions > 10%
-            
+
             View detailed report in the Lighthouse CI temporary public storage (link in job artifacts).
-            
+
             _Dashboard chunk regressions like 1.2MB would be caught by this check._`;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/frontend/budget.json
+++ b/frontend/budget.json
@@ -12,6 +12,10 @@
             "budget": 200
           },
           {
+            "resourceType": "stylesheet",
+            "budget": 60
+          },
+          {
             "resourceType": "image",
             "budget": 100
           },

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -1,10 +1,19 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 3,
+      "numberOfRuns": 2,
+      "url": [
+        "/",
+        "/dashboard",
+        "/create-quest",
+        "/creator-dashboard",
+        "/leaderboard",
+        "/quest/1"
+      ],
       "settings": {
         "preset": "desktop",
         "staticDistDir": "./dist",
+        "isSinglePageApplication": true,
         "budgetFile": "./budget.json"
       }
     },
@@ -15,7 +24,13 @@
         "largest-contentful-paint": ["error", { "maxNumericValue": 2500, "aggregationMethod": "optimistic" }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "percentile" }],
         "interactive": ["warn", { "maxNumericValue": 3800 }],
-        "total-blocking-time": ["warn", { "maxNumericValue": 300 }]
+        "total-blocking-time": ["warn", { "maxNumericValue": 300 }],
+        "resource-summary:script:size": ["error", { "maxNumericValue": 204800 }],
+        "resource-summary:stylesheet:size": ["error", { "maxNumericValue": 61440 }],
+        "resource-summary:image:size": ["error", { "maxNumericValue": 102400 }],
+        "resource-summary:font:size": ["error", { "maxNumericValue": 51200 }],
+        "resource-summary:total:size": ["error", { "maxNumericValue": 512000 }],
+        "resource-summary:third-party:count": ["error", { "maxNumericValue": 15 }]
       }
     },
     "upload": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "check-env:mainnet": "node scripts/check-env.mjs --mode mainnet",
     "dev": "vite",
     "validate:assets": "node scripts/validate-public-assets.mjs",
+    "check:bundle-budget": "node scripts/check-bundle-budget.mjs",
     "prebuild": "node scripts/check-env.mjs && node scripts/validate-public-assets.mjs",
     "build": "tsc -b && vite build",
     "build:analyze": "vite build --config vite.config.ts",

--- a/frontend/scripts/check-bundle-budget.mjs
+++ b/frontend/scripts/check-bundle-budget.mjs
@@ -1,0 +1,142 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const frontendRoot = path.resolve(scriptDir, "..")
+const distDir = path.join(frontendRoot, "dist")
+const budgetPath = path.join(frontendRoot, "budget.json")
+
+// Single JS chunk hard cap, independent of the aggregate script budget below.
+// Keeps one runaway chunk (e.g. an un-code-split vendor import) from hiding
+// inside an otherwise-healthy total. Slightly above Vite's chunkSizeWarningLimit
+// (244 KB, see vite.config.ts) so a plain warning there fails the build here.
+const PER_CHUNK_SCRIPT_BUDGET_KB = 300
+
+const EXTENSION_TO_RESOURCE_TYPE = {
+  ".js": "script",
+  ".mjs": "script",
+  ".cjs": "script",
+  ".css": "stylesheet",
+  ".png": "image",
+  ".jpg": "image",
+  ".jpeg": "image",
+  ".gif": "image",
+  ".svg": "image",
+  ".webp": "image",
+  ".avif": "image",
+  ".woff": "font",
+  ".woff2": "font",
+  ".eot": "font",
+  ".ttf": "font",
+  ".otf": "font",
+}
+
+function readBudget() {
+  const raw = JSON.parse(fs.readFileSync(budgetPath, "utf8"))
+  const budget = raw.performance?.budgets?.[0]
+  if (!budget) {
+    throw new Error(`Could not find performance.budgets[0] in ${budgetPath}`)
+  }
+
+  const sizeBudgetsKb = {}
+  for (const entry of budget.resourceSizes ?? []) {
+    sizeBudgetsKb[entry.resourceType] = entry.budget
+  }
+
+  return sizeBudgetsKb
+}
+
+function walkFiles(dir) {
+  const results = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const absolutePath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(absolutePath))
+    } else if (entry.isFile()) {
+      results.push(absolutePath)
+    }
+  }
+  return results
+}
+
+function formatKb(bytes) {
+  return (bytes / 1024).toFixed(1)
+}
+
+if (!fs.existsSync(distDir)) {
+  console.error(`Build output not found at ${distDir}. Run "pnpm run build" first.`)
+  process.exit(1)
+}
+
+const sizeBudgetsKb = readBudget()
+const files = walkFiles(distDir)
+
+const totalsByResourceType = {}
+let totalBytes = 0
+const oversizedChunks = []
+
+for (const absolutePath of files) {
+  const size = fs.statSync(absolutePath).size
+  totalBytes += size
+
+  const ext = path.extname(absolutePath).toLowerCase()
+  const resourceType = EXTENSION_TO_RESOURCE_TYPE[ext]
+  if (resourceType) {
+    totalsByResourceType[resourceType] = (totalsByResourceType[resourceType] ?? 0) + size
+  }
+
+  if (resourceType === "script" && size / 1024 > PER_CHUNK_SCRIPT_BUDGET_KB) {
+    oversizedChunks.push({ file: path.relative(distDir, absolutePath), sizeKb: size / 1024 })
+  }
+}
+
+const failures = []
+const rows = [{ resourceType: "total", actualKb: totalBytes / 1024, budgetKb: sizeBudgetsKb.total }]
+for (const resourceType of ["script", "stylesheet", "image", "font"]) {
+  rows.push({
+    resourceType,
+    actualKb: (totalsByResourceType[resourceType] ?? 0) / 1024,
+    budgetKb: sizeBudgetsKb[resourceType],
+  })
+}
+
+console.log("=== Frontend Bundle Budget Report ===")
+console.log(`Source of truth: ${path.relative(frontendRoot, budgetPath)}\n`)
+
+for (const row of rows) {
+  const budgetKb = row.budgetKb
+  const exceeded = typeof budgetKb === "number" && row.actualKb > budgetKb
+  if (exceeded) failures.push(row)
+  const status = budgetKb == null ? "  -  " : exceeded ? "FAIL " : "OK   "
+  const budgetLabel = budgetKb == null ? "n/a" : `${budgetKb} KB`
+  console.log(`${status}${row.resourceType.padEnd(12)} ${row.actualKb.toFixed(1).padStart(9)} KB / ${budgetLabel}`)
+}
+
+if (oversizedChunks.length > 0) {
+  console.log(`\nOversized JS chunks (> ${PER_CHUNK_SCRIPT_BUDGET_KB} KB each):`)
+  for (const chunk of oversizedChunks) {
+    console.log(`FAIL ${chunk.file}: ${chunk.sizeKb.toFixed(1)} KB`)
+  }
+}
+
+console.log("")
+
+if (process.env.GITHUB_OUTPUT) {
+  const totalRow = rows.find((r) => r.resourceType === "total")
+  const scriptRow = rows.find((r) => r.resourceType === "script")
+  const lines = [
+    `total_kb=${totalRow.actualKb.toFixed(1)}`,
+    `script_kb=${scriptRow.actualKb.toFixed(1)}`,
+    `passed=${failures.length === 0 && oversizedChunks.length === 0}`,
+  ]
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, lines.join("\n") + "\n")
+}
+
+if (failures.length > 0 || oversizedChunks.length > 0) {
+  console.error("Bundle budget check failed. See FAIL rows above.")
+  console.error(`Budgets are defined in ${path.relative(frontendRoot, budgetPath)} — update them deliberately if the growth is expected.`)
+  process.exit(1)
+}
+
+console.log("Bundle budget check passed.")


### PR DESCRIPTION
Frontend bundle-size reporting was informational only, and Lighthouse CI checked a single route with no enforced resource-size gates.

- Add frontend/scripts/check-bundle-budget.mjs, run in the CI frontend job right after build; fails the job when total/script/stylesheet/ image/font sizes or any single JS chunk exceed frontend/budget.json.
- Add a stylesheet (CSS) budget to budget.json alongside script/image/font.
- Wire budget.json's numbers into lighthouserc.json as hard resource-summary assertions, so Lighthouse CI actually fails on budget violations instead of only reporting them.
- Expand Lighthouse CI (both the static-dist job and the Vercel-preview job) to audit key routes (/, /dashboard, /create-quest, /creator-dashboard, /leaderboard, /quest/1) instead of only "/", using isSinglePageApplication for SPA route fallback.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

Closes #<!-- issue number -->

Closes #1486
Closes #1483
Closes #1484
Closes #1485

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [ ] I have added at least one label to this PR
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [ ] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->
