### PR TITLE
test(contracts): add property-based tests for ownership, enrollment, and milestone completion invariants

### DIFF
--- a/contracts/milestone/tests/completion_invariants_proptest.rs
+++ b/contracts/milestone/tests/completion_invariants_proptest.rs
@@ -1,0 +1,180 @@
+//! Property tests for milestone-completion invariants (issue #1440).
+//!
+//! Covers, across randomized interleavings of `verify_completion` calls:
+//! - Ownership: only the real quest owner may verify a completion; every
+//!   other caller is rejected with `Error::Unauthorized` and never mutates
+//!   completion state.
+//! - Enrollment: an address that was never enrolled is always rejected with
+//!   `Error::NotEnrolled`.
+//! - Idempotency: a given (milestone, enrollee) pair can be completed at
+//!   most once; every subsequent attempt returns `Error::AlreadyCompleted`.
+//! - Prerequisite ordering: a milestone created with `requires_previous`
+//!   cannot be completed for an enrollee until the immediately preceding
+//!   milestone has been completed for that same enrollee.
+//!
+//! `is_completed` and `get_enrollee_completions` are cross-checked against
+//! a ground-truth model tracked alongside the contract calls after every
+//! single operation, not just at the end of the sequence.
+
+use certificate::CertificateContract;
+use common::Visibility;
+use milestone::{Error, MilestoneContract, MilestoneContractClient};
+use proptest::prelude::*;
+use quest::{QuestContract, QuestContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+struct VerifyAction {
+    milestone_idx: usize,
+    enrollee_idx: usize,
+    impostor: bool,
+}
+
+fn arb_action() -> impl Strategy<Value = VerifyAction> {
+    (0usize..3, 0usize..3, any::<bool>()).prop_map(|(milestone_idx, enrollee_idx, impostor)| {
+        VerifyAction {
+            milestone_idx,
+            enrollee_idx,
+            impostor,
+        }
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn milestone_completion_invariants_hold(
+        actions in proptest::collection::vec(arb_action(), 1..30)
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let quest_contract_id = env.register(QuestContract, ());
+        let quest_client = QuestContractClient::new(&env, &quest_contract_id);
+
+        let milestone_contract_id = env.register(MilestoneContract, ());
+        let milestone_client = MilestoneContractClient::new(&env, &milestone_contract_id);
+
+        let cert_id = env.register(CertificateContract, (milestone_contract_id.clone(),));
+        let admin = Address::generate(&env);
+        milestone_client.initialize(&admin, &quest_contract_id, &cert_id);
+
+        let owner = Address::generate(&env);
+        let fake_token = env.register(QuestContract, ());
+
+        let qid = quest_client.create_quest(
+            &owner,
+            &String::from_str(&env, "Quest"),
+            &String::from_str(&env, "Description"),
+            &String::from_str(&env, "Programming"),
+            &Vec::<String>::new(&env),
+            &fake_token,
+            &Visibility::Public,
+            &None,
+            &None,
+        );
+
+        // Three milestones: 0 (no prerequisite), 1 (requires milestone 0),
+        // 2 (no prerequisite despite following 1).
+        let m0 = milestone_client.create_milestone(
+            &owner, &qid,
+            &String::from_str(&env, "M0"), &String::from_str(&env, "desc"),
+            &100, &false,
+        );
+        let m1 = milestone_client.create_milestone(
+            &owner, &qid,
+            &String::from_str(&env, "M1"), &String::from_str(&env, "desc"),
+            &100, &true,
+        );
+        let m2 = milestone_client.create_milestone(
+            &owner, &qid,
+            &String::from_str(&env, "M2"), &String::from_str(&env, "desc"),
+            &100, &false,
+        );
+        let milestone_ids = [m0, m1, m2];
+        let requires_previous = [false, true, false];
+
+        // enrollees[0] and enrollees[1] are enrolled; enrollees[2] never is.
+        let enrollees = [
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+        ];
+        quest_client.add_enrollee(&qid, &enrollees[0]);
+        quest_client.add_enrollee(&qid, &enrollees[1]);
+        let enrolled_set: HashSet<usize> = [0usize, 1usize].into_iter().collect();
+
+        // Ground-truth model of completed (milestone_idx, enrollee_idx) pairs.
+        let mut completed: HashSet<(usize, usize)> = HashSet::new();
+
+        for action in &actions {
+            let mi = action.milestone_idx % milestone_ids.len();
+            let ei = action.enrollee_idx % enrollees.len();
+            let mid = milestone_ids[mi];
+            let enrollee = enrollees[ei].clone();
+
+            let caller = if action.impostor {
+                Address::generate(&env)
+            } else {
+                owner.clone()
+            };
+
+            let result = milestone_client.try_verify_completion(&caller, &qid, &mid, &enrollee);
+
+            if action.impostor {
+                prop_assert_eq!(
+                    result, Err(Ok(Error::Unauthorized)),
+                    "non-owner caller must never be able to verify a completion"
+                );
+            } else if !enrolled_set.contains(&ei) {
+                prop_assert_eq!(
+                    result, Err(Ok(Error::NotEnrolled)),
+                    "unenrolled address must never have a completion verified"
+                );
+            } else if completed.contains(&(mi, ei)) {
+                prop_assert_eq!(
+                    result, Err(Ok(Error::AlreadyCompleted)),
+                    "a (milestone, enrollee) pair must not be completable twice"
+                );
+            } else if requires_previous[mi] && mi > 0 && !completed.contains(&(mi - 1, ei)) {
+                prop_assert_eq!(
+                    result, Err(Ok(Error::MilestoneNotUnlocked)),
+                    "milestone with an incomplete prerequisite must be rejected"
+                );
+            } else {
+                prop_assert!(
+                    result.is_ok(),
+                    "expected verification to succeed for milestone {} enrollee {}: {:?}",
+                    mi, ei, result
+                );
+                completed.insert((mi, ei));
+            }
+
+            // Cross-check contract state against the ground-truth model after
+            // every single operation.
+            for (check_mi, check_mid) in milestone_ids.iter().enumerate() {
+                for (check_ei, check_enrollee) in enrollees.iter().enumerate() {
+                    let expected = completed.contains(&(check_mi, check_ei));
+                    let actual = milestone_client.is_completed(&qid, check_mid, check_enrollee);
+                    prop_assert_eq!(
+                        actual, expected,
+                        "is_completed disagreed with model for milestone {} enrollee {}",
+                        check_mi, check_ei
+                    );
+                }
+            }
+
+            for (check_ei, check_enrollee) in enrollees.iter().enumerate() {
+                let expected_count = completed.iter().filter(|(_, e)| *e == check_ei).count() as u32;
+                let actual_count = milestone_client.get_enrollee_completions(&qid, check_enrollee);
+                prop_assert_eq!(
+                    actual_count, expected_count,
+                    "get_enrollee_completions disagreed with model for enrollee {}",
+                    check_ei
+                );
+            }
+        }
+    }
+}

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -108,21 +108,6 @@ pub struct CategoryInfo {
     pub expires_at: u64,
 }
 
-/// Metadata about a public category, including when its on-chain listing will
-/// expire. Frontends use `expires_at` to warn users before a category (and the
-/// quests listed under it) silently disappears due to TTL expiry.
-#[contracttype]
-#[derive(Clone, Debug, PartialEq)]
-pub struct CategoryInfo {
-    pub category: String,
-    pub quest_count: u32,
-    /// Remaining persistent-TTL entries (ledgers) before the category listing expires.
-    pub ttl_remaining: u32,
-    /// Approximate absolute expiry timestamp (ledger seconds). Derived from
-    /// `ttl_remaining` using the ~5s/ledger assumption documented in ADR-005.
-    pub expires_at: u64,
-}
-
 // TTL constants and address validation moved to common.
 const MAX_TAGS: u32 = 5;
 const MAX_TAG_LEN: u32 = 32;
@@ -428,6 +413,10 @@ impl QuestContract {
         env.storage()
             .persistent()
             .set(&DataKey::Enrollees(id), &Vec::<Address>::new(&env));
+        env.storage().persistent().set(
+            &DataKey::QuestVersionHistory(id),
+            &Vec::<QuestVersion>::new(&env),
+        );
         env.storage().instance().set(&DataKey::NextId, &(id + 1));
         extend_instance_ttl(&env);
 

--- a/contracts/quest/tests/ownership_enrollment_proptest.rs
+++ b/contracts/quest/tests/ownership_enrollment_proptest.rs
@@ -1,0 +1,233 @@
+//! Property tests for quest ownership and enrollment invariants (issue #1440).
+//!
+//! Ownership: only the address stored as `QuestInfo.owner` may mutate a
+//! quest via `update_quest`; every other address must be rejected with
+//! `Error::Unauthorized`, regardless of how it was generated.
+//!
+//! Enrollment: across any interleaving of owner-add, self-join, remove, and
+//! leave operations, the enrollee list must stay duplicate-free, capacity
+//! must never be exceeded, and `is_enrollee` / `get_enrollees` /
+//! `get_active_participant_count` must always agree with each other.
+
+use common::Visibility;
+use proptest::prelude::*;
+use quest::{Error, QuestContract, QuestContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+fn setup_quest_with_owner() -> (Env, QuestContractClient<'static>, Address, u32) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuestContract, ());
+    let client = QuestContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let fake_token = env.register(QuestContract, ());
+
+    let quest_id = client.create_quest(
+        &owner,
+        &String::from_str(&env, "Quest"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Programming"),
+        &Vec::<String>::new(&env),
+        &fake_token,
+        &Visibility::Public,
+        &None,
+        &None,
+    );
+
+    (env, client, owner, quest_id)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// INVARIANT: `update_quest` succeeds for the real owner and is
+    /// rejected with `Error::Unauthorized` for every other address, no
+    /// matter how many distinct impostor addresses are tried in sequence.
+    #[test]
+    fn only_owner_can_update_quest(num_impostors in 1usize..8) {
+        let (env, client, owner, quest_id) = setup_quest_with_owner();
+
+        for _ in 0..num_impostors {
+            let impostor = Address::generate(&env);
+            prop_assert_ne!(impostor.clone(), owner.clone());
+
+            let result = client.try_update_quest(
+                &quest_id,
+                &impostor,
+                &Some(String::from_str(&env, "Hijacked")),
+                &None,
+                &None,
+                &None,
+                &None,
+                &None,
+            );
+            prop_assert_eq!(
+                result,
+                Err(Ok(Error::Unauthorized)),
+                "non-owner must not be able to update the quest"
+            );
+        }
+
+        // The real owner must still be able to update the quest afterwards —
+        // rejected impostor calls must not have corrupted any state.
+        let result = client.try_update_quest(
+            &quest_id,
+            &owner,
+            &Some(String::from_str(&env, "Renamed")),
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        );
+        prop_assert!(result.is_ok(), "the real owner must still be able to update the quest");
+
+        let quest = client.get_quest(&quest_id);
+        prop_assert_eq!(quest.name, String::from_str(&env, "Renamed"));
+        prop_assert_eq!(quest.owner, owner, "ownership must never change as a side effect of rejected updates");
+    }
+}
+
+/// Enrollment operations used to build randomized interleavings.
+#[derive(Debug, Clone)]
+enum EnrollAction {
+    OwnerAdd,
+    SelfJoin,
+    Remove(usize),
+    Leave(usize),
+}
+
+fn arb_enroll_action() -> impl Strategy<Value = EnrollAction> {
+    prop_oneof![
+        Just(EnrollAction::OwnerAdd),
+        Just(EnrollAction::SelfJoin),
+        (0usize..20).prop_map(EnrollAction::Remove),
+        (0usize..20).prop_map(EnrollAction::Leave),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// INVARIANT: after every enrollment operation, in any order:
+    /// - the enrollee list contains no duplicates
+    /// - `is_enrollee` agrees with membership in `get_enrollees`
+    /// - `get_active_participant_count` equals the number of enrollees
+    ///   `get_active_participants` returns
+    /// - the enrollment cap, once set, is never exceeded
+    #[test]
+    fn enrollment_state_stays_consistent(
+        actions in proptest::collection::vec(arb_enroll_action(), 1..25),
+        cap in prop::option::of(1u32..5),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(QuestContract, ());
+        let client = QuestContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let fake_token = env.register(QuestContract, ());
+
+        let quest_id = client.create_quest(
+            &owner,
+            &String::from_str(&env, "Quest"),
+            &String::from_str(&env, "Description"),
+            &String::from_str(&env, "Programming"),
+            &Vec::<String>::new(&env),
+            &fake_token,
+            &Visibility::Public,
+            &cap,
+            &None,
+        );
+
+        let mut tracked: std::vec::Vec<Address> = std::vec::Vec::new();
+
+        for action in &actions {
+            match action {
+                EnrollAction::OwnerAdd => {
+                    let candidate = Address::generate(&env);
+                    if client.try_add_enrollee(&quest_id, &candidate).is_ok() {
+                        tracked.push(candidate);
+                    }
+                }
+                EnrollAction::SelfJoin => {
+                    let candidate = Address::generate(&env);
+                    if client.try_join_quest(&candidate, &quest_id).is_ok() {
+                        tracked.push(candidate);
+                    }
+                }
+                EnrollAction::Remove(idx) => {
+                    if tracked.is_empty() { continue; }
+                    let target = tracked[*idx % tracked.len()].clone();
+                    if client.try_remove_enrollee(&quest_id, &target).is_ok() {
+                        tracked.retain(|a| a != &target);
+                    }
+                }
+                EnrollAction::Leave(idx) => {
+                    if tracked.is_empty() { continue; }
+                    let target = tracked[*idx % tracked.len()].clone();
+                    if client.try_leave_quest(&target, &quest_id).is_ok() {
+                        tracked.retain(|a| a != &target);
+                    }
+                }
+            }
+
+            // --- Invariants checked after every single operation ---
+
+            let enrollees = client.get_enrollees(&quest_id);
+
+            // No duplicates.
+            let mut seen: std::vec::Vec<Address> = std::vec::Vec::new();
+            for e in enrollees.iter() {
+                prop_assert!(
+                    !seen.contains(&e),
+                    "duplicate enrollee found in get_enrollees: {:?}",
+                    e
+                );
+                seen.push(e);
+            }
+
+            // Cap respected.
+            if let Some(max) = cap {
+                prop_assert!(
+                    enrollees.len() <= max,
+                    "enrollee count {} exceeded cap {}",
+                    enrollees.len(),
+                    max
+                );
+            }
+
+            // is_enrollee agrees with get_enrollees for every tracked address.
+            for addr in &tracked {
+                let is_member = enrollees.iter().any(|e| &e == addr);
+                let reported = client.is_enrollee(&quest_id, addr);
+                prop_assert_eq!(
+                    is_member, reported,
+                    "is_enrollee disagreed with get_enrollees for {:?}",
+                    addr
+                );
+            }
+
+            // Active participant count matches active participant list length.
+            let active = client.get_active_participants(&quest_id);
+            let active_count = client.get_active_participant_count(&quest_id);
+            prop_assert_eq!(
+                active.len(),
+                active_count,
+                "get_active_participant_count disagreed with get_active_participants().len()"
+            );
+
+            // Every active participant must still be a current enrollee.
+            for a in active.iter() {
+                prop_assert!(
+                    enrollees.iter().any(|e| e == a),
+                    "active participant {:?} is not in the enrollee list",
+                    a
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds proptest coverage for quest **ownership** — `update_quest` is rejected with `Error::Unauthorized` for every address other than the real quest owner, across randomized sequences of impostor addresses.
- Adds proptest coverage for **enrollment** invariants — across randomized interleavings of owner-add, self-join, remove, and leave operations: no duplicate enrollees, the enrollment cap is never exceeded, and `is_enrollee` / `get_enrollees` / `get_active_participant_count` stay consistent with each other after every operation.
- Adds proptest coverage for **milestone completion** invariants in the milestone crate — ownership enforcement, enrollment gating (`Error::NotEnrolled`), idempotency (`Error::AlreadyCompleted`), and prerequisite ordering (`Error::MilestoneNotUnlocked`), cross-checked against a tracked ground-truth model after every operation.
- Pool accounting and reward distribution invariants were already covered by the existing `contracts/rewards/tests/proptest_invariants.rs`, so this PR does not duplicate that.

While building this out I found two pre-existing bugs that block the workspace from building/testing at all, so I fixed both as necessary prerequisites:
- `contracts/quest/src/lib.rs` had `CategoryInfo` defined twice, which fails to compile via a `#[contracttype]` macro conflict — the whole workspace was unbuildable on `main`. Removed the duplicate.
- `QuestContract::bump()` unconditionally extends the TTL of the `QuestVersionHistory` persistent entry, but `create_quest` never initialized that entry, so the very first `bump()` call after quest creation panics with a missing-key error — **every `create_quest` call panicked**. This also meant the existing `id_monotonicity_proptest.rs` in the quest crate could never actually pass. Fixed by initializing an empty history `Vec` at creation time, matching how `Enrollees` is already initialized.

## Test plan
- [x] `cargo test -p quest --test ownership_enrollment_proptest` — passes
- [x] `cargo test -p milestone --test completion_invariants_proptest` — passes
- [x] `cargo test -p quest --test id_monotonicity_proptest` — passes (previously panicked on `main` due to the `create_quest` bug above)
- [x] `cargo test -p rewards --test proptest_invariants test_idempotency_invariant` — still passes after the fix
- [x] `cargo test --workspace` no longer fails to compile due to the duplicate `CategoryInfo` struct

Closes #1440
Closes #1442
Closes #1441
Closes #1439