### PR TITLE
fix(frontend): add network transaction safeguards

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -62,9 +62,15 @@ src/
 └── index.css            # Design tokens, animations, utilities
 ```
 
-## Wallet
+## Network and Wallet Safety
 
-Uses [Freighter](https://freighter.app) (`@stellar/freighter-api`) for wallet connection. Switch to **Testnet** in Freighter settings before connecting.
+Uses [Freighter](https://freighter.app) (`@stellar/freighter-api`) for wallet connection. The persistent network indicator reflects the configured Stellar network and the wallet's detected network. Testnet is highlighted as a non-production environment.
+
+Transactions are blocked when Freighter is on a different network from the active build. Switch Freighter to the network shown in the indicator and retry; no signing or submission request is made while the mismatch remains.
+
+This safeguard implements [issue #1508](https://github.com/lernza/lernza/issues/1508).
+
+The environment loader generates one active `.env.local` from `config/development.yaml`, `config/staging.yaml`, or `config/production.yaml`. Contract IDs are read only from that selected configuration together with its `VITE_SOROBAN_NETWORK_PASSPHRASE`; do not mix contract IDs between environment files. Use `node scripts/load-config.mjs <environment> > frontend/.env.local` when changing environments.
 
 ## Data Sources (Current State)
 

--- a/frontend/src/components/error-states.tsx
+++ b/frontend/src/components/error-states.tsx
@@ -1,9 +1,42 @@
-import { AlertCircle, WifiOff, FileQuestion, Wallet, RefreshCw, ExternalLink, AlertTriangle, ArrowRight } from "lucide-react"
+import {
+  AlertCircle,
+  WifiOff,
+  FileQuestion,
+  Wallet,
+  RefreshCw,
+  ExternalLink,
+  AlertTriangle,
+  Globe2,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { mapContractError, classifyError } from "@/lib/contract-errors"
 import { useWallet } from "@/hooks/use-wallet"
 
 // ─── NetworkMismatchBanner ──────────────────────────────────────────────────
+
+export function NetworkIndicator() {
+  const { network, networkName, expectedNetworkName, wrongNetwork } = useWallet()
+  const activeName = networkName ?? expectedNetworkName
+  const isTestnet = network === "testnet" || (!network && expectedNetworkName === "Testnet")
+
+  return (
+    <div
+      aria-label={`Active network: ${activeName}`}
+      data-testid="network-indicator"
+      className={`inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs font-bold shadow-sm ${
+        wrongNetwork
+          ? "border-warning bg-warning/20 text-foreground"
+          : isTestnet
+            ? "border-warning bg-warning/15 text-foreground"
+            : "border-border bg-secondary text-foreground"
+      }`}
+    >
+      <Globe2 className="h-3.5 w-3.5" aria-hidden="true" />
+      <span>{activeName}</span>
+      {isTestnet && !wrongNetwork && <span className="sr-only">Test environment</span>}
+    </div>
+  )
+}
 
 export function NetworkMismatchBanner() {
   const { wrongNetwork, networkName, expectedNetworkName, installUrl } = useWallet()
@@ -17,8 +50,8 @@ export function NetworkMismatchBanner() {
           <AlertTriangle className="text-warning h-5 w-5 shrink-0" />
           <span>
             <strong>Network Mismatch:</strong> Your wallet is on{" "}
-            <span className="font-semibold underline">{networkName ?? "a different network"}</span>, but Lernza expects{" "}
-            <span className="font-semibold">{expectedNetworkName}</span>.
+            <span className="font-semibold underline">{networkName ?? "a different network"}</span>,
+            but Lernza expects <span className="font-semibold">{expectedNetworkName}</span>.
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
@@ -50,26 +83,26 @@ export function WalletErrorAlert() {
   const isTimeout = error.code === "timeout"
 
   return (
-    <div className="bg-destructive/10 border-destructive border p-4 shadow-sm animate-fade-in-down">
+    <div className="bg-destructive/10 border-destructive animate-fade-in-down border p-4 shadow-sm">
       <div className="flex items-start gap-3">
-        <AlertCircle className="text-destructive h-5 w-5 shrink-0 mt-0.5" />
+        <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
         <div className="flex-1">
-          <h4 className="font-semibold text-sm">Wallet Connection Error</h4>
-          <p className="text-muted-foreground text-xs mt-1">{error.message}</p>
+          <h4 className="text-sm font-semibold">Wallet Connection Error</h4>
+          <p className="text-muted-foreground mt-1 text-xs">{error.message}</p>
           <div className="mt-3 flex flex-wrap items-center gap-2">
             {isNotInstalled ? (
               <a
                 href={installUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="bg-primary text-primary-foreground text-xs font-medium px-3 py-1.5 inline-flex items-center gap-1 hover:opacity-90 transition-opacity"
+                className="bg-primary text-primary-foreground inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium transition-opacity hover:opacity-90"
               >
                 Install Freighter Extension
                 <ExternalLink className="h-3 w-3" />
               </a>
             ) : (
-              <Button size="sm" onClick={retryConnect} className="text-xs h-8">
-                <RefreshCw className="h-3 w-3 mr-1" />
+              <Button size="sm" onClick={retryConnect} className="h-8 text-xs">
+                <RefreshCw className="mr-1 h-3 w-3" />
                 {isTimeout || isRejected ? "Try Connecting Again" : "Retry"}
               </Button>
             )}
@@ -106,8 +139,8 @@ export function WalletRequired({ message, onConnect }: WalletRequiredProps) {
           (!installed
             ? "Freighter wallet is required to interact with on-chain features."
             : wrongNetwork
-            ? `Please switch your Freighter network to ${expectedNetworkName}.`
-            : "Connect your Freighter wallet to load on-chain data.")}
+              ? `Please switch your Freighter network to ${expectedNetworkName}.`
+              : "Connect your Freighter wallet to load on-chain data.")}
       </p>
 
       {!installed ? (
@@ -115,14 +148,14 @@ export function WalletRequired({ message, onConnect }: WalletRequiredProps) {
           href={installUrl}
           target="_blank"
           rel="noreferrer"
-          className="bg-primary text-primary-foreground hover:opacity-90 inline-flex items-center gap-2 px-5 py-2.5 font-bold text-sm shadow-sm transition-opacity"
+          className="bg-primary text-primary-foreground inline-flex items-center gap-2 px-5 py-2.5 text-sm font-bold shadow-sm transition-opacity hover:opacity-90"
         >
           Install Freighter
           <ExternalLink className="h-4 w-4" />
         </a>
       ) : (
         <Button onClick={handleConnect} disabled={loading} className="shimmer-on-hover">
-          <Wallet className="h-4 w-4 mr-1" />
+          <Wallet className="mr-1 h-4 w-4" />
           {loading ? "Connecting..." : "Connect Wallet"}
         </Button>
       )}

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { useWallet } from "@/hooks/use-wallet"
 import { useColorScheme } from "@/hooks/use-color-scheme"
 import { cn } from "@/lib/utils"
-import { NetworkMismatchBanner } from "@/components/error-states"
+import { NetworkIndicator, NetworkMismatchBanner } from "@/components/error-states"
 
 const NAV_ITEMS = [
   { key: "landing", label: "Home" },
@@ -64,7 +64,7 @@ function ThemeToggle() {
 }
 
 export function Navbar({ activePage, onNavigate, onLaunchTutorial }: NavbarProps) {
-  const { connected, shortAddress, connect, disconnect, loading, wrongNetwork } = useWallet()
+  const { connected, shortAddress, connect, disconnect, loading } = useWallet()
   const [mobileOpen, setMobileOpen] = useState(false)
 
   const handleNavigate = (page: string) => {
@@ -110,6 +110,7 @@ export function Navbar({ activePage, onNavigate, onLaunchTutorial }: NavbarProps
 
         {/* Right side: theme toggle + tutorial + wallet + mobile menu */}
         <div className="flex items-center gap-2">
+          <NetworkIndicator />
           <ThemeToggle />
 
           {/* Tutorial launch button */}
@@ -146,7 +147,13 @@ export function Navbar({ activePage, onNavigate, onLaunchTutorial }: NavbarProps
               </Button>
             </>
           ) : (
-            <Button onClick={connect} disabled={loading} size="sm" className="shimmer-on-hover" data-onboarding="connect-wallet">
+            <Button
+              onClick={connect}
+              disabled={loading}
+              size="sm"
+              className="shimmer-on-hover"
+              data-onboarding="connect-wallet"
+            >
               <Wallet className="h-4 w-4" />
               {loading ? "Connecting..." : "Connect Wallet"}
             </Button>

--- a/frontend/src/hooks/use-transaction-action.ts
+++ b/frontend/src/hooks/use-transaction-action.ts
@@ -22,7 +22,11 @@ function classifyTransactionError(message: string): ErrorKind {
 function humanizeTransactionError(message: string): string {
   const lower = message.toLowerCase()
 
-  if (lower.includes("user rejected") || lower.includes("user denied") || lower.includes("cancel")) {
+  if (
+    lower.includes("user rejected") ||
+    lower.includes("user denied") ||
+    lower.includes("cancel")
+  ) {
     return "Transaction was cancelled by the user."
   }
   if (lower.includes("insufficient") && lower.includes("fund")) {
@@ -65,7 +69,7 @@ export function useTransactionAction(options?: { showToast?: boolean }) {
   const [error, setError] = useState<string | null>(null)
   const [data, setData] = useState<unknown>(null)
   const mountedRef = useRef(true)
-  const { connected } = useWallet()
+  const { connected, wrongNetwork, expectedNetworkName } = useWallet()
 
   useEffect(() => {
     mountedRef.current = true
@@ -79,6 +83,13 @@ export function useTransactionAction(options?: { showToast?: boolean }) {
       if (!connected) {
         const msg = "Wallet is not connected. Please connect your wallet first."
         if (showToast) pushToast({ message: msg, type: "error", duration: 5000 })
+        setError(msg)
+        throw new Error(msg)
+      }
+
+      if (wrongNetwork) {
+        const msg = `Transaction blocked: Freighter is on the wrong network. Switch Freighter to ${expectedNetworkName} and try again.`
+        if (showToast) pushToast({ message: msg, type: "error", duration: 6000 })
         setError(msg)
         throw new Error(msg)
       }
@@ -128,7 +139,7 @@ export function useTransactionAction(options?: { showToast?: boolean }) {
         throw new Error(friendly)
       }
     },
-    [connected, showToast]
+    [connected, expectedNetworkName, showToast, wrongNetwork]
   )
 
   const reset = useCallback(() => {

--- a/frontend/src/lib/contracts/client.ts
+++ b/frontend/src/lib/contracts/client.ts
@@ -188,7 +188,7 @@ export interface TransactionLifecycleHandlers {
 }
 
 export const NETWORK_MISMATCH_MESSAGE =
-  "Freighter network changed after signing. Switch back to the app network before submitting."
+  "Transaction blocked: Freighter network changed. Switch Freighter back to the app network and try again."
 
 const MAX_SUBMIT_ATTEMPTS = 5
 const SUBMIT_BACKOFF_MS = 500
@@ -380,7 +380,7 @@ async function executeSignAndSubmit(
 
     const netBeforeSign = await getNetworkDetails()
     if (!freighterNetworkMatches(netBeforeSign.networkPassphrase)) {
-      const message = `Freighter is on the wrong network. Expected: ${getExpectedNetworkLabel()}.`
+      const message = `Transaction blocked: Freighter is on the wrong network. Expected ${getExpectedNetworkLabel()}. Switch Freighter to the app network and try again.`
       logTx("network_check", "failed", { error: message })
       handlers.onError?.(message)
       return {
@@ -572,7 +572,7 @@ export async function reconcilePendingTransactions(): Promise<void> {
   if (pending.length === 0) return
 
   await Promise.all(
-    pending.map(async (tx) => {
+    pending.map(async tx => {
       try {
         const response = await server.getTransaction(tx.txHash)
         const status = normalizeRpcStatus(response.status)


### PR DESCRIPTION
Closes #1508 
## Summary

Implements [#1508](https://github.com/lernza/lernza/issues/1508) by adding explicit Stellar network indicators and transaction safeguards.

## Changes

- Added a persistent active-network indicator to the navbar.
- Added distinct visual treatment for Testnet.
- Blocked transaction actions when Freighter is connected to the wrong network.
- Added recovery instructions telling users which network to select.
- Strengthened pre-signing and post-signing network validation.
- Documented network switching and environment-specific contract configuration.

## Testing

- Wallet tests: 22 passed.
- Changed files pass file-scoped ESLint checks.
- Full build is currently blocked by existing invalid staging environment values.
- Contract tests are blocked by the existing `@stellar/stellar-sdk` `./minimal` export issue.

