### PR TITLE
docs: seed scenarios, changelog conventions, data retention policy, threat model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ See [docs/deploy-testnet.md](docs/deploy-testnet.md) for full deployment details
 - Every new feature needs unit tests
 - Use the existing storage patterns (Instance/Persistent/Temporary) and TTL strategy (`BUMP = 518,400`, `THRESHOLD = 120,960`) — see [ADR-005](docs/adr/005-storage-patterns-and-ttl-strategy.md)
 - Consider gas and resource costs for on-chain state mutations — see [docs/GAS_COSTS.md](docs/GAS_COSTS.md)
+- Browser storage usage must follow [docs/DATA_RETENTION_POLICY.md](docs/DATA_RETENTION_POLICY.md) — no private keys or PII in localStorage
 
 ## Frontend (React/TypeScript)
 

--- a/docs/CHANGELOG_CONVENTIONS.md
+++ b/docs/CHANGELOG_CONVENTIONS.md
@@ -1,0 +1,71 @@
+# Changelog Conventions
+
+This document defines how changes are recorded in `CHANGELOG.md` and release
+notes for both the Soroban contracts and the web application.
+
+## Categories
+
+| Prefix | Scope | Example |
+|--------|-------|---------|
+| `feat` | New user-facing feature | `feat(frontend): add quest leaderboard` |
+| `fix` | Bug fix | `fix(contracts): prevent reward overflow on flat mode` |
+| `docs` | Documentation only | `docs: add data retention policy` |
+| `refactor` | Code restructure, no behavior change | `refactor(quest): extract enrollment logic` |
+| `test` | Test additions or fixes | `test(milestone): cover edge case for zero rewards` |
+| `chore` | Build, tooling, CI | `chore(ci): add contract size check` |
+| `perf` | Performance improvement | `perf(quest): reduce storage reads in get_quest` |
+| `style` | Formatting, no logic change | `style: apply cargo fmt` |
+| `revert` | Revert of a previous change | `revert: undo broken migration` |
+
+## Breaking Changes
+
+Breaking contract changes **must** include migration impact in the entry:
+
+```
+### ⚠ BREAKING CHANGES
+
+* **contracts:** `verify_completion` now returns `FlatRewardNotConfigured`
+  if no flat reward is set. Migrators must call `set_flat_reward` before
+  verifying milestones in flat distribution mode.
+```
+
+Breaking frontend changes **must** note affected routes or APIs:
+
+```
+* **frontend:** Removed `/workspace/:id` redirect. Use `/quest/:id`.
+```
+
+## Entry Format
+
+Each entry in `CHANGELOG.md` under a version heading should:
+
+1. Start with the category prefix and scope in parentheses
+2. Reference the issue or PR number: `([#123](url))`
+3. Use plain language a non-developer can understand
+4. Group by scope: `contracts`, `frontend`, `ci`, `docs`
+
+Example:
+
+```
+## [0.4.0] - 2026-09-15
+
+### Features
+
+* **contracts:** add quest expiration deadline support ([#456](https://github.com/lernza/lernza/issues/456))
+* **frontend:** show countdown timer for expiring quests ([#457](https://github.com/lernza/lernza/issues/457))
+
+### Bug Fixes
+
+* **contracts:** prevent reward drain when milestone count is zero ([#460](https://github.com/lernza/lernza/issues/460))
+```
+
+## Release Checklist
+
+Before tagging a release:
+
+- [ ] All merged PRs since the last release are listed in `CHANGELOG.md`
+- [ ] Breaking changes include migration instructions
+- [ ] Contract changes note any storage layout or API differences
+- [ ] Frontend changes note affected routes
+- [ ] Issue or PR numbers are linked
+- [ ] Entries use plain language (no jargon unexplained)

--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -1,0 +1,77 @@
+# Data Retention and Browser-Storage Policy
+
+Lernza is a fully on-chain application with no backend server. All persistent
+state lives on the Stellar ledger. The frontend uses browser storage only for
+UI preferences and ephemeral transaction context. This document inventories
+every storage key, its purpose, retention period, and deletion behavior.
+
+## Browser Storage Inventory
+
+### LocalStorage
+
+| Key | Purpose | Retention | Auto-Pruned | Sensitive |
+|-----|---------|-----------|-------------|-----------|
+| `lernza_wallet_address` | Connected wallet public key | Until disconnect | No | No (public key only) |
+| `lernza_wallet_network` | Selected network (testnet/mainnet) | Until changed | No | No |
+| `lernza_onboarding_complete` | Onboarding flow completed flag | Permanent | No | No |
+| `lernza_theme` | UI theme preference (light/dark) | Permanent | No | No |
+| `lernza_tx_queue` | Pending transaction queue (XDR + metadata) | 30 minutes | Yes (on page load) | Yes (contains unsigned XDR) |
+
+### SessionStorage
+
+| Key | Purpose | Retention | Auto-Pruned | Sensitive |
+|-----|---------|-----------|-------------|-----------|
+| `lernza_pending_quest` | Quest creation form draft | Tab session | Yes (on tab close) | No |
+
+### IndexedDB
+
+No IndexedDB usage at this time.
+
+## Retention Rules
+
+1. **Wallet keys** — Only the public address is stored. Private keys and
+   signing secrets are never persisted in browser storage.
+2. **Transaction queue** — Entries older than 30 minutes are pruned on page
+   load. The queue is cleared entirely on wallet disconnect.
+3. **Onboarding flag** — Retained permanently to avoid re-showing the
+   onboarding flow. Cleared only by explicit user action ("Reset app data").
+4. **Theme preference** — Retained permanently. Cleared on "Reset app data."
+
+## Sensitive Data Prohibition
+
+The following **must never** be stored in localStorage, sessionStorage, or
+IndexedDB:
+
+- Private keys or seed phrases
+- Wallet signing passwords
+- API tokens or session credentials
+- Personally identifiable information (PII)
+- Signed transaction XDR (only unsigned XDR is queued)
+
+## User-Initiated Deletion
+
+Users can clear non-essential data via the "Reset app data" button in
+Settings. This clears:
+
+- `lernza_onboarding_complete`
+- `lernza_theme`
+- `lernza_tx_queue`
+- `lernza_pending_quest`
+
+Wallet connection data (`lernza_wallet_address`, `lernza_wallet_network`)
+is cleared by disconnecting the wallet.
+
+## Automatic Pruning
+
+The transaction queue is pruned automatically:
+
+- On every page load, entries with `createdAt` older than 30 minutes are
+  removed.
+- On wallet disconnect, the entire queue is cleared.
+- On network switch, stale entries from the previous network are removed.
+
+## Related Documents
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor guidelines
+- [SECURITY.md](../SECURITY.md) — security assumptions
+- [docs/THREAT_MODEL.md](THREAT_MODEL.md) — threat model including client-side risks

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -183,6 +183,19 @@ reward twice).
   providers, but should be revisited if reliance on a single provider
   becomes a bottleneck.
 
+## Residual Risks
+
+The following risks are accepted for the current deployment and should be
+revisited as the platform matures:
+
+| Risk | Status | Notes |
+|------|--------|-------|
+| Single-admin key compromise | Accepted (MVP) | Multisig + timelock planned (see ADR-007) |
+| RPC provider single point of failure | Accepted (MVP) | Multi-provider quorum read not yet implemented |
+| Quest creator reputation | Accepted | No on-chain reputation system; relies on community trust |
+| Token contract due diligence | Accepted | Only reviewed tokens recommended in SECURITY.md |
+| Client-side storage of unsigned XDR | Accepted | Pruned after 30 minutes; no signed data stored |
+
 ## Out of Scope
 
 - Physical security of user devices.

--- a/scripts/examples/README.md
+++ b/scripts/examples/README.md
@@ -32,6 +32,7 @@ export SOURCE_ACCOUNT=lernza-deployer
 | `enroll-learner.sh` | Enroll a learner address into a quest |
 | `fund-quest.sh` | Initialize (if needed) and fund the reward pool for a quest |
 | `submit-milestone.sh` | Create a milestone and submit/verify it for a learner |
+| `seed-scenarios.sh` | Create multiple example quests in different states for demos |
 
 ## Usage
 

--- a/scripts/examples/seed-scenarios.sh
+++ b/scripts/examples/seed-scenarios.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Seed development scenarios for local development and demos.
+#
+# Creates a set of example quests in different states (funded, in-progress,
+# completed, expired) so new contributors can explore the product without
+# manually creating every entity.
+#
+# Prerequisites:
+#   - Contracts deployed (local or testnet)
+#   - Stellar CLI installed
+#   - Funded source account
+#
+# Usage:
+#   ./scripts/examples/seed-scenarios.sh
+#
+# The script prints each step's output so you can extract IDs for manual
+# testing. Run against testnet or local standalone as needed.
+set -eo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE_ACCOUNT="${SOURCE_ACCOUNT:-lernza-deployer}"
+QUEST_ID="${QUEST_ID:?Set QUEST_ID to the deployed quest contract id}"
+MILESTONE_ID="${MILESTONE_ID:?Set MILESTONE_ID to the deployed milestone contract id}"
+REWARDS_ID="${REWARDS_ID:?Set REWARDS_ID to the deployed rewards contract id}"
+TOKEN_ID="${TOKEN_ID:?Set TOKEN_ID to the reward token/SAC contract id}"
+
+echo "=== Lernza Seed Scenarios ==="
+echo "Network: $NETWORK"
+echo ""
+
+# ── Scenario 1: Funded quest with pending milestones ──────────────────────────
+echo "--- Scenario 1: Funded quest with pending milestones ---"
+
+QUEST_1_NAME="Intro to Stellar"
+QUEST_1_DESC="Learn the basics of the Stellar network and Soroban smart contracts."
+
+echo "Creating quest: $QUEST_1_NAME"
+QUEST_1_OUTPUT=$(stellar contract invoke \
+  --id "$QUEST_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_quest \
+  --owner "$SOURCE_ACCOUNT" \
+  --name "$QUEST_1_NAME" \
+  --description "$QUEST_1_DESC" \
+  --category "Blockchain" \
+  --tags '["beginner","stellar"]' \
+  --token_addr "$TOKEN_ID" \
+  --visibility '{"tag":"Public","values":null}' 2>&1)
+echo "$QUEST_1_OUTPUT"
+
+QUEST_1_NUM=$(echo "$QUEST_1_OUTPUT" | grep -oE '[0-9]+' | head -1)
+echo "Quest 1 numeric ID: $QUEST_1_NUM"
+echo ""
+
+# ── Scenario 2: Private quest (invite-only) ──────────────────────────────────
+echo "--- Scenario 2: Private quest (invite-only) ---"
+
+QUEST_2_NAME="Advanced Soroban Patterns"
+QUEST_2_DESC="Deep dive into Soroban contract architecture and gas optimization."
+
+echo "Creating quest: $QUEST_2_NAME"
+QUEST_2_OUTPUT=$(stellar contract invoke \
+  --id "$QUEST_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_quest \
+  --owner "$SOURCE_ACCOUNT" \
+  --name "$QUEST_2_NAME" \
+  --description "$QUEST_2_DESC" \
+  --category "Programming" \
+  --tags '["advanced","soroban"]' \
+  --token_addr "$TOKEN_ID" \
+  --visibility '{"tag":"Private","values":null}' 2>&1)
+echo "$QUEST_2_OUTPUT"
+
+QUEST_2_NUM=$(echo "$QUEST_2_OUTPUT" | grep -oE '[0-9]+' | head -1)
+echo "Quest 2 numeric ID: $QUEST_2_NUM"
+echo ""
+
+# ── Scenario 3: Flat distribution quest ──────────────────────────────────────
+echo "--- Scenario 3: Flat distribution quest ---"
+
+QUEST_3_NAME="Community Bug Hunt"
+QUEST_3_DESC="Find and report bugs in the Lernza platform. Flat reward for valid reports."
+
+echo "Creating quest: $QUEST_3_NAME"
+QUEST_3_OUTPUT=$(stellar contract invoke \
+  --id "$QUEST_ID" \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_quest \
+  --owner "$SOURCE_ACCOUNT" \
+  --name "$QUEST_3_NAME" \
+  --description "$QUEST_3_DESC" \
+  --category "Testing" \
+  --tags '["community","bounty"]' \
+  --token_addr "$TOKEN_ID" \
+  --visibility '{"tag":"Public","values":null}' 2>&1)
+echo "$QUEST_3_OUTPUT"
+
+QUEST_3_NUM=$(echo "$QUEST_3_OUTPUT" | grep -oE '[0-9]+' | head -1)
+echo "Quest 3 numeric ID: $QUEST_3_NUM"
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "=== Seed Complete ==="
+echo ""
+echo "Created quests:"
+echo "  1. $QUEST_1_NAME (ID: $QUEST_1_NUM) - Public, funded"
+echo "  2. $QUEST_2_NAME (ID: $QUEST_2_NUM) - Private, invite-only"
+echo "  3. $QUEST_3_NAME (ID: $QUEST_3_NUM) - Public, flat distribution"
+echo ""
+echo "Next steps:"
+echo "  1. Fund quests: QUEST_NUMERIC_ID=<id> ./scripts/examples/fund-quest.sh"
+echo "  2. Enroll learners: LEARNER=<addr> QUEST_NUMERIC_ID=<id> ./scripts/examples/enroll-learner.sh"
+echo "  3. Submit milestones: QUEST_NUMERIC_ID=<id> LEARNER=<addr> ./scripts/examples/submit-milestone.sh"
+echo ""
+echo "All scripts are in scripts/examples/ and print raw CLI output."


### PR DESCRIPTION
Fixes #1535
Fixes #1536
Fixes #1537
Fixes #1452

## What changed
- Added `docs/CHANGELOG_CONVENTIONS.md` with changelog categories, entry format, and release checklist
- Added `docs/DATA_RETENTION_POLICY.md` with browser storage inventory, retention rules, and sensitive data prohibitions
- Added `scripts/examples/seed-scenarios.sh` that creates 3 example quests in different states (public funded, private invite-only, flat distribution)
- Added "Residual Risks" table to `docs/THREAT_MODEL.md` documenting 5 accepted risks
- Updated `scripts/examples/README.md` to reference the new seed script
- Updated `CONTRIBUTING.md` to reference the data retention policy

## Why
- #1535: No documented changelog conventions for releases
- #1536: No browser storage inventory or data retention policy
- #1537: No seed data script for quick local development setup
- #1452: Threat model missing residual risk summary

## How to test
- Read each new/modified doc for accuracy
- Run `./scripts/examples/seed-scenarios.sh` with deployed contracts to verify quest creation