### PR TITLE
fix(contracts): validate recipient is active participant in reward_user

### DIFF
--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
-use common::{extend_instance_ttl, QuestInfo, QuestStatus, BUMP, MAX_REWARD_AMOUNT, THRESHOLD};
+use common::{
+    extend_instance_ttl, EnrolleeStatus, QuestInfo, QuestStatus, BUMP, MAX_REWARD_AMOUNT, THRESHOLD,
+};
 use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
     Env, String, Symbol, Vec,
@@ -10,6 +12,12 @@ use soroban_sdk::{
 #[contractclient(name = "QuestClient")]
 pub trait QuestContractTrait {
     fn get_quest(env: Env, quest_id: u32) -> Result<QuestInfo, soroban_sdk::Val>;
+    fn is_enrollee(env: Env, quest_id: u32, user: Address) -> Result<bool, soroban_sdk::Val>;
+    fn get_enrollee_status(
+        env: Env,
+        quest_id: u32,
+        enrollee: Address,
+    ) -> Result<EnrolleeStatus, soroban_sdk::Val>;
 }
 
 #[contractclient(name = "MilestoneClient")]
@@ -103,6 +111,8 @@ pub enum Error {
     /// Contract is administratively paused (shared code 400).
     Paused = 400,
     BatchTooLarge = 17,
+    /// Reward recipient is no longer an active participant in the quest (issue #1325).
+    RecipientNotEnrolled = 18,
 }
 
 // TTL constants moved to common.
@@ -511,6 +521,28 @@ impl RewardsContract {
             return Err(Error::MilestoneNotCompleted);
         }
 
+        // Issue #1325: Verify the recipient is still an active participant.
+        // A user who was removed or left the quest after completing a milestone
+        // must not receive a reward payout.
+        let quest_contract_addr = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::QuestContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client = QuestClient::new(&env, &quest_contract_addr);
+        let is_active = quest_client
+            .try_is_enrollee(&quest_id, &enrollee)
+            .unwrap_or(Ok(false))
+            .unwrap_or(false)
+            && quest_client
+                .try_get_enrollee_status(&quest_id, &enrollee)
+                .unwrap_or(Ok(EnrolleeStatus::Inactive))
+                .unwrap_or(EnrolleeStatus::Inactive)
+                == EnrolleeStatus::Active;
+        if !is_active {
+            return Err(Error::RecipientNotEnrolled);
+        }
+
         // Validate amount matches the milestone's configured reward to prevent
         // the authority from over- or under-paying relative to what was promised.
         match milestone_client.try_get_milestone_reward(&quest_id, &milestone_id) {
@@ -755,6 +787,27 @@ impl RewardsContract {
             .persistent()
             .get::<DataKey, Address>(&auth_key)
             .ok_or(Error::QuestNotFunded)?;
+
+        // Issue #1325: Verify the claimant is still an active participant.
+        // A user who was removed or left the quest after completing milestones
+        // must not be able to self-claim rewards.
+        let quest_contract_addr_cb = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::QuestContractAddr)
+            .ok_or(Error::NotInitialized)?;
+        let claimant_active = QuestClient::new(&env, &quest_contract_addr_cb)
+            .try_is_enrollee(&quest_id, &claimant)
+            .unwrap_or(Ok(false))
+            .unwrap_or(false)
+            && QuestClient::new(&env, &quest_contract_addr_cb)
+                .try_get_enrollee_status(&quest_id, &claimant)
+                .unwrap_or(Ok(EnrolleeStatus::Inactive))
+                .unwrap_or(EnrolleeStatus::Inactive)
+                == EnrolleeStatus::Active;
+        if !claimant_active {
+            return Err(Error::RecipientNotEnrolled);
+        }
 
         let milestone_contract_addr = env
             .storage()

--- a/contracts/rewards/tests/integration_test.rs
+++ b/contracts/rewards/tests/integration_test.rs
@@ -22,7 +22,7 @@
 //! | 9 | `test_broken_quest_linkage_propagates_error` | Cross-contract error propagation |
 
 use certificate::{CertificateContract, CertificateContractClient};
-use common::Visibility;
+use common::{EnrolleeStatus, Visibility};
 use milestone::{Error as MilestoneError, MilestoneContract, MilestoneContractClient};
 use quest::{QuestContract, QuestContractClient};
 use rewards::{Error as RewardsError, RewardsContract, RewardsContractClient};
@@ -151,6 +151,32 @@ impl QuestSystemTest {
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// Issue #1325 — a suspended participant must not receive a verified reward.
+#[test]
+fn test_distribute_reward_rejects_suspended_enrollee() {
+    let ctx = QuestSystemTest::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+
+    ctx.mint_tokens(&owner, &5_000);
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+    let ms_id = ctx.create_milestone(&owner, q_id, "Suspended Milestone", 500);
+    ctx.milestone()
+        .verify_completion(&owner, &q_id, &ms_id, &enrollee);
+
+    ctx.quest()
+        .set_enrollee_status(&q_id, &enrollee, &EnrolleeStatus::Suspended);
+
+    let result = ctx
+        .rewards()
+        .try_distribute_reward(&owner, &q_id, &ms_id, &enrollee, &500);
+    assert_eq!(result, Err(Ok(RewardsError::RecipientNotEnrolled)));
+    assert_eq!(ctx.token_balance(&enrollee), 0);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 5_000);
+}
 
 /// 1. Happy Path — Create → Enroll → Fund → Complete → Claim
 ///
@@ -544,4 +570,85 @@ fn test_broken_quest_linkage_propagates_error() {
     // try_get_quest on a ghost address fails → rewards wraps it as QuestLookupFailed
     let result = rewards.try_fund_quest(&funder, &1, &500);
     assert_eq!(result, Err(Ok(RewardsError::QuestLookupFailed)));
+}
+
+/// 10. Issue #1325 — reward_user (distribute_reward) must reject recipients who
+///     are no longer active participants in the quest.
+///
+/// Scenario:
+///   1. Enrollee completes a milestone while still enrolled.
+///   2. Owner removes the enrollee before reward distribution (simulating suspension).
+///   3. `distribute_reward` must return `RecipientNotEnrolled` and transfer no tokens.
+///
+/// This guards against the window between milestone completion and reward
+/// payout where a user could be suspended or removed from the quest.
+#[test]
+fn test_distribute_reward_rejects_removed_enrollee() {
+    let ctx = QuestSystemTest::setup();
+    let owner = Address::generate(&ctx.env);
+    let enrollee = Address::generate(&ctx.env);
+
+    ctx.mint_tokens(&owner, &5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &enrollee);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.create_milestone(&owner, q_id, "Milestone", 500);
+
+    // Enrollee completes the milestone while still enrolled
+    ctx.milestone()
+        .verify_completion(&owner, &q_id, &ms_id, &enrollee);
+
+    // Simulate suspension: owner removes the enrollee before reward is distributed
+    ctx.quest().remove_enrollee(&q_id, &enrollee);
+    assert!(!ctx.quest().is_enrollee(&q_id, &enrollee));
+
+    // distribute_reward must now reject — recipient is no longer an active participant
+    let result = ctx
+        .rewards()
+        .try_distribute_reward(&owner, &q_id, &ms_id, &enrollee, &500);
+    assert_eq!(result, Err(Ok(RewardsError::RecipientNotEnrolled)));
+
+    // No tokens transferred, pool unchanged
+    assert_eq!(ctx.token_balance(&enrollee), 0);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 5_000);
+}
+
+/// 10b. Issue #1325 — claim_batch must also reject a claimant who is no longer
+///      an active participant.
+///
+/// Mirrors test 10 but exercises the self-service `claim_batch` path.
+#[test]
+fn test_claim_batch_rejects_removed_enrollee() {
+    let ctx = QuestSystemTest::setup();
+    let owner = Address::generate(&ctx.env);
+    let claimant = Address::generate(&ctx.env);
+
+    ctx.mint_tokens(&owner, &5_000);
+
+    let q_id = ctx.create_quest(&owner);
+    ctx.quest().add_enrollee(&q_id, &claimant);
+    ctx.rewards().fund_quest(&owner, &q_id, &5_000);
+
+    let ms_id = ctx.create_milestone(&owner, q_id, "Batch Milestone", 500);
+
+    // Claimant completes the milestone while still enrolled
+    ctx.milestone()
+        .verify_completion(&owner, &q_id, &ms_id, &claimant);
+
+    // Simulate suspension: owner removes the claimant before they self-claim
+    ctx.quest().remove_enrollee(&q_id, &claimant);
+    assert!(!ctx.quest().is_enrollee(&q_id, &claimant));
+
+    // claim_batch must now reject — claimant is no longer an active participant
+    let milestone_ids = soroban_sdk::vec![&ctx.env, ms_id];
+    let result = ctx
+        .rewards()
+        .try_claim_batch(&claimant, &q_id, &milestone_ids);
+    assert_eq!(result, Err(Ok(RewardsError::RecipientNotEnrolled)));
+
+    // No tokens transferred, pool unchanged
+    assert_eq!(ctx.token_balance(&claimant), 0);
+    assert_eq!(ctx.rewards().get_pool_balance(&q_id), 5_000);
 }


### PR DESCRIPTION
Summary
Fixes issue #1325 by preventing rewards from being distributed to quest participants who are no longer active.
Problem
distribute_reward and claim_batch previously verified enrollment but did not check the participant’s current status. As a result, a participant could complete a milestone, become suspended, banned, inactive, or removed, and still receive the associated reward.
Changes
Added get_enrollee_status to the Rewards contract’s Quest client interface.
Updated distribute_reward to require the recipient to be enrolled and have EnrolleeStatus::Active.
Updated claim_batch with the same active-participant validation.
Added the RecipientNotEnrolled error with code 18.
Added regression tests for removed and suspended participants.
Ensured rejected rewards do not transfer tokens or reduce the quest reward pool.
Preserved the existing MilestoneNotCompleted error precedence for recipients who were never enrolled.
Testing
cargo +1.88.0 test -p rewards --test integration_test -- --nocapture
Result: 14 tests passed
The broader cargo test -p rewards command remains blocked by unrelated pre-existing compile errors in other tests that use an outdated milestone contract method signature.

closes #1325 
