### PR TITLE
fix(milestone): enrich milestone_completed and peer_approved events

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -918,7 +918,7 @@ impl MilestoneContract {
             .get(&DataKey::Mode(quest_id))
             .unwrap_or(DistributionMode::Custom);
 
-        let reward = match mode {
+        let reward = match mode.clone() {
             DistributionMode::Custom => milestone.reward_amount,
             DistributionMode::Flat => env
                 .storage()
@@ -990,10 +990,10 @@ impl MilestoneContract {
 
         // Emit milestone completion event
         // Event topics: (milestone_completed,)
-        // Event data: (quest_id, milestone_id, enrollee)
+        // Event data: (quest_id, milestone_id, enrollee, reward, distribution_mode)
         env.events().publish(
             (Symbol::new(&env, "milestone_completed"),),
-            (quest_id, milestone_id, enrollee.clone()),
+            (quest_id, milestone_id, enrollee.clone(), reward, mode),
         );
 
         Ok(reward)
@@ -1220,7 +1220,7 @@ impl MilestoneContract {
             .get(&DataKey::VerificationMode(quest_id))
             .unwrap_or(VerificationMode::OwnerOnly);
 
-        let required_approvals = match verification_mode {
+        let required_approvals = match verification_mode.clone() {
             VerificationMode::PeerReview(approvals) => approvals,
             VerificationMode::OwnerOnly => return Err(Error::Unauthorized),
         };
@@ -1357,10 +1357,10 @@ impl MilestoneContract {
 
             // Emit peer approval completion event
             // Event topics: (peer_approved,)
-            // Event data: (milestone_id, quest_id, enrollee, peer, reward_amount)
+            // Event data: (milestone_id, quest_id, enrollee, peer, reward_amount, verification_mode, approval_count)
             env.events().publish(
                 (Symbol::new(&env, "peer_approved"),),
-                (milestone_id, quest_id, enrollee.clone(), peer, reward),
+                (milestone_id, quest_id, enrollee.clone(), peer, reward, verification_mode, new_approvals),
             );
 
             Ok(Some(reward))


### PR DESCRIPTION
 fix(milestone): enrich milestone_completed and peer_approved events with
  mode/reward context
  
  Problem
  
  The milestone_completed and peer_approved events were emitted without the
  reward or mode context that was in effect at the time of completion. Off-chain
  indexers and auditors had no way to determine what reward rules applied without
  making separate contract calls — and those calls reflect current state, not the
  state at the time of the event.
  
  Three specific gaps:
  
  - milestone_completed omitted reward_amount and distribution_mode
  - peer_approved omitted verification_mode and approval_count
  - Historical events become permanently ambiguous if the owner changes the mode
  after the fact
  
  Changes
  
  milestone_completed event — contracts/milestone/src/lib.rs
  
  Before: (quest_id, milestone_id, enrollee)
  After: (quest_id, milestone_id, enrollee, reward, distribution_mode)
  
  peer_approved event — contracts/milestone/src/lib.rs
  
  Before: (milestone_id, quest_id, enrollee, peer, reward_amount)
  After: (milestone_id, quest_id, enrollee, peer, reward_amount,
  verification_mode, approval_count)
  
  Both mode and verification_mode are cloned before their consuming match
  expressions so they remain available at the emit site. No new dependencies
  introduced — both types already carry #[contracttype] and #[derive(Clone)].
  
  Impact
  
  - Indexers get a self-contained event: no extra contract calls needed per
  completion
  - Full audit trail: reward amount, distribution mode, verification mode, and
  approval count are all recorded atomically with the event
  - Replay-safe: historical events carry the mode that was actually in effect,
  regardless of future owner changes

closes #1277