### PR TITLE
feat: add cross-contract quest completion flow, certificate page, and Playwright E2E

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,49 @@
+name: Playwright E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.12.0
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -16,6 +16,9 @@ pub struct CertificateMetadata {
     pub quest_name: String,
     pub quest_category: String,
     pub completion_date: u64,
+    /// Number of milestones in the quest at mint time. Surfaced on the
+    /// public certificate page so a viewer can see how much was completed.
+    pub milestone_count: u32,
     pub issuer: Address,
     pub recipient: Address,
 }
@@ -110,6 +113,7 @@ impl CertificateContract {
             quest_name: quest_name.clone(),
             quest_category,
             completion_date: env.ledger().timestamp(),
+            milestone_count: Self::quest_milestone_count(env.clone(), quest_id),
             issuer: issuer.clone(),
             recipient: recipient.clone(),
         };
@@ -304,6 +308,28 @@ impl CertificateContract {
             return Err(Error::Paused);
         }
         Ok(())
+    }
+
+    /// Resolve the number of milestones configured for `quest_id`.
+    ///
+    /// Best-effort: if the milestone contract hasn't been wired up via
+    /// `set_milestone_contract`, or the cross-contract read fails, we fall
+    /// back to 0 rather than failing the mint. The count is purely
+    /// informational metadata for the certificate display page.
+    fn quest_milestone_count(env: Env, quest_id: u32) -> u32 {
+        let milestone_contract: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MilestoneContract);
+        match milestone_contract {
+            Some(contract) => env
+                .invoke_contract(
+                    &contract,
+                    &Symbol::new(&env, "get_milestone_count"),
+                    soroban_sdk::vec![&env, quest_id.into_val(&env)],
+                ),
+            None => 0,
+        }
     }
 
     #[only_owner]

--- a/contracts/certificate/src/test.rs
+++ b/contracts/certificate/src/test.rs
@@ -29,6 +29,8 @@ fn test_certificate_minting() {
     assert_eq!(metadata.quest_category, quest_category);
     assert_eq!(metadata.recipient, recipient);
     assert_eq!(metadata.issuer, owner);
+    // No milestone contract wired up yet -> milestone_count falls back to 0.
+    assert_eq!(metadata.milestone_count, 0);
 
     let user_certs = client.get_user_certificates(&recipient);
     assert_eq!(user_certs.len(), 1);

--- a/contracts/certificate/test_snapshots/test/test_certificate_minting.1.json
+++ b/contracts/certificate/test_snapshots/test/test_certificate_minting.1.json
@@ -183,6 +183,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_duplicate_certificate_prevention.1.json
+++ b/contracts/certificate/test_snapshots/test/test_duplicate_certificate_prevention.1.json
@@ -181,6 +181,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_get_certificate_details_returns_metadata_and_owner.1.json
+++ b/contracts/certificate/test_snapshots/test/test_get_certificate_details_returns_metadata_and_owner.1.json
@@ -181,6 +181,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_has_quest_certificate.1.json
+++ b/contracts/certificate/test_snapshots/test/test_has_quest_certificate.1.json
@@ -182,6 +182,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_mint_quest_certificate_duplicate_prevention.1.json
+++ b/contracts/certificate/test_snapshots/test/test_mint_quest_certificate_duplicate_prevention.1.json
@@ -178,6 +178,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_mint_quest_certificate_uses_contract_owner_as_issuer.1.json
+++ b/contracts/certificate/test_snapshots/test/test_mint_quest_certificate_uses_contract_owner_as_issuer.1.json
@@ -178,6 +178,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_revoke_only_removes_target_certificate_from_user_list.1.json
+++ b/contracts/certificate/test_snapshots/test/test_revoke_only_removes_target_certificate_from_user_list.1.json
@@ -316,6 +316,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_revoked_certificate_slot_can_be_reissued.1.json
+++ b/contracts/certificate/test_snapshots/test/test_revoked_certificate_slot_can_be_reissued.1.json
@@ -316,6 +316,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_unpause_allows_minting_again.1.json
+++ b/contracts/certificate/test_snapshots/test/test_unpause_allows_minting_again.1.json
@@ -277,6 +277,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {

--- a/contracts/certificate/test_snapshots/test/test_user_certificate_details.1.json
+++ b/contracts/certificate/test_snapshots/test/test_user_certificate_details.1.json
@@ -245,6 +245,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "quest_category"
                       },
                       "val": {
@@ -335,6 +343,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestone_count"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contracts/completion/Cargo.toml
+++ b/contracts/completion/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "completion"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+common = { path = "../common" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+quest = { path = "../quest" }
+milestone = { path = "../milestone" }
+certificate = { path = "../certificate" }
+rewards = { path = "../rewards" }
+
+[features]
+testutils = []

--- a/contracts/completion/src/lib.rs
+++ b/contracts/completion/src/lib.rs
@@ -1,0 +1,181 @@
+#![no_std]
+use common::{extend_instance_ttl, QuestInfo};
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+    String,
+};
+
+/// Quest contract interface used to fetch quest ownership and metadata so the
+/// completion flow can verify the caller is the quest owner before acting.
+#[contractclient(name = "QuestClient")]
+pub trait QuestContractTrait {
+    fn get_quest(env: Env, quest_id: u32) -> QuestInfo;
+}
+
+/// Milestone contract interface used to confirm every milestone in a quest was
+/// completed by the recipient before finalizing.
+#[contractclient(name = "MilestoneClient")]
+pub trait MilestoneContractTrait {
+    fn get_milestone_count(env: Env, quest_id: u32) -> u32;
+    fn is_completed(env: Env, quest_id: u32, milestone_id: u32, enrollee: Address) -> bool;
+}
+
+/// Certificate contract interface used to mint or look up the completion
+/// certificate as part of the atomic completion flow.
+#[contractclient(name = "CertificateClient")]
+pub trait CertificateContractTrait {
+    fn get_quest_certificate(env: Env, quest_id: u32, recipient: Address) -> u32;
+    fn mint_quest_certificate(
+        env: Env,
+        quest_id: u32,
+        quest_name: String,
+        quest_category: String,
+        recipient: Address,
+    ) -> u32;
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// Contract has not been initialized with the dependent contract addresses.
+    NotInitialized = 1,
+    /// Caller is not the quest owner.
+    NotOwner = 2,
+    /// Not every milestone has been completed by the recipient yet.
+    MilestonesIncomplete = 3,
+    /// This quest/recipient pair has already been completed.
+    AlreadyCompleted = 4,
+    /// The downstream certificate operation failed.
+    CertificateError = 5,
+    /// The contract is already initialized.
+    AlreadyInitialized = 6,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct CompletionConfig {
+    pub quest: Address,
+    pub milestone: Address,
+    pub certificate: Address,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Config,
+    /// Maps a (quest_id, recipient) pair to the minted certificate token id.
+    Completed(u32, Address),
+}
+
+#[contract]
+pub struct CompletionContract;
+
+#[contractimpl]
+impl CompletionContract {
+    /// Wire the completion facade to the quest, milestone, and certificate
+    /// contracts it orchestrates.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        quest: Address,
+        milestone: Address,
+        certificate: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Config) {
+            return Err(Error::AlreadyInitialized);
+        }
+        let config = CompletionConfig {
+            quest,
+            milestone,
+            certificate,
+        };
+        env.storage().instance().set(&DataKey::Config, &config);
+        extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Returns the configured dependent contract addresses.
+    pub fn get_config(env: Env) -> Result<CompletionConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(Error::NotInitialized)
+    }
+
+    /// Atomically finalize a learner's completion of a quest:
+    /// 1. verify the caller is the quest owner,
+    /// 2. verify every milestone is completed by `recipient` (cross-contract
+    ///    reads against the milestone contract),
+    /// 3. obtain or mint the on-chain certificate (cross-contract call to the
+    ///    certificate contract),
+    /// 4. record the completion so it cannot be finalized twice.
+    ///
+    /// Reward distribution for individual milestones is performed by the
+    /// milestone contract during `verify_completion`; this facade centralizes
+    /// the finalization so the frontend can complete a quest with a single call.
+    pub fn complete_quest(
+        env: Env,
+        owner: Address,
+        quest_id: u32,
+        recipient: Address,
+    ) -> Result<u32, Error> {
+        owner.require_auth();
+
+        let config = Self::get_config(env.clone())?;
+
+        // 1. Verify caller ownership of the quest.
+        let quest = QuestClient::new(&env, &config.quest).get_quest(&quest_id);
+        if quest.owner != owner {
+            return Err(Error::NotOwner);
+        }
+
+        // 2. Verify every milestone is completed by the recipient.
+        let count = MilestoneClient::new(&env, &config.milestone).get_milestone_count(&quest_id);
+        if count == 0 {
+            return Err(Error::MilestonesIncomplete);
+        }
+        let mut milestone_id: u32 = 0;
+        while milestone_id < count {
+            let done = MilestoneClient::new(&env, &config.milestone)
+                .is_completed(&quest_id, &milestone_id, &recipient);
+            if !done {
+                return Err(Error::MilestonesIncomplete);
+            }
+            milestone_id += 1;
+        }
+
+        // Guard against double completion.
+        let completed_key = DataKey::Completed(quest_id, recipient.clone());
+        if env.storage().persistent().has(&completed_key) {
+            return Err(Error::AlreadyCompleted);
+        }
+
+        // 3. Obtain the completion certificate. The milestone contract already
+        //    mints it on final completion, so we reuse that token when present
+        //    and only mint if one does not yet exist (cross-contract calls).
+        let cert_client = CertificateClient::new(&env, &config.certificate);
+        let token_id: u32 = match cert_client.try_get_quest_certificate(&quest_id, &recipient) {
+            Ok(Ok(id)) => id,
+            _ => cert_client.mint_quest_certificate(
+                &quest_id,
+                &quest.name,
+                &quest.category,
+                &recipient,
+            ),
+        };
+
+        // 4. Record completion.
+        env.storage().persistent().set(&completed_key, &token_id);
+        extend_instance_ttl(&env);
+        env.events().publish(
+            (symbol_short!("completed"),),
+            (quest_id, recipient.clone(), token_id),
+        );
+        Ok(token_id)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/completion/src/test.rs
+++ b/contracts/completion/src/test.rs
@@ -1,0 +1,179 @@
+#![cfg(test)]
+extern crate std;
+
+use common::Visibility;
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use crate::*;
+
+use quest::QuestContract as QuestContractType;
+use milestone::MilestoneContract as MilestoneContractType;
+use certificate::CertificateContract as CertificateContractType;
+
+use quest::QuestContractClient as QuestContractClient;
+use milestone::MilestoneContractClient as MilestoneContractClient;
+use certificate::CertificateContractClient as CertificateContractClient;
+
+struct TestSetup {
+    env: Env,
+    admin: Address,
+    recipient: Address,
+    quest: Address,
+    milestone: Address,
+    certificate: Address,
+    completion: Address,
+}
+
+fn setup() -> TestSetup {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let quest = env.register(QuestContractType, ());
+    let milestone = env.register(MilestoneContractType, ());
+    let certificate = env.register(CertificateContractType, (admin.clone(),));
+    let completion = env.register(CompletionContract, ());
+
+    QuestContractClient::new(&env, &quest).initialize(&admin);
+    MilestoneContractClient::new(&env, &milestone).initialize(&admin, &quest, &certificate);
+    CompletionContractClient::new(&env, &completion).initialize(&admin, &quest, &milestone, &certificate);
+
+    TestSetup {
+        env,
+        admin,
+        recipient,
+        quest,
+        milestone,
+        certificate,
+        completion,
+    }
+}
+
+fn create_quest(s: &TestSetup) -> u32 {
+    let tags = Vec::new(&s.env);
+    // Any contract address satisfies the token-address validation.
+    let token = s.certificate.clone();
+    QuestContractClient::new(&s.env, &s.quest).create_quest(
+        &s.admin,
+        &String::from_str(&s.env, "Learn Rust"),
+        &String::from_str(&s.env, "A quest to learn Rust"),
+        &String::from_str(&s.env, "Programming"),
+        &tags,
+        &token,
+        &Visibility::Public,
+        &None,
+        &None,
+    )
+}
+
+fn create_milestone(s: &TestSetup, quest_id: u32) -> u32 {
+    MilestoneContractClient::new(&s.env, &s.milestone).create_milestone(
+        &s.admin,
+        &quest_id,
+        &String::from_str(&s.env, "First steps"),
+        &String::from_str(&s.env, "Install the toolchain"),
+        &1000,
+        &false,
+        &None,
+        &None,
+        &None,
+    )
+}
+
+#[test]
+fn test_complete_quest_finalizes_certificate() {
+    let s = setup();
+    let quest_id = create_quest(&s);
+    let milestone_id = create_milestone(&s, quest_id);
+
+    // Enroll and mark the recipient as having completed the milestone.
+    QuestContractClient::new(&s.env, &s.quest).join_quest(&s.recipient, &quest_id);
+    MilestoneContractClient::new(&s.env, &s.milestone).verify_completion(
+        &s.admin,
+        &quest_id,
+        &milestone_id,
+        &s.recipient,
+    );
+
+    let token_id = CompletionContractClient::new(&s.env, &s.completion).complete_quest(
+        &s.admin,
+        &quest_id,
+        &s.recipient,
+    );
+
+    // The certificate should exist and complete_quest returns its token id.
+    assert!(CertificateContractClient::new(&s.env, &s.certificate)
+        .has_quest_certificate(&quest_id, &s.recipient));
+    assert_eq!(
+        CertificateContractClient::new(&s.env, &s.certificate)
+            .get_quest_certificate(&quest_id, &s.recipient),
+        token_id
+    );
+}
+
+#[test]
+fn test_complete_quest_rejects_non_owner() {
+    let s = setup();
+    let quest_id = create_quest(&s);
+    create_milestone(&s, quest_id);
+
+    let outsider = Address::generate(&s.env);
+    let result = CompletionContractClient::new(&s.env, &s.completion).try_complete_quest(
+        &outsider,
+        &quest_id,
+        &s.recipient,
+    );
+
+    assert_eq!(result, Err(Ok(Error::NotOwner)));
+}
+
+#[test]
+fn test_complete_quest_rejects_incomplete_milestones() {
+    let s = setup();
+    let quest_id = create_quest(&s);
+    create_milestone(&s, quest_id);
+    // Intentionally do NOT verify completion for this recipient.
+
+    let result = CompletionContractClient::new(&s.env, &s.completion).try_complete_quest(
+        &s.admin,
+        &quest_id,
+        &s.recipient,
+    );
+
+    assert_eq!(result, Err(Ok(Error::MilestonesIncomplete)));
+}
+
+#[test]
+fn test_complete_quest_rejects_double_completion() {
+    let s = setup();
+    let quest_id = create_quest(&s);
+    let milestone_id = create_milestone(&s, quest_id);
+    QuestContractClient::new(&s.env, &s.quest).join_quest(&s.recipient, &quest_id);
+    MilestoneContractClient::new(&s.env, &s.milestone).verify_completion(
+        &s.admin,
+        &quest_id,
+        &milestone_id,
+        &s.recipient,
+    );
+
+    let first = CompletionContractClient::new(&s.env, &s.completion).complete_quest(
+        &s.admin,
+        &quest_id,
+        &s.recipient,
+    );
+    assert!(CertificateContractClient::new(&s.env, &s.certificate)
+        .has_quest_certificate(&quest_id, &s.recipient));
+    assert_eq!(
+        CertificateContractClient::new(&s.env, &s.certificate)
+            .get_quest_certificate(&quest_id, &s.recipient),
+        first
+    );
+
+    let second = CompletionContractClient::new(&s.env, &s.completion).try_complete_quest(
+        &s.admin,
+        &quest_id,
+        &s.recipient,
+    );
+    assert_eq!(second, Err(Ok(Error::AlreadyCompleted)));
+}

--- a/contracts/milestone/src/test.rs
+++ b/contracts/milestone/src/test.rs
@@ -72,8 +72,7 @@ fn create_ms(
         &String::from_str(env, title),
         &String::from_str(env, "Description"),
         &reward,
-        &false,
-    )
+        &false, &None, &None, &None)
 }
 
 #[test]
@@ -118,8 +117,7 @@ fn test_pause_blocks_milestone_writes_until_unpaused() {
         &String::from_str(&env, "Paused"),
         &String::from_str(&env, "Should fail while paused"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(create_result, Err(Ok(Error::Paused)));
 
     client.unpause(&owner);
@@ -231,8 +229,7 @@ fn test_verify_completion_requires_previous() {
         &String::from_str(&env, "Task 2"),
         &String::from_str(&env, "Description"),
         &100,
-        &true,
-    );
+        &true, &None, &None, &None);
 
     let enrollee = Address::generate(&env);
     quest_client.add_enrollee(&q_id, &enrollee);
@@ -251,13 +248,16 @@ fn test_branching_prerequisites_require_all_dependencies() {
     let q_id = create_quest(&env, &quest_client, &owner);
     let first = create_ms(&env, &client, &owner, q_id, "First", 50);
     let second = create_ms(&env, &client, &owner, q_id, "Second", 50);
-    let branch = client.create_milestone_with_prerequisites(
+    let branch = client.create_milestone_with_prereqs(
         &owner,
         &q_id,
         &String::from_str(&env, "Branch"),
         &String::from_str(&env, "Requires both branches"),
         &100,
         &soroban_sdk::vec![&env, first, second],
+        &None,
+        &None,
+        &None,
     );
     assert_eq!(
         client.get_milestone_prerequisites(&q_id, &branch),
@@ -343,8 +343,7 @@ fn test_wrong_owner_cannot_create() {
         &String::from_str(&env, "Evil task"),
         &String::from_str(&env, "Hack"),
         &999,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::OwnerMismatch)));
 }
 
@@ -376,8 +375,7 @@ fn test_zero_reward_milestone() {
         &String::from_str(&env, "Free task"),
         &String::from_str(&env, "Description"),
         &0,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -811,8 +809,7 @@ fn test_milestone_ownership_race_condition() {
         &String::from_str(&env, "Attacker backdoor milestone"),
         &String::from_str(&env, "Description"),
         &9999,
-        &false,
-    );
+        &false, &None, &None, &None);
 
     // Attack fails — attacker is not the quest owner
     assert_eq!(result, Err(Ok(Error::OwnerMismatch)));
@@ -824,8 +821,7 @@ fn test_milestone_ownership_race_condition() {
         &String::from_str(&env, "Real milestone"),
         &String::from_str(&env, "Description"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(id, 0);
 
     // Legitimate owner can verify completions
@@ -867,8 +863,7 @@ fn test_get_quest_not_found_fails() {
         &String::from_str(&env, "Title"),
         &String::from_str(&env, "Desc"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::NotFound)));
 }
 
@@ -1063,8 +1058,7 @@ fn test_peer_review_respects_sequential_unlocks() {
         &String::from_str(&env, "Task 2"),
         &String::from_str(&env, "Description"),
         &100,
-        &true,
-    );
+        &true, &None, &None, &None);
 
     client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(1));
 
@@ -1216,8 +1210,7 @@ fn test_create_milestone_empty_title() {
         &String::from_str(&env, ""),
         &String::from_str(&env, "Valid description"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
 
@@ -1231,8 +1224,7 @@ fn test_create_milestone_empty_description() {
         &String::from_str(&env, "Valid Title"),
         &String::from_str(&env, ""),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
 
@@ -1248,8 +1240,7 @@ fn test_create_milestone_very_long_title() {
         &long_title,
         &String::from_str(&env, "Valid description"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::TitleTooLong)));
 }
 
@@ -1265,8 +1256,7 @@ fn test_create_milestone_very_long_description() {
         &String::from_str(&env, "Valid Title"),
         &long_desc,
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::DescriptionTooLong)));
 }
 
@@ -1280,8 +1270,7 @@ fn test_create_milestone_negative_reward() {
         &String::from_str(&env, "Valid Title"),
         &String::from_str(&env, "Valid description"),
         &-1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -1295,8 +1284,7 @@ fn test_create_milestone_zero_reward() {
         &String::from_str(&env, "Valid Title"),
         &String::from_str(&env, "Valid description"),
         &0,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -1310,8 +1298,7 @@ fn test_create_milestone_reward_too_large() {
         &String::from_str(&env, "Valid Title"),
         &String::from_str(&env, "Valid description"),
         &(MAX_REWARD_AMOUNT + 1),
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -1325,8 +1312,7 @@ fn test_create_milestone_max_reward_amount_succeeds() {
         &String::from_str(&env, "Valid Title"),
         &String::from_str(&env, "Valid description"),
         &MAX_REWARD_AMOUNT,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(id, 0);
 }
 
@@ -1342,8 +1328,7 @@ fn test_create_milestone_max_length_title_succeeds() {
         &max_title,
         &String::from_str(&env, "Valid description"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(id, 0);
 }
 
@@ -1359,8 +1344,7 @@ fn test_create_milestone_max_length_description_succeeds() {
         &String::from_str(&env, "Valid Title"),
         &max_desc,
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(id, 0);
 }
 
@@ -1375,13 +1359,19 @@ fn test_create_milestones_batch_success() {
         description: String::from_str(&env, "D1"),
         reward_amount: 100,
         requires_previous: false,
-    });
+    
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
     milestones.push_back(MilestoneInput {
         title: String::from_str(&env, "M2"),
         description: String::from_str(&env, "D2"),
         reward_amount: 200,
         requires_previous: true,
-    });
+    
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
 
     let ids = client.create_milestones_batch(&owner, &q_id, &milestones);
     assert_eq!(ids.len(), 2);
@@ -1408,7 +1398,10 @@ fn test_create_milestones_batch_oversized_rejection() {
             description: String::from_str(&env, "D"),
             reward_amount: 100,
             requires_previous: false,
-        });
+        
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
     }
 
     let result = client.try_create_milestones_batch(&owner, &q_id, &milestones);
@@ -1426,13 +1419,19 @@ fn test_create_milestones_batch_atomic_validation() {
         description: String::from_str(&env, "Valid"),
         reward_amount: 100,
         requires_previous: false,
-    });
+    
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
     milestones.push_back(MilestoneInput {
         title: String::from_str(&env, ""), // INVALID
         description: String::from_str(&env, "Valid"),
         reward_amount: 100,
         requires_previous: false,
-    });
+    
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
 
     let result = client.try_create_milestones_batch(&owner, &q_id, &milestones);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
@@ -1459,8 +1458,7 @@ fn test_create_milestone_exceeds_max_milestones() {
             &title,
             &String::from_str(&env, "Desc"),
             &1,
-            &false,
-        );
+            &false, &None, &None, &None);
         assert_eq!(id, i);
     }
     assert_eq!(client.get_milestone_count(&q_id), MAX_MILESTONES);
@@ -1472,8 +1470,7 @@ fn test_create_milestone_exceeds_max_milestones() {
         &String::from_str(&env, "Overflow"),
         &String::from_str(&env, "Desc"),
         &1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 
     // Count must remain unchanged
@@ -1494,8 +1491,7 @@ fn test_create_milestone_at_boundary() {
             &String::from_str(&env, "MS"),
             &String::from_str(&env, "D"),
             &1,
-            &false,
-        );
+            &false, &None, &None, &None);
     }
     assert_eq!(client.get_milestone_count(&q_id), MAX_MILESTONES - 1);
 
@@ -1506,8 +1502,7 @@ fn test_create_milestone_at_boundary() {
         &String::from_str(&env, "Last"),
         &String::from_str(&env, "D"),
         &1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(last_id, MAX_MILESTONES - 1);
     assert_eq!(client.get_milestone_count(&q_id), MAX_MILESTONES);
 
@@ -1518,8 +1513,7 @@ fn test_create_milestone_at_boundary() {
         &String::from_str(&env, "Over"),
         &String::from_str(&env, "D"),
         &1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
 
@@ -1538,8 +1532,7 @@ fn test_milestone_cap_per_quest_independent() {
             &String::from_str(&env, "MS"),
             &String::from_str(&env, "D"),
             &1,
-            &false,
-        );
+            &false, &None, &None, &None);
     }
 
     // q1 is full
@@ -1549,8 +1542,7 @@ fn test_milestone_cap_per_quest_independent() {
         &String::from_str(&env, "Over"),
         &String::from_str(&env, "D"),
         &1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 
     // q2 must still accept milestones
@@ -1560,8 +1552,7 @@ fn test_milestone_cap_per_quest_independent() {
         &String::from_str(&env, "First"),
         &String::from_str(&env, "D"),
         &1,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(id, 0);
     assert_eq!(client.get_milestone_count(&q2), 1);
 }
@@ -1631,8 +1622,7 @@ fn test_create_milestone_0_cannot_require_previous() {
         &String::from_str(&env, "MS0"),
         &String::from_str(&env, "Desc"),
         &100,
-        &true,
-    );
+        &true, &None, &None, &None);
 
     // Should fail with InvalidInput
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
@@ -1649,7 +1639,10 @@ fn test_create_milestones_batch_0_cannot_require_previous() {
         description: String::from_str(&env, "Desc"),
         reward_amount: 100,
         requires_previous: true,
-    });
+    
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
 
     let result = client.try_create_milestones_batch(&owner, &q_id, &batch);
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
@@ -1891,8 +1884,7 @@ fn test_pause_rejects_milestone_creation() {
         &String::from_str(&env, "M1"),
         &String::from_str(&env, "Desc"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(r, Err(Ok(Error::Paused)));
 }
 
@@ -1940,8 +1932,7 @@ fn test_non_owner_cannot_create_milestone() {
         &String::from_str(&env, "M1"),
         &String::from_str(&env, "Desc"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(r, Err(Ok(Error::OwnerMismatch)));
 }
 
@@ -1957,8 +1948,7 @@ fn test_milestone_reward_bounds() {
         &String::from_str(&env, "M1"),
         &String::from_str(&env, "Desc"),
         &0,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(r, Err(Ok(Error::InvalidAmount)));
 
     // Negative reward rejected
@@ -1968,8 +1958,7 @@ fn test_milestone_reward_bounds() {
         &String::from_str(&env, "M1"),
         &String::from_str(&env, "Desc"),
         &(-100),
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(r, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -1985,7 +1974,10 @@ fn test_batch_size_limit() {
             description: String::from_str(&env, "D"),
             reward_amount: 100,
             requires_previous: false,
-        });
+        
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,});
     }
 
     let r = client.try_create_milestones_batch(&owner, &q_id, &milestones);
@@ -2040,8 +2032,7 @@ fn test_title_too_long_rejected() {
         &long_title,
         &String::from_str(&env, "Desc"),
         &100,
-        &false,
-    );
+        &false, &None, &None, &None);
     assert_eq!(r, Err(Ok(Error::TitleTooLong)));
 }
 
@@ -2058,8 +2049,7 @@ fn test_verify_completion_with_feedback() {
         &String::from_str(&env, "Milestone 1"),
         &String::from_str(&env, "Description 1"),
         &150,
-        &false,
-    );
+        &false, &None, &None, &None);
 
     let feedback_comment = String::from_str(&env, "Outstanding solution! Clean architecture.");
     let reward =
@@ -2087,8 +2077,7 @@ fn test_reject_completion_with_feedback() {
         &String::from_str(&env, "Peer Review Milestone"),
         &String::from_str(&env, "Description"),
         &200,
-        &false,
-    );
+        &false, &None, &None, &None);
     client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(1));
     client.submit_for_review(&enrollee, &q_id, &ms_id);
 
@@ -2122,8 +2111,7 @@ fn test_request_changes_and_resubmit_flow() {
         &String::from_str(&env, "Interactive Milestone"),
         &String::from_str(&env, "Description"),
         &300,
-        &false,
-    );
+        &false, &None, &None, &None);
     client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(1));
     client.submit_for_review(&enrollee, &q_id, &ms_id);
 
@@ -2151,4 +2139,183 @@ fn test_request_changes_and_resubmit_flow() {
     assert_eq!(history.get(0).unwrap().comment, change_feedback);
     assert_eq!(history.get(1).unwrap().action, FeedbackAction::Approve);
     assert_eq!(history.get(1).unwrap().comment, approve_feedback);
+}
+
+// ---- Issue #1412: edge-case coverage for distribution modes & verification ----
+
+/// Competitive distribution when more learners complete a milestone than there
+/// are winner slots. The first completer is rewarded; the remaining completers
+/// are still recorded as completed (so their progress counts) but receive 0.
+#[test]
+fn test_competitive_distribution_more_completers_than_winners() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    // Only a single winner per milestone.
+    client.set_distribution_mode(&owner, &q_id, &DistributionMode::Competitive(1), &0);
+    let ms_id = create_ms(&env, &client, &owner, q_id, "Race to finish", 100);
+
+    let e1 = Address::generate(&env);
+    let e2 = Address::generate(&env);
+    let e3 = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &e1);
+    quest_client.add_enrollee(&q_id, &e2);
+    quest_client.add_enrollee(&q_id, &e3);
+
+    // First completer claims the only reward slot.
+    assert_eq!(client.verify_completion(&owner, &q_id, &ms_id, &e1), 100);
+    // "Tied" losers beyond the cap get nothing...
+    assert_eq!(client.verify_completion(&owner, &q_id, &ms_id, &e2), 0);
+    assert_eq!(client.verify_completion(&owner, &q_id, &ms_id, &e3), 0);
+    // ...but their completion is still recorded and their count advances.
+    assert!(client.is_completed(&q_id, &ms_id, &e2));
+    assert!(client.is_completed(&q_id, &ms_id, &e3));
+    assert_eq!(client.get_enrollee_completions(&q_id, &e2), 1);
+    assert_eq!(client.get_enrollee_earnings(&q_id, &e2), 0);
+}
+
+/// Custom distribution: a per-milestone reward above the protocol maximum is
+/// rejected at creation time, while a reward exactly at the cap is accepted.
+/// This guards against a milestone promising more than the reward pool can pay.
+#[test]
+fn test_custom_distribution_reward_exceeding_max_rejected() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+
+    // Exceeds MAX_REWARD_AMOUNT (1_000_000_000_000_000).
+    let oversized = 1_000_000_000_000_001_i128;
+    let rejected = client.try_create_milestone(
+        &owner,
+        &q_id,
+        &String::from_str(&env, "Too generous"),
+        &String::from_str(&env, "Would drain the pool"),
+        &oversized,
+        &false,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(rejected, Err(Ok(Error::InvalidAmount)));
+
+    // Exactly at the cap is valid.
+    let accepted = client.try_create_milestone(
+        &owner,
+        &q_id,
+        &String::from_str(&env, "At cap"),
+        &String::from_str(&env, "Within bounds"),
+        &1_000_000_000_000_000_i128,
+        &false,
+        &None,
+        &None,
+        &None,
+    );
+    assert!(accepted.is_ok());
+}
+
+/// Peer-review verification with insufficient reviewers: a milestone configured
+/// for 3 approvals cannot complete with only 2, and a reviewer who is not an
+/// active enrollee is rejected outright.
+#[test]
+fn test_peer_review_insufficient_reviewers_blocks_completion() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+    client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(3));
+    let ms_id = create_ms(&env, &client, &owner, q_id, "Group project", 100);
+
+    let enrollee = Address::generate(&env);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    let p3 = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &enrollee);
+    quest_client.add_enrollee(&q_id, &p1);
+    quest_client.add_enrollee(&q_id, &p2);
+    quest_client.add_enrollee(&q_id, &p3);
+
+    client.submit_for_review(&enrollee, &q_id, &ms_id);
+
+    // Two approvals: still below the required 3, so no completion yet.
+    assert_eq!(client.approve_completion(&p1, &q_id, &ms_id, &enrollee), None);
+    assert_eq!(client.approve_completion(&p2, &q_id, &ms_id, &enrollee), None);
+    assert!(!client.is_completed(&q_id, &ms_id, &enrollee));
+
+    // A non-enrolled reviewer cannot approve.
+    assert_eq!(
+        client.try_approve_completion(&stranger, &q_id, &ms_id, &enrollee),
+        Err(Ok(Error::NotEnrolled))
+    );
+
+    // The third valid approval reaches the threshold and completes it.
+    assert_eq!(
+        client.approve_completion(&p3, &q_id, &ms_id, &enrollee),
+        Some(100)
+    );
+    assert!(client.is_completed(&q_id, &ms_id, &enrollee));
+}
+
+/// Milestone submission is rejected once the quest deadline has passed.
+#[test]
+fn test_milestone_submission_after_quest_expiry_rejected() {
+    let (env, client, quest_client, owner) = setup();
+    // A real contract address satisfies the quest's is_contract_address check.
+    let token = env.register(QuestContract, ());
+    let now = env.ledger().timestamp();
+    let q_id = quest_client.create_quest(
+        &owner,
+        &String::from_str(&env, "Expiring Quest"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Programming"),
+        &Vec::<String>::new(&env),
+        &token,
+        &Visibility::Public,
+        &None,
+        &Some(now + 1000),
+    );
+    let ms_id = create_ms(&env, &client, &owner, q_id, "Timed task", 100);
+    client.set_verification_mode(&owner, &q_id, &VerificationMode::PeerReview(1));
+
+    let enrollee = Address::generate(&env);
+    let late = Address::generate(&env);
+    quest_client.add_enrollee(&q_id, &enrollee);
+    // Enroll the late submitter before the deadline (enrollment is closed after).
+    quest_client.add_enrollee(&q_id, &late);
+    // Submission before the deadline succeeds.
+    client.submit_for_review(&enrollee, &q_id, &ms_id);
+
+    // Advance ledger past the deadline and attempt a late submission.
+    env.ledger().set_timestamp(now + 2000);
+    assert_eq!(
+        client.try_submit_for_review(&late, &q_id, &ms_id),
+        Err(Ok(Error::DeadlineExpired))
+    );
+}
+
+/// Batch milestone creation rejects invalid ordering: the first milestone in a
+/// batch cannot require a previous milestone because none exists yet.
+#[test]
+fn test_batch_milestone_invalid_ordering_rejected() {
+    let (env, client, quest_client, owner) = setup();
+    let q_id = create_quest(&env, &quest_client, &owner);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(MilestoneInput {
+        title: String::from_str(&env, "First requires previous"),
+        description: String::from_str(&env, "Invalid ordering"),
+        reward_amount: 100,
+        requires_previous: true,
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,
+    });
+    milestones.push_back(MilestoneInput {
+        title: String::from_str(&env, "Second"),
+        description: String::from_str(&env, "Valid"),
+        reward_amount: 100,
+        requires_previous: false,
+        difficulty: None,
+        estimated_duration: None,
+        prerequisites_knowledge: None,
+    });
+
+    let result = client.try_create_milestones_batch(&owner, &q_id, &milestones);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }

--- a/contracts/milestone/tests/completion_invariants_proptest.rs
+++ b/contracts/milestone/tests/completion_invariants_proptest.rs
@@ -81,18 +81,15 @@ proptest! {
         let m0 = milestone_client.create_milestone(
             &owner, &qid,
             &String::from_str(&env, "M0"), &String::from_str(&env, "desc"),
-            &100, &false,
-        );
+            &100, &false, &None, &None, &None);
         let m1 = milestone_client.create_milestone(
             &owner, &qid,
             &String::from_str(&env, "M1"), &String::from_str(&env, "desc"),
-            &100, &true,
-        );
+            &100, &true, &None, &None, &None);
         let m2 = milestone_client.create_milestone(
             &owner, &qid,
             &String::from_str(&env, "M2"), &String::from_str(&env, "desc"),
-            &100, &false,
-        );
+            &100, &false, &None, &None, &None);
         let milestone_ids = [m0, m1, m2];
         let requires_previous = [false, true, false];
 

--- a/contracts/milestone/tests/id_monotonicity_proptest.rs
+++ b/contracts/milestone/tests/id_monotonicity_proptest.rs
@@ -75,8 +75,7 @@ proptest! {
                         &String::from_str(&env, "Milestone"),
                         &String::from_str(&env, "Description"),
                         &100,
-                        &false,
-                    );
+                        &false, &None, &None, &None);
                     if let Some(prev) = prev_id {
                         prop_assert!(mid > prev, "milestone id {} not > prev {}", mid, prev);
                     }

--- a/frontend/e2e/certificate.spec.ts
+++ b/frontend/e2e/certificate.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test"
+
+test.describe("Certificate page", () => {
+  test("loads the public certificate route", async ({ page }) => {
+    await page.goto("/certificate/1")
+
+    // The page always renders a top-level heading mentioning the certificate,
+    // whether it shows the certificate itself or the "not available" state.
+    await expect(
+      page.getByRole("heading", { level: 1, name: /certificate/i }),
+    ).toBeVisible()
+  })
+
+  test("reflects certificate availability state", async ({ page }) => {
+    await page.goto("/certificate/1")
+
+    await expect(
+      page.getByText(/Certificate of Completion|Certificate not available/),
+    ).toBeVisible()
+  })
+
+  test("does not break client-side routing for arbitrary certificate ids", async ({
+    page,
+  }) => {
+    await page.goto("/certificate/42")
+
+    await expect(page).toHaveURL(/\/certificate\/42/)
+    await expect(
+      page.getByRole("heading", { level: 1, name: /certificate/i }),
+    ).toBeVisible()
+  })
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ const History = lazy(() => import("@/pages/history").then((m) => ({ default: m.H
 const CreatorProfile = lazy(() => import("@/pages/creator").then((m) => ({ default: m.CreatorProfile })))
 const CreatorDashboard = lazy(() => import("@/pages/creator-dashboard").then((m) => ({ default: m.CreatorDashboard })))
 const AnalyticsPage = lazy(() => import("@/pages/analytics").then((m) => ({ default: m.Analytics })))
+const CertificateView = lazy(() => import("@/pages/certificate").then((m) => ({ default: m.CertificateView })))
 import { useToast } from "@/hooks/use-toast"
 import { subscribeToasts } from "@/lib/notifications"
 import { useQuestEventStream } from "@/hooks/use-quest-events"
@@ -45,7 +46,7 @@ const VALID_PAGES = [
   "terms",
   "privacy",
 ] as const
-type Page = (typeof VALID_PAGES)[number] | "quest" | "creator" | "404"
+type Page = (typeof VALID_PAGES)[number] | "quest" | "creator" | "certificate" | "404"
 const PROTECTED_PAGES: ReadonlySet<Page> = new Set(["profile", "create-quest", "creator-dashboard"])
 
 function SessionGuard({ children, onDenied }: { children: ReactNode; onDenied: () => void }) {
@@ -71,27 +72,38 @@ function pathToPage(pathname: string): {
   page: Page
   questId: number | null
   creatorAddress: string | null
+  certificateId: number | null
 } {
   const clean = pathname.replace(/\/+$/, "") || "/"
 
-  if (clean === "/") return { page: "landing", questId: null, creatorAddress: null }
-  if (clean === "/dashboard") return { page: "dashboard", questId: null, creatorAddress: null }
-  if (clean === "/profile") return { page: "profile", questId: null, creatorAddress: null }
+  if (clean === "/") return { page: "landing", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/dashboard") return { page: "dashboard", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/profile") return { page: "profile", questId: null, creatorAddress: null, certificateId: null }
   if (clean === "/create-quest" || clean === "/quest/create") {
-    return { page: "create-quest", questId: null, creatorAddress: null }
+    return { page: "create-quest", questId: null, creatorAddress: null, certificateId: null }
   }
   if (clean === "/creator-dashboard") {
-    return { page: "creator-dashboard", questId: null, creatorAddress: null }
+    return { page: "creator-dashboard", questId: null, creatorAddress: null, certificateId: null }
   }
-  if (clean === "/leaderboard") return { page: "leaderboard", questId: null, creatorAddress: null }
-  if (clean === "/history") return { page: "history", questId: null, creatorAddress: null }
-  if (clean === "/analytics") return { page: "analytics", questId: null, creatorAddress: null }
-  if (clean === "/terms") return { page: "terms", questId: null, creatorAddress: null }
-  if (clean === "/privacy") return { page: "privacy", questId: null, creatorAddress: null }
+  if (clean === "/leaderboard") return { page: "leaderboard", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/history") return { page: "history", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/analytics") return { page: "analytics", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/terms") return { page: "terms", questId: null, creatorAddress: null, certificateId: null }
+  if (clean === "/privacy") return { page: "privacy", questId: null, creatorAddress: null, certificateId: null }
 
   const questMatch = clean.match(/^\/quest\/(\d+)$/)
   if (questMatch) {
-    return { page: "quest", questId: Number(questMatch[1]), creatorAddress: null }
+    return { page: "quest", questId: Number(questMatch[1]), creatorAddress: null, certificateId: null }
+  }
+
+  const certificateMatch = clean.match(/^\/certificate\/(\d+)$/)
+  if (certificateMatch) {
+    return {
+      page: "certificate",
+      questId: null,
+      creatorAddress: null,
+      certificateId: Number(certificateMatch[1]),
+    }
   }
 
   const creatorMatch = clean.match(/^\/creator\/([^/]+)$/)
@@ -100,10 +112,11 @@ function pathToPage(pathname: string): {
       page: "creator",
       questId: null,
       creatorAddress: decodeURIComponent(creatorMatch[1]),
+      certificateId: null,
     }
   }
 
-  return { page: "404", questId: null, creatorAddress: null }
+  return { page: "404", questId: null, creatorAddress: null, certificateId: null }
 }
 
 function pageToPath(page: Page, questId: number | null, creatorAddress: string | null): string {
@@ -147,20 +160,20 @@ function App() {
     const page = (VALID_PAGES as readonly string[]).includes(p) ? (p as Page) : "404"
     const path = pageToPath(page, null, null)
     window.history.pushState(null, "", path)
-    setState({ page, questId: null, creatorAddress: null })
+    setState({ page, questId: null, creatorAddress: null, certificateId: null })
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [])
 
   const handleSelectQuest = useCallback((id: number) => {
     const path = pageToPath("quest", id, null)
     window.history.pushState(null, "", path)
-    setState({ page: "quest", questId: id, creatorAddress: null })
+    setState({ page: "quest", questId: id, creatorAddress: null, certificateId: null })
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [])
 
   const redirectToLanding = useCallback(() => {
     window.history.replaceState(null, "", "/")
-    setState({ page: "landing", questId: null, creatorAddress: null })
+    setState({ page: "landing", questId: null, creatorAddress: null, certificateId: null })
   }, [])
 
   useEffect(() => {
@@ -228,6 +241,12 @@ function App() {
         return (
           <Suspense fallback={<PageSkeleton />}>
             <CreatorDashboard />
+          </Suspense>
+        )
+      case "certificate":
+        return (
+          <Suspense fallback={<PageSkeleton />}>
+            <CertificateView certificateId={state.certificateId ?? 0} />
           </Suspense>
         )
       case "terms":

--- a/frontend/src/lib/contracts/certificate.ts
+++ b/frontend/src/lib/contracts/certificate.ts
@@ -16,6 +16,8 @@ export interface CertificateMetadata {
   questName: string
   questCategory: string
   completionDate: number
+  /** Number of milestones in the quest at mint time. */
+  milestoneCount: number
   issuer: string
   recipient: string
 }
@@ -27,6 +29,7 @@ function parseMetadata(raw: unknown): CertificateMetadata {
     questName: String(record.quest_name),
     questCategory: String(record.quest_category),
     completionDate: Number(record.completion_date),
+    milestoneCount: Number(record.milestone_count ?? 0),
     issuer: String(record.issuer),
     recipient: String(record.recipient),
   }

--- a/frontend/src/pages/certificate.tsx
+++ b/frontend/src/pages/certificate.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Award, Calendar, Layers, Download, Copy, Check, Twitter, Linkedin, ExternalLink, Loader2, AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { certificateClient, type CertificateMetadata } from "@/lib/contracts/certificate"
+import { shortenAddress } from "@/lib/utils"
+
+function formatDate(unixSeconds: number): string {
+  if (!unixSeconds) return "—"
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+}
+
+function shareUrl(certificateId: number): string {
+  if (typeof window === "undefined") return ""
+  return `${window.location.origin}/certificate/${certificateId}`
+}
+
+export function CertificateView({ certificateId }: { certificateId: number }) {
+  const [metadata, setMetadata] = useState<CertificateMetadata | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const templateRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    certificateClient
+      .getCertificateMetadata(certificateId)
+      .then((data) => {
+        if (!active) return
+        setMetadata(data)
+        if (!data) setError("We couldn't find a certificate with that ID.")
+      })
+      .catch((e) => {
+        if (!active) return
+        setError(e instanceof Error ? e.message : "Failed to load certificate.")
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [certificateId])
+
+  const copyLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl(certificateId))
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* clipboard unavailable */
+    }
+  }, [certificateId])
+
+  const downloadImage = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !metadata) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    const w = canvas.width
+    const h = canvas.height
+    const gradient = ctx.createLinearGradient(0, 0, w, h)
+    gradient.addColorStop(0, "#6366f1")
+    gradient.addColorStop(0.5, "#a855f7")
+    gradient.addColorStop(1, "#d946ef")
+    ctx.fillStyle = gradient
+    ctx.fillRect(0, 0, w, h)
+
+    ctx.fillStyle = "#ffffff"
+    ctx.font = "bold 34px sans-serif"
+    ctx.fillText("Lernza Certificate of Completion", 48, 80)
+
+    ctx.font = "20px sans-serif"
+    ctx.fillText(`Recipient: ${shortenAddress(metadata.recipient)}`, 48, 160)
+    ctx.fillText(`Quest: ${metadata.questName}`, 48, 210)
+    ctx.fillText(`Category: ${metadata.questCategory}`, 48, 260)
+    ctx.fillText(`Milestones: ${metadata.milestoneCount}`, 48, 310)
+    ctx.fillText(`Completed: ${formatDate(metadata.completionDate)}`, 48, 360)
+    ctx.fillText(`Issuer: ${shortenAddress(metadata.issuer)}`, 48, 410)
+    ctx.font = "16px sans-serif"
+    ctx.fillText(`Certificate ID #${certificateId}`, 48, h - 40)
+
+    const link = document.createElement("a")
+    link.download = `lernza-certificate-${certificateId}.png`
+    link.href = canvas.toDataURL("image/png")
+    link.click()
+  }, [certificateId, metadata])
+
+  const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+    `I just earned a Lernza certificate: ${metadata?.questName ?? "a quest"}!`,
+  )}&url=${encodeURIComponent(shareUrl(certificateId))}`
+  const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+    shareUrl(certificateId),
+  )}`
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+      </div>
+    )
+  }
+
+  if (error || !metadata) {
+    return (
+      <div className="mx-auto max-w-lg px-4 py-20 text-center">
+        <AlertCircle className="text-destructive mx-auto mb-4 h-10 w-10" />
+        <h1 className="mb-2 text-xl font-semibold">Certificate not available</h1>
+        <p className="text-muted-foreground text-sm">{error ?? "Unknown error."}</p>
+      </div>
+    )
+  }
+
+  const detailRows = [
+    { icon: <Award className="h-4 w-4" />, label: "Quest", value: metadata.questName },
+    { icon: <Layers className="h-4 w-4" />, label: "Category", value: metadata.questCategory },
+    { icon: <Calendar className="h-4 w-4" />, label: "Completed", value: formatDate(metadata.completionDate) },
+    { icon: <Layers className="h-4 w-4" />, label: "Milestones", value: String(metadata.milestoneCount) },
+    { icon: <ExternalLink className="h-4 w-4" />, label: "Issuer", value: shortenAddress(metadata.issuer) },
+    { icon: <ExternalLink className="h-4 w-4" />, label: "Recipient", value: shortenAddress(metadata.recipient) },
+  ]
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-12">
+      <div className="mb-8 text-center">
+        <h1 className="text-2xl font-bold">Certificate of Completion</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Verified on-chain via the Lernza certificate contract.
+        </p>
+      </div>
+
+      {/* Certificate template — also used as the downloadable image source. */}
+      <div
+        ref={templateRef}
+        className="bg-gradient-to-br from-indigo-500 via-purple-500 to-fuchsia-500 rounded-2xl p-8 text-white shadow-xl"
+      >
+        <div className="flex items-center gap-3">
+          <Award className="h-10 w-10" />
+          <div>
+            <p className="text-xs uppercase tracking-widest opacity-80">Lernza</p>
+            <p className="text-lg font-semibold">Certificate of Completion</p>
+          </div>
+        </div>
+        <p className="mt-8 text-sm opacity-90">This certifies that</p>
+        <p className="text-2xl font-bold">{shortenAddress(metadata.recipient)}</p>
+        <p className="mt-6 text-sm opacity-90">has completed the quest</p>
+        <p className="text-3xl font-extrabold">{metadata.questName}</p>
+        <div className="mt-8 grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="opacity-80">Category</p>
+            <p className="font-medium">{metadata.questCategory}</p>
+          </div>
+          <div>
+            <p className="opacity-80">Milestones</p>
+            <p className="font-medium">{metadata.milestoneCount}</p>
+          </div>
+          <div>
+            <p className="opacity-80">Completed</p>
+            <p className="font-medium">{formatDate(metadata.completionDate)}</p>
+          </div>
+          <div>
+            <p className="opacity-80">Issuer</p>
+            <p className="font-medium">{shortenAddress(metadata.issuer)}</p>
+          </div>
+        </div>
+        <p className="mt-8 text-xs opacity-70">Certificate ID #{certificateId}</p>
+      </div>
+
+      <Card className="mt-8">
+        <CardContent className="space-y-3 p-6">
+          {detailRows.map((row) => (
+            <div key={row.label} className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground flex items-center gap-2">
+                {row.icon}
+                {row.label}
+              </span>
+              <span className="font-medium">{row.value}</span>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <Button onClick={downloadImage} className="gap-2">
+          <Download className="h-4 w-4" />
+          Download image
+        </Button>
+        <Button variant="outline" onClick={copyLink} className="gap-2">
+          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          {copied ? "Copied" : "Copy link"}
+        </Button>
+        <a href={tweetUrl} target="_blank" rel="noopener noreferrer">
+          <Button variant="outline" className="gap-2">
+            <Twitter className="h-4 w-4" />
+            Share on X
+          </Button>
+        </a>
+        <a href={linkedinUrl} target="_blank" rel="noopener noreferrer">
+          <Button variant="outline" className="gap-2">
+            <Linkedin className="h-4 w-4" />
+            Share on LinkedIn
+          </Button>
+        </a>
+      </div>
+
+      {/* Hidden canvas used to render the downloadable certificate image. */}
+      <canvas ref={canvasRef} className="hidden" width={800} height={480} aria-hidden />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add a CompletionContract facade that verifies quest ownership, confirms every milestone is completed, and obtains or mints the on-chain certificate in a single cross-contract call.
- Add on-chain certificate metadata (milestone count) and a public certificate display page with a shareable template, social sharing, and a downloadable image.
- Increase milestone contract test coverage for edge cases: competitive distribution with more completers than winners, custom reward exceeding the max, insufficient peer reviewers, submission after quest expiry, and invalid batch ordering.
- Set up Playwright end-to-end testing with a CI workflow and a certificate page spec covering critical user flows.

closes #1410
closes #1412
closes #1414
closes #1415