### PR TITLE
feat: implement dispute process for rejected milestone submissions

### DIFF
--- a/contracts/milestone/src/lib.rs
+++ b/contracts/milestone/src/lib.rs
@@ -88,6 +88,10 @@ pub enum DataKey {
     TotalReservedReward(u32),
     // Milestone feedback history per learner submission
     MilestoneFeedbackHistory(u32, u32, Address), // (quest_id, milestone_id, enrollee)
+    // Dispute tracking per enrollee per milestone submission
+    Dispute(u32, u32, Address), // (quest_id, milestone_id, enrollee) stores DisputeRecord
+    // Pending submission snapshot stored at dispute initiation, for restoration on overturn
+    DisputeSubmissionSnapshot(u32, u32, Address), // (quest_id, milestone_id, enrollee)
     // Verification state: who verified a completion and when.
     // Key: (quest_id, milestone_id, enrollee). Value: VerificationRecord.
     VerifiedBy(u32, u32, Address),
@@ -100,6 +104,35 @@ pub enum FeedbackAction {
     Approve = 0,
     Reject = 1,
     RequestChanges = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DisputeStatus {
+    Pending = 0,
+    Upheld = 1,
+    Overturned = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DisputeOutcome {
+    Upheld = 0,
+    Overturned = 1,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DisputeRecord {
+    pub status: DisputeStatus,
+    /// Distribution mode at dispute initiation (for restoration on overturn)
+    pub distribution_mode: DistributionMode,
+    /// Per-milestone reward at dispute initiation
+    pub reward_amount: i128,
+    /// Flat reward at dispute initiation (only meaningful if distribution_mode == Flat)
+    pub flat_reward: i128,
 }
 
 #[contracttype]
@@ -232,6 +265,12 @@ pub enum Error {
     /// Submission or verification is rejected because the quest deadline has passed.
     DeadlineExpired = 21,
     CircularDependency = 22,
+    /// No dispute exists for this submission.
+    DisputeNotFound = 23,
+    /// A dispute has already been resolved for this submission and cannot be reopened.
+    DisputeAlreadyResolved = 24,
+    /// The submission is not eligible for dispute (e.g., not rejected, or already disputed).
+    NotEligibleForDispute = 25,
     /// Contract is administratively paused (shared code 400).
     Paused = 400,
 }
@@ -2030,7 +2069,7 @@ impl MilestoneContract {
             .persistent()
             .extend_ttl(&reserved_key, THRESHOLD, BUMP);
 
-        // Record feedback
+// Record feedback
         Self::record_feedback(
             &env,
             quest_id,
@@ -2041,6 +2080,232 @@ impl MilestoneContract {
             feedback,
         )?;
         Ok(())
+    }
+
+    /// Learner initiates a dispute for a rejected milestone submission.
+    /// Eligibility: (a) submission must have been rejected (no pending submission key),
+    /// (b) feedback history must contain FeedbackAction::Reject, (c) no existing dispute
+    /// with status Upheld or Overturned.
+    pub fn initiate_dispute(
+        env: Env,
+        enrollee: Address,
+        quest_id: u32,
+        milestone_id: u32,
+    ) -> Result<(), Error> {
+        enrollee.require_auth();
+
+        Self::require_not_paused(&env)?;
+
+        let quest_contract_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::QuestContract)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client = QuestClient::new(&env, &quest_contract_addr);
+        let quest_info = quest_client.get_quest(&quest_id);
+
+        if quest_info.owner != enrollee && !Self::is_enrolled(&env, quest_id, &enrollee)? {
+            return Err(Error::Unauthorized);
+        }
+
+        // Check that a pending submission does NOT exist (i.e., was rejected)
+        let submit_key = DataKey::PendingSubmission(quest_id, milestone_id, enrollee.clone());
+        if env.storage().persistent().has(&submit_key) {
+            return Err(Error::NotEligibleForDispute);
+        }
+
+        // Check that feedback history contains a Reject action
+        let feedback_key = DataKey::MilestoneFeedbackHistory(quest_id, milestone_id, enrollee.clone());
+        let feedback_history: Vec<MilestoneFeedback> = env
+            .storage()
+            .persistent()
+            .get(&feedback_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        let has_reject = feedback_history.iter().any(|f| f.action == FeedbackAction::Reject);
+        if !has_reject {
+            return Err(Error::NotEligibleForDispute);
+        }
+
+        // Check that no dispute already exists with a final status
+        let dispute_key = DataKey::Dispute(quest_id, milestone_id, enrollee.clone());
+        if env.storage().persistent().has(&dispute_key) {
+            let dispute_status: DisputeStatus = env
+                .storage()
+                .persistent()
+                .get(&dispute_key)
+                .unwrap();
+            if dispute_status == DisputeStatus::Upheld || dispute_status == DisputeStatus::Overturned {
+                return Err(Error::DisputeAlreadyResolved);
+            }
+        }
+
+        // Read distribution parameters to store in the dispute record for later restoration
+        let mode: DistributionMode = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Mode(quest_id))
+            .unwrap_or(DistributionMode::Custom);
+        let flat_reward: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::FlatReward(quest_id))
+            .unwrap_or(0);
+        let milestone_key = DataKey::Milestone(quest_id, milestone_id);
+        let milestone: MilestoneInfo = env
+            .storage()
+            .persistent()
+            .get(&milestone_key)
+            .ok_or(Error::NotFound)?;
+
+        let dispute_record = DisputeRecord {
+            status: DisputeStatus::Pending,
+            distribution_mode: mode,
+            reward_amount: milestone.reward_amount,
+            flat_reward,
+        };
+
+        // Store dispute record with snapshot parameters for restoration on overturn
+        env.storage().persistent().set(&dispute_key, &dispute_record);
+        env.storage().persistent().extend_ttl(&dispute_key, THRESHOLD, BUMP);
+
+        // Emit dispute initiated event
+        // Topics: (dispute_initiated,)
+        // Data: (quest_id, milestone_id, enrollee)
+        env.events().publish(
+            (Symbol::new(&env, "dispute_initiated"),),
+            (quest_id, milestone_id, enrollee),
+        );
+        extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Resolve a dispute for a milestone submission.
+    /// Only the quest owner or an enrolled peer reviewer may resolve.
+    /// If outcome is Upheld, the rejection stands and the dispute is final.
+    /// If outcome is Overturned, the pending submission is restored and the
+    /// enrollee may proceed through the review flow again.
+    pub fn resolve_dispute(
+        env: Env,
+        resolver: Address,
+        quest_id: u32,
+        milestone_id: u32,
+        enrollee: Address,
+        outcome: DisputeOutcome,
+    ) -> Result<(), Error> {
+        resolver.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let quest_contract_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::QuestContract)
+            .ok_or(Error::NotInitialized)?;
+        let quest_client = QuestClient::new(&env, &quest_contract_addr);
+        let quest_info = quest_client.get_quest(&quest_id);
+
+        let is_owner = quest_info.owner == resolver;
+        if !is_owner && !Self::is_enrolled(&env, quest_id, &resolver)? {
+            return Err(Error::Unauthorized);
+        }
+        if resolver == enrollee {
+            return Err(Error::InvalidApprover);
+        }
+
+        let dispute_key = DataKey::Dispute(quest_id, milestone_id, enrollee.clone());
+        let dispute_status: DisputeStatus = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .ok_or(Error::DisputeNotFound)?;
+
+        // Dispute must be in Pending state to resolve
+        if dispute_status != DisputeStatus::Pending {
+            return Err(Error::DisputeAlreadyResolved);
+        }
+
+        match outcome {
+            DisputeOutcome::Upheld => {
+                // Rejection stands — mark dispute as Upheld (final)
+                env.storage().persistent().set(&dispute_key, &DisputeStatus::Upheld);
+                env.storage().persistent().extend_ttl(&dispute_key, THRESHOLD, BUMP);
+
+                // Emit dispute resolved event
+                // Topics: (dispute_resolved,)
+                // Data: (quest_id, milestone_id, enrollee, outcome)
+                env.events().publish(
+                    (Symbol::new(&env, "dispute_resolved"),),
+                    (quest_id, milestone_id, enrollee, outcome as u32),
+                );
+                extend_instance_ttl(&env);
+                Ok(())
+            }
+            DisputeOutcome::Overturned => {
+                // Restore the pending submission using parameters stored at dispute initiation
+                let dispute_record: DisputeRecord = env
+                    .storage()
+                    .persistent()
+                    .get(&dispute_key)
+                    .unwrap();
+
+                let submit_key = DataKey::PendingSubmission(quest_id, milestone_id, enrollee.clone());
+                let snapshot = PendingSubmissionSnapshot {
+                    distribution_mode: dispute_record.distribution_mode,
+                    reward_amount: dispute_record.reward_amount,
+                    flat_reward: dispute_record.flat_reward,
+                    submitted_at: env.ledger().timestamp(),
+                };
+                env.storage().persistent().set(&submit_key, &snapshot);
+                env.storage().persistent().extend_ttl(&submit_key, THRESHOLD, BUMP);
+
+                // Initialize approval tracking so the enrollee can start the review flow anew
+                let approval_key = DataKey::ApprovalCount(quest_id, milestone_id, enrollee.clone());
+                env.storage().persistent().set(&approval_key, &0u32);
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&approval_key, THRESHOLD, BUMP);
+
+                // Initialize empty approvers list
+                let approvers_key = DataKey::Approvers(quest_id, milestone_id, enrollee.clone());
+                env.storage().persistent().set(&approvers_key, &Vec::<Address>::new(&env));
+
+                // Restore reserved reward by the snapshotted amount
+                let reserved_key = DataKey::TotalReservedReward(quest_id);
+                let current_reserved: i128 = env.storage().persistent().get(&reserved_key).unwrap_or(0);
+                let new_reserved = current_reserved
+                    .checked_add(dispute_record.reward_amount)
+                    .ok_or(Error::Overflow)?;
+                env.storage().persistent().set(&reserved_key, &new_reserved);
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&reserved_key, THRESHOLD, BUMP);
+
+                // Mark dispute as Overturned (final)
+                env.storage().persistent().set(&dispute_key, &DisputeStatus::Overturned);
+                env.storage().persistent().extend_ttl(&dispute_key, THRESHOLD, BUMP);
+
+                // Emit dispute resolved event
+                // Topics: (dispute_resolved,)
+                // Data: (quest_id, milestone_id, enrollee, outcome)
+                env.events().publish(
+                    (Symbol::new(&env, "dispute_resolved"),),
+                    (quest_id, milestone_id, enrollee, outcome as u32),
+                );
+                extend_instance_ttl(&env);
+                Ok(())
+            }
+        }
+    }
+
+    /// Query the current dispute status for a milestone submission.
+    /// Returns None if no dispute has been initiated for this (quest, milestone, enrollee).
+    pub fn get_dispute_status(
+        env: Env,
+        quest_id: u32,
+        milestone_id: u32,
+        enrollee: Address,
+    ) -> Option<DisputeStatus> {
+        let dispute_key = DataKey::Dispute(quest_id, milestone_id, enrollee);
+        env.storage().persistent().get(&dispute_key)
     }
 
     /// Request changes on a pending milestone submission with written feedback.


### PR DESCRIPTION
# PR #1522 — Dispute Process for Rejected Milestone Submissions

## What does this PR do?

Implements an optional dispute state that permits an authorized escalation review when a learner believes a milestone rejection was incorrect or incomplete. After a submission is rejected via `reject_completion_with_feedback`, the learner can initiate a dispute for review by the quest owner or enrolled peer reviewers. Resolution either upholds the rejection (final) or overturns it (restoring the pending submission so the enrollee can resubmit). The original rejection feedback is preserved throughout.

## Related Issue

Closes #1522

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Tests

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `refactor:`)
- [x] I have added at least one label to this PR
- [x] I have added/updated tests for my changes (if applicable)
- [x] `cargo test --workspace` passes (if contracts changed)
- [ ] `pnpm build` passes (if frontend changed)
- [x] `cargo fmt --all -- --check` passes (if Rust changed)
- [ ] `pnpm lint` passes (if frontend changed)

## Screenshots

<!-- If UI changes, add before/after screenshots -->