### PR TITLE
feat: add owner review queue workspace

### DIFF
--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -1,0 +1,45 @@
+import { RefreshCw } from "lucide-react"
+import { useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { filterAndSortReviewQueue, groupReviewQueue, type ReviewSubmission, type SubmissionStatus } from "@/lib/review-queue"
+
+interface ReviewQueueProps {
+  submissions: ReviewSubmission[]
+  isLoading?: boolean
+  error?: string | null
+  onRefresh: () => void
+  onReview: (submission: ReviewSubmission) => void
+}
+
+export function ReviewQueue({ submissions, isLoading = false, error, onRefresh, onReview }: ReviewQueueProps) {
+  const [learner, setLearner] = useState("")
+  const [milestone, setMilestone] = useState("")
+  const [status, setStatus] = useState<"all" | SubmissionStatus>("pending")
+  const [submittedBefore, setSubmittedBefore] = useState("")
+  const [sort, setSort] = useState<"oldest" | "deadline">("oldest")
+  const visible = useMemo(() => filterAndSortReviewQueue(submissions, { learner, milestone, status, submittedBefore }, sort), [submissions, learner, milestone, status, submittedBefore, sort])
+  const groups = useMemo(() => groupReviewQueue(visible), [visible])
+
+  return (
+    <section aria-label="Owner review queue" className="space-y-4">
+      <div className="border-border bg-card grid gap-3 border p-4 sm:grid-cols-2 lg:grid-cols-5">
+        <input aria-label="Filter by learner" className="border-border bg-background border p-2 text-sm" placeholder="Learner" value={learner} onChange={(event) => setLearner(event.target.value)} />
+        <input aria-label="Filter by milestone" className="border-border bg-background border p-2 text-sm" placeholder="Milestone" value={milestone} onChange={(event) => setMilestone(event.target.value)} />
+        <select aria-label="Filter by status" className="border-border bg-background border p-2 text-sm" value={status} onChange={(event) => setStatus(event.target.value as "all" | SubmissionStatus)}>
+          <option value="pending">Pending</option><option value="all">All statuses</option><option value="approved">Approved</option><option value="rejected">Rejected</option>
+        </select>
+        <input aria-label="Submitted before" type="date" className="border-border bg-background border p-2 text-sm" value={submittedBefore} onChange={(event) => setSubmittedBefore(event.target.value)} />
+        <select aria-label="Sort queue" className="border-border bg-background border p-2 text-sm" value={sort} onChange={(event) => setSort(event.target.value as "oldest" | "deadline")}>
+          <option value="oldest">Oldest submission</option><option value="deadline">Approaching deadline</option>
+        </select>
+      </div>
+      <Button variant="outline" size="sm" onClick={onRefresh} disabled={isLoading}><RefreshCw className="h-4 w-4" /> Refresh queue</Button>
+      {error ? <div role="alert" className="border-destructive/40 bg-destructive/10 text-destructive border p-4">Unable to load submissions. {error}</div> : null}
+      {!isLoading && !error && visible.length === 0 ? <div className="border-border text-muted-foreground border p-8 text-center">No submissions match these filters.</div> : null}
+      <div className="space-y-4">
+        {[...groups.entries()].map(([key, items]) => <div key={key} className="border-border bg-card border p-4"><h3 className="mb-3 font-semibold">{items[0].questName} · {items[0].milestoneName}</h3><div className="space-y-2">{items.map((item) => <div key={item.id} className="flex flex-col gap-3 border-b pb-3 last:border-0 sm:flex-row sm:items-center sm:justify-between"><div><p className="font-medium">{item.learner}</p><p className="text-muted-foreground text-xs">Submitted {new Date(item.submittedAt).toLocaleDateString()}</p></div><div className="flex items-center gap-3"><Badge variant={item.status === "pending" ? "default" : "secondary"}>{item.status}</Badge><Button size="sm" onClick={() => onReview(item)}>Review</Button></div></div>)}</div></div>)}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/lib/review-queue.test.ts
+++ b/frontend/src/lib/review-queue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { filterAndSortReviewQueue, groupReviewQueue, type ReviewSubmission } from "./review-queue"
+
+const submissions: ReviewSubmission[] = [
+  { id: "a", questId: "q1", questName: "Quest", milestoneId: "m1", milestoneName: "Build", learner: "Ada", submittedAt: "2026-01-01", deadline: "2026-01-10", status: "pending" },
+  { id: "b", questId: "q1", questName: "Quest", milestoneId: "m1", milestoneName: "Build", learner: "Lin", submittedAt: "2026-01-03", deadline: "2026-01-05", status: "pending" },
+  { id: "c", questId: "q1", questName: "Quest", milestoneId: "m2", milestoneName: "Ship", learner: "Ada", submittedAt: "2026-01-02", status: "approved" },
+]
+
+describe("review queue", () => {
+  it("filters by learner/status and sorts oldest first", () => {
+    expect(filterAndSortReviewQueue(submissions, { learner: "ada", milestone: "", status: "pending" }, "oldest").map((item) => item.id)).toEqual(["a"])
+  })
+
+  it("sorts by approaching deadline and groups by quest/milestone", () => {
+    const filtered = filterAndSortReviewQueue(submissions, { learner: "", milestone: "", status: "all" }, "deadline")
+    expect(filtered.map((item) => item.id)).toEqual(["b", "a", "c"])
+    expect(groupReviewQueue(filtered).get("q1:m1")?.map((item) => item.id)).toEqual(["b", "a"])
+  })
+})

--- a/frontend/src/lib/review-queue.ts
+++ b/frontend/src/lib/review-queue.ts
@@ -1,0 +1,55 @@
+export type SubmissionStatus = "pending" | "approved" | "rejected"
+
+export interface ReviewSubmission {
+  id: string
+  questId: string
+  questName: string
+  milestoneId: string
+  milestoneName: string
+  learner: string
+  submittedAt: string
+  deadline?: string
+  status: SubmissionStatus
+}
+
+export interface ReviewQueueFilters {
+  learner: string
+  milestone: string
+  status: "all" | SubmissionStatus
+  submittedBefore?: string
+}
+
+export function filterAndSortReviewQueue(
+  submissions: ReviewSubmission[],
+  filters: ReviewQueueFilters,
+  sort: "oldest" | "deadline"
+): ReviewSubmission[] {
+  const learner = filters.learner.trim().toLowerCase()
+  const milestone = filters.milestone.trim().toLowerCase()
+  const submittedBefore = filters.submittedBefore ? Date.parse(filters.submittedBefore) : undefined
+
+  return submissions
+    .filter((submission) => {
+      if (learner && !submission.learner.toLowerCase().includes(learner)) return false
+      if (milestone && !submission.milestoneName.toLowerCase().includes(milestone)) return false
+      if (filters.status !== "all" && submission.status !== filters.status) return false
+      if (submittedBefore !== undefined && Date.parse(submission.submittedAt) > submittedBefore) return false
+      return true
+    })
+    .sort((left, right) => {
+      const leftDate = Date.parse(sort === "oldest" ? left.submittedAt : left.deadline ?? "9999-12-31")
+      const rightDate = Date.parse(sort === "oldest" ? right.submittedAt : right.deadline ?? "9999-12-31")
+      return leftDate - rightDate
+    })
+}
+
+export function groupReviewQueue(submissions: ReviewSubmission[]): Map<string, ReviewSubmission[]> {
+  const groups = new Map<string, ReviewSubmission[]>()
+  for (const submission of submissions) {
+    const key = `${submission.questId}:${submission.milestoneId}`
+    const group = groups.get(key) ?? []
+    group.push(submission)
+    groups.set(key, group)
+  }
+  return groups
+}


### PR DESCRIPTION
## Summary

Adds the owner review workspace requested in #1523.

- Filters by learner, milestone, status, and submission age.
- Sorts by oldest submission or approaching deadline.
- Groups submissions by quest and milestone.
- Provides explicit empty and error states plus a refresh action.
- Uses responsive layouts so queue actions remain usable on narrow screens.
- Keeps review actions callback-driven so approving/rejecting can refresh the existing query without a full-page reload.

Closes #1523

## Verification

- `git diff --check`
- Unit tests added for filtering, sorting, and grouping.
- Frontend test command was not run because dependencies are not installed in the checkout.